### PR TITLE
feat: core/manifest.ts — parse + validate shard.yaml

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,7 +13,7 @@ Ship the core: install, update, status. Prove that vault template upgrades work 
 ### Milestone 1: Foundation (Day 1)
 
 - [x] Scaffold with `create-pastel-app` ([#1](https://github.com/breferrari/shardmind/issues/1))
-- [ ] `source/core/manifest.ts` — parse + validate shard.yaml with zod ([#2](https://github.com/breferrari/shardmind/issues/2))
+- [x] `source/core/manifest.ts` — parse + validate shard.yaml with zod ([#2](https://github.com/breferrari/shardmind/issues/2))
 - [ ] `source/core/schema.ts` — parse shard-schema.yaml, generate dynamic zod validator ([#3](https://github.com/breferrari/shardmind/issues/3))
 - [ ] `source/core/download.ts` — fetch GitHub tarball, extract to temp dir ([#4](https://github.com/breferrari/shardmind/issues/4))
 - [ ] `source/core/renderer.ts` — Nunjucks engine, frontmatter-aware split/render/recombine ([#5](https://github.com/breferrari/shardmind/issues/5))

--- a/source/core/manifest.ts
+++ b/source/core/manifest.ts
@@ -33,11 +33,20 @@ export async function parseManifest(filePath: string): Promise<ShardManifest> {
   let raw: string;
   try {
     raw = await fs.readFile(filePath, 'utf-8');
-  } catch {
+  } catch (err) {
+    const fsCode = err instanceof Error && 'code' in err ? (err as NodeJS.ErrnoException).code : undefined;
+    if (fsCode === 'ENOENT') {
+      throw new ShardMindError(
+        `Cannot read shard.yaml: ${filePath}`,
+        'MANIFEST_NOT_FOUND',
+        'Check the file path and ensure shard.yaml exists.',
+      );
+    }
+    const message = err instanceof Error ? err.message : String(err);
     throw new ShardMindError(
-      `Cannot read shard.yaml: ${filePath}`,
-      'MANIFEST_NOT_FOUND',
-      'Check the file path and ensure shard.yaml exists.',
+      `Cannot read shard.yaml: ${filePath} (${fsCode ?? 'unknown'})`,
+      'MANIFEST_READ_FAILED',
+      message,
     );
   }
 
@@ -56,7 +65,7 @@ export async function parseManifest(filePath: string): Promise<ShardManifest> {
   const result = ShardManifestSchema.safeParse(parsed);
   if (!result.success) {
     const details = result.error.issues
-      .map(i => `${i.path.join('.')}: ${i.message}`)
+      .map(i => `${i.path.length === 0 ? '(root)' : i.path.join('.')}: ${i.message}`)
       .join('; ');
     throw new ShardMindError(
       `shard.yaml validation failed: ${details}`,

--- a/source/core/manifest.ts
+++ b/source/core/manifest.ts
@@ -1,0 +1,69 @@
+import fs from 'node:fs/promises';
+import { parse as parseYaml } from 'yaml';
+import semver from 'semver';
+import { z } from 'zod';
+import type { ShardManifest } from '../runtime/types.js';
+import { ShardMindError } from '../runtime/types.js';
+
+export const ShardManifestSchema = z.object({
+  apiVersion: z.literal('v1'),
+  name: z.string().regex(/^[a-z0-9-]+$/, 'Must be lowercase alphanumeric with hyphens'),
+  namespace: z.string().regex(/^[a-z0-9-]+$/, 'Must be lowercase alphanumeric with hyphens'),
+  version: z.string().refine(v => semver.valid(v) !== null, 'Must be valid semver'),
+  description: z.string().optional(),
+  persona: z.string().optional(),
+  license: z.string().optional(),
+  homepage: z.string().url().optional(),
+  requires: z.object({
+    obsidian: z.string().optional(),
+    node: z.string().optional(),
+  }).optional(),
+  dependencies: z.array(z.object({
+    name: z.string(),
+    namespace: z.string(),
+    version: z.string(),
+  })).default([]),
+  hooks: z.object({
+    'post-install': z.string().optional(),
+    'post-update': z.string().optional(),
+  }).default({}),
+});
+
+export async function parseManifest(filePath: string): Promise<ShardManifest> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, 'utf-8');
+  } catch {
+    throw new ShardMindError(
+      `Cannot read shard.yaml: ${filePath}`,
+      'MANIFEST_NOT_FOUND',
+      'Check the file path and ensure shard.yaml exists.',
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(raw);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new ShardMindError(
+      `shard.yaml is not valid YAML: ${message}`,
+      'MANIFEST_INVALID_YAML',
+      'Check shard.yaml for syntax errors.',
+    );
+  }
+
+  const result = ShardManifestSchema.safeParse(parsed);
+  if (!result.success) {
+    const details = result.error.issues
+      .map(i => `${i.path.join('.')}: ${i.message}`)
+      .join('; ');
+    throw new ShardMindError(
+      `shard.yaml validation failed: ${details}`,
+      'MANIFEST_VALIDATION_FAILED',
+      'Check shard.yaml against the shard manifest spec.',
+    );
+  }
+
+  return result.data as ShardManifest;
+}

--- a/tests/unit/manifest.test.ts
+++ b/tests/unit/manifest.test.ts
@@ -1,0 +1,146 @@
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs/promises';
+import { describe, it, expect } from 'vitest';
+import { parseManifest, ShardManifestSchema } from '../../source/core/manifest.js';
+
+const FIXTURE_DIR = path.resolve('examples/minimal-shard');
+const VALID_MANIFEST = path.join(FIXTURE_DIR, 'shard.yaml');
+
+describe('parseManifest', () => {
+  it('parses valid shard.yaml from minimal-shard fixture', async () => {
+    const manifest = await parseManifest(VALID_MANIFEST);
+    expect(manifest.apiVersion).toBe('v1');
+    expect(manifest.name).toBe('minimal');
+    expect(manifest.namespace).toBe('shardmind');
+    expect(manifest.version).toBe('0.1.0');
+    expect(manifest.description).toBe('Minimal shard for development and testing');
+    expect(manifest.persona).toBe('Developers testing ShardMind');
+    expect(manifest.license).toBe('MIT');
+    expect(manifest.homepage).toBe('https://github.com/breferrari/shardmind');
+    expect(manifest.requires).toEqual({ node: '>=18.0.0' });
+    expect(manifest.hooks).toEqual({ 'post-install': 'hooks/post-install.ts' });
+  });
+
+  it('defaults dependencies to [] and hooks to {} when omitted', async () => {
+    const yaml = `apiVersion: v1\nname: test\nnamespace: dev\nversion: 1.0.0`;
+    const tmp = path.join(os.tmpdir(), `manifest-test-${Date.now()}.yaml`);
+    await fs.writeFile(tmp, yaml);
+    try {
+      const manifest = await parseManifest(tmp);
+      expect(manifest.dependencies).toEqual([]);
+      expect(manifest.hooks).toEqual({});
+    } finally {
+      await fs.unlink(tmp);
+    }
+  });
+
+  it('parses manifest with all optional fields including dependencies', async () => {
+    const yaml = [
+      'apiVersion: v1',
+      'name: full-shard',
+      'namespace: acme',
+      'version: 2.3.1',
+      'description: Full example',
+      'persona: Engineers',
+      'license: MIT',
+      'homepage: https://example.com',
+      'requires:',
+      '  obsidian: ">=1.12.0"',
+      '  node: ">=18.0.0"',
+      'dependencies:',
+      '  - name: skills',
+      '    namespace: kepano',
+      '    version: "^1.0.0"',
+      'hooks:',
+      '  post-install: hooks/post-install.ts',
+      '  post-update: hooks/post-update.ts',
+    ].join('\n');
+    const tmp = path.join(os.tmpdir(), `manifest-test-${Date.now()}.yaml`);
+    await fs.writeFile(tmp, yaml);
+    try {
+      const manifest = await parseManifest(tmp);
+      expect(manifest.dependencies).toHaveLength(1);
+      expect(manifest.dependencies[0]).toEqual({ name: 'skills', namespace: 'kepano', version: '^1.0.0' });
+      expect(manifest.hooks['post-install']).toBe('hooks/post-install.ts');
+      expect(manifest.hooks['post-update']).toBe('hooks/post-update.ts');
+    } finally {
+      await fs.unlink(tmp);
+    }
+  });
+
+  it('rejects non-existent file', async () => {
+    const err = await parseManifest('/no/such/file.yaml').catch(e => e);
+    expect(err.code).toBe('MANIFEST_NOT_FOUND');
+  });
+
+  it('rejects invalid YAML syntax', async () => {
+    const tmp = path.join(os.tmpdir(), `manifest-test-${Date.now()}.yaml`);
+    await fs.writeFile(tmp, ':\n  bad:\n    - [\ninvalid');
+    try {
+      const err = await parseManifest(tmp).catch(e => e);
+      expect(err.code).toBe('MANIFEST_INVALID_YAML');
+    } finally {
+      await fs.unlink(tmp);
+    }
+  });
+
+  it('rejects missing required field (apiVersion)', async () => {
+    const yaml = `name: test\nnamespace: dev\nversion: 1.0.0`;
+    const tmp = path.join(os.tmpdir(), `manifest-test-${Date.now()}.yaml`);
+    await fs.writeFile(tmp, yaml);
+    try {
+      const err = await parseManifest(tmp).catch(e => e);
+      expect(err.code).toBe('MANIFEST_VALIDATION_FAILED');
+      expect(err.message).toContain('apiVersion');
+    } finally {
+      await fs.unlink(tmp);
+    }
+  });
+
+  it('rejects invalid semver version', async () => {
+    const yaml = `apiVersion: v1\nname: test\nnamespace: dev\nversion: not-a-version`;
+    const tmp = path.join(os.tmpdir(), `manifest-test-${Date.now()}.yaml`);
+    await fs.writeFile(tmp, yaml);
+    try {
+      const err = await parseManifest(tmp).catch(e => e);
+      expect(err.code).toBe('MANIFEST_VALIDATION_FAILED');
+      expect(err.message).toContain('version');
+    } finally {
+      await fs.unlink(tmp);
+    }
+  });
+
+  it('rejects name with uppercase letters', async () => {
+    const yaml = `apiVersion: v1\nname: BadName\nnamespace: dev\nversion: 1.0.0`;
+    const tmp = path.join(os.tmpdir(), `manifest-test-${Date.now()}.yaml`);
+    await fs.writeFile(tmp, yaml);
+    try {
+      const err = await parseManifest(tmp).catch(e => e);
+      expect(err.code).toBe('MANIFEST_VALIDATION_FAILED');
+      expect(err.message).toContain('name');
+    } finally {
+      await fs.unlink(tmp);
+    }
+  });
+
+  it('rejects namespace with spaces', async () => {
+    const yaml = `apiVersion: v1\nname: test\nnamespace: "bad space"\nversion: 1.0.0`;
+    const tmp = path.join(os.tmpdir(), `manifest-test-${Date.now()}.yaml`);
+    await fs.writeFile(tmp, yaml);
+    try {
+      const err = await parseManifest(tmp).catch(e => e);
+      expect(err.code).toBe('MANIFEST_VALIDATION_FAILED');
+      expect(err.message).toContain('namespace');
+    } finally {
+      await fs.unlink(tmp);
+    }
+  });
+});
+
+describe('ShardManifestSchema', () => {
+  it('is exported for reuse', () => {
+    expect(ShardManifestSchema).toBeDefined();
+    expect(ShardManifestSchema.parse).toBeTypeOf('function');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2

- `ShardManifestSchema` — zod schema matching spec §4.3 (apiVersion, name/namespace regex, semver validation, optional fields with defaults)
- `parseManifest(filePath)` — reads YAML, validates, returns typed `ShardManifest`
- Error handling via `ShardMindError` with codes: `MANIFEST_NOT_FOUND`, `MANIFEST_INVALID_YAML`, `MANIFEST_VALIDATION_FAILED`

## Test plan

- [x] 10 unit tests in `tests/unit/manifest.test.ts`
  - Parses valid `examples/minimal-shard/shard.yaml`
  - Parses manifest with all optional fields + dependencies
  - Verifies defaults (dependencies → [], hooks → {})
  - Rejects: non-existent file, invalid YAML, missing apiVersion, bad semver, uppercase name, namespace with spaces
- [x] `npm run typecheck` passes
- [x] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)