### PR TITLE
feat: core/modules.ts — module resolution + file gating

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,7 @@ Ship the core: install, update, status. Prove that vault template upgrades work 
 - [x] `source/core/schema.ts` — parse shard-schema.yaml, generate dynamic zod validator ([#3](https://github.com/breferrari/shardmind/issues/3))
 - [x] `source/core/download.ts` — fetch GitHub tarball, extract to temp dir ([#4](https://github.com/breferrari/shardmind/issues/4))
 - [x] `source/core/renderer.ts` — Nunjucks engine, frontmatter-aware split/render/recombine ([#5](https://github.com/breferrari/shardmind/issues/5))
-- [ ] `source/core/modules.ts` — walk template dir, classify by module, resolve file lists ([#6](https://github.com/breferrari/shardmind/issues/6))
+- [x] `source/core/modules.ts` — walk template dir, classify by module, resolve file lists ([#6](https://github.com/breferrari/shardmind/issues/6))
 - [ ] `source/runtime/types.ts` + `runtime/index.ts` — shared types and exports ([#7](https://github.com/breferrari/shardmind/issues/7))
 - [ ] CI/CD — GitHub Actions for typecheck, test, build, npm publish ([#16](https://github.com/breferrari/shardmind/issues/16))
 - [ ] Unit tests: manifest, schema, renderer (5 fixture scenarios), modules

--- a/source/core/modules.ts
+++ b/source/core/modules.ts
@@ -1,0 +1,170 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { ShardSchema, ModuleResolution, FileEntry } from '../runtime/types.js';
+
+const VOLATILE_MARKER = '{# shardmind: volatile #}';
+
+// Directories that are always copied (not module-gated)
+const ALWAYS_COPY_DIRS = ['scripts', 'utilities', 'skills'] as const;
+
+export async function resolveModules(
+  schema: ShardSchema,
+  selections: Record<string, 'included' | 'excluded'>,
+  tempDir: string,
+): Promise<ModuleResolution> {
+  const render: FileEntry[] = [];
+  const copy: FileEntry[] = [];
+  const skip: FileEntry[] = [];
+
+  // 1. Walk templates/ directory
+  const templatesDir = path.join(tempDir, 'templates');
+  if (await dirExists(templatesDir)) {
+    const files = await walkDir(templatesDir);
+    for (const absPath of files) {
+      const relPath = path.relative(templatesDir, absPath).replace(/\\/g, '/');
+      const moduleId = findModule(relPath, schema);
+      const isExcluded = moduleId !== null && selections[moduleId] === 'excluded';
+
+      if (isExcluded) {
+        skip.push({ sourcePath: absPath, outputPath: computeTemplateOutput(relPath), module: moduleId, volatile: false, iterator: null });
+        continue;
+      }
+
+      if (relPath.endsWith('.njk')) {
+        const volatile = await detectVolatile(absPath);
+        const iterator = extractIterator(relPath);
+        const outputPath = computeTemplateOutput(relPath);
+        render.push({ sourcePath: absPath, outputPath, module: moduleId, volatile, iterator });
+      } else {
+        copy.push({ sourcePath: absPath, outputPath: relPath, module: moduleId, volatile: false, iterator: null });
+      }
+    }
+  }
+
+  // 2. Walk commands/ and agents/ (module-gated)
+  for (const dir of ['commands', 'agents'] as const) {
+    const dirPath = path.join(tempDir, dir);
+    if (!await dirExists(dirPath)) continue;
+
+    const files = await walkDir(dirPath);
+    for (const absPath of files) {
+      const relPath = path.relative(dirPath, absPath).replace(/\\/g, '/');
+      const fileName = path.basename(relPath, path.extname(relPath));
+      const moduleId = findModuleForResource(fileName, dir, schema);
+      const isExcluded = moduleId !== null && selections[moduleId] === 'excluded';
+      const outputPath = `.claude/${dir}/${relPath}`;
+
+      if (isExcluded) {
+        skip.push({ sourcePath: absPath, outputPath, module: moduleId, volatile: false, iterator: null });
+      } else {
+        copy.push({ sourcePath: absPath, outputPath, module: moduleId, volatile: false, iterator: null });
+      }
+    }
+  }
+
+  // 3. Walk scripts/, utilities/, skills/ (always copied)
+  for (const dir of ALWAYS_COPY_DIRS) {
+    const dirPath = path.join(tempDir, dir);
+    if (!await dirExists(dirPath)) continue;
+
+    const files = await walkDir(dirPath);
+    for (const absPath of files) {
+      const relPath = path.relative(dirPath, absPath).replace(/\\/g, '/');
+      copy.push({ sourcePath: absPath, outputPath: `.claude/${dir}/${relPath}`, module: null, volatile: false, iterator: null });
+    }
+  }
+
+  // 4. Walk codex/ (if present)
+  const codexDir = path.join(tempDir, 'codex');
+  if (await dirExists(codexDir)) {
+    const files = await walkDir(codexDir);
+    for (const absPath of files) {
+      const relPath = path.relative(codexDir, absPath).replace(/\\/g, '/');
+      copy.push({ sourcePath: absPath, outputPath: `.codex/prompts/${relPath}`, module: null, volatile: false, iterator: null });
+    }
+  }
+
+  return { render, copy, skip };
+}
+
+function computeTemplateOutput(relPath: string): string {
+  // Special case: settings.json.njk → .claude/settings.json
+  if (relPath === 'settings.json.njk') {
+    return '.claude/settings.json';
+  }
+  // Strip .njk suffix
+  if (relPath.endsWith('.njk')) {
+    return relPath.slice(0, -4);
+  }
+  return relPath;
+}
+
+function findModule(relPath: string, schema: ShardSchema): string | null {
+  for (const [moduleId, mod] of Object.entries(schema.modules)) {
+    for (const modPath of mod.paths) {
+      if (relPath.startsWith(modPath)) {
+        return moduleId;
+      }
+    }
+  }
+  return null;
+}
+
+function findModuleForResource(
+  fileName: string,
+  resourceType: 'commands' | 'agents',
+  schema: ShardSchema,
+): string | null {
+  for (const [moduleId, mod] of Object.entries(schema.modules)) {
+    const list = mod[resourceType];
+    if (list && list.includes(fileName)) {
+      return moduleId;
+    }
+  }
+  return null;
+}
+
+function extractIterator(relPath: string): string | null {
+  const basename = path.basename(relPath, '.njk');
+  // Match filenames like _each.md or _each.anything
+  if (!basename.startsWith('_each')) return null;
+  // Iterator key is the parent directory name
+  const dir = path.dirname(relPath);
+  if (dir === '.') return null;
+  return path.basename(dir);
+}
+
+async function detectVolatile(filePath: string): Promise<boolean> {
+  const handle = await fs.open(filePath, 'r');
+  try {
+    const buf = Buffer.alloc(256);
+    const { bytesRead } = await handle.read(buf, 0, 256, 0);
+    const firstLine = buf.toString('utf-8', 0, bytesRead).split(/\r?\n/)[0] ?? '';
+    return firstLine.trim() === VOLATILE_MARKER;
+  } finally {
+    await handle.close();
+  }
+}
+
+async function dirExists(dirPath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(dirPath);
+    return stat.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function walkDir(dirPath: string): Promise<string[]> {
+  const results: string[] = [];
+  const entries = await fs.readdir(dirPath, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...await walkDir(fullPath));
+    } else if (entry.isFile()) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}

--- a/source/core/modules.ts
+++ b/source/core/modules.ts
@@ -101,9 +101,26 @@ function computeTemplateOutput(relPath: string): string {
 
 function findModule(relPath: string, schema: ShardSchema): string | null {
   for (const [moduleId, mod] of Object.entries(schema.modules)) {
+    // Check paths (directory prefixes)
     for (const modPath of mod.paths) {
       if (relPath.startsWith(modPath)) {
         return moduleId;
+      }
+    }
+    // Check partials (exact path matches against template-relative paths)
+    if (mod.partials) {
+      for (const partial of mod.partials) {
+        if (relPath === partial) {
+          return moduleId;
+        }
+      }
+    }
+    // Check bases (match templates/bases/<id>.base.njk against bases[] IDs)
+    if (mod.bases) {
+      for (const baseId of mod.bases) {
+        if (relPath === `bases/${baseId}.base.njk`) {
+          return moduleId;
+        }
       }
     }
   }
@@ -139,8 +156,8 @@ async function detectVolatile(filePath: string): Promise<boolean> {
   try {
     const buf = Buffer.alloc(256);
     const { bytesRead } = await handle.read(buf, 0, 256, 0);
-    const firstLine = buf.toString('utf-8', 0, bytesRead).split(/\r?\n/)[0] ?? '';
-    return firstLine.trim() === VOLATILE_MARKER;
+    const content = buf.toString('utf-8', 0, bytesRead);
+    return content.trimStart().startsWith(VOLATILE_MARKER);
   } finally {
     await handle.close();
   }

--- a/tests/unit/modules.test.ts
+++ b/tests/unit/modules.test.ts
@@ -34,20 +34,34 @@ describe('resolveModules', () => {
     expect(copyPaths).toContain('.claude/commands/example-command.md');
   });
 
-  it('skips excluded module files', async () => {
-    const schema = await loadSchema();
-    const selections = { brain: 'included' as const, extras: 'excluded' as const };
-    const result = await resolveModules(schema, selections, EXAMPLE_SHARD);
+  it('skips excluded module files (commands, templates, and partials)', async () => {
+    // Copy fixture and add a template under extras/ path to exercise template gating
+    const tmpShard = path.join(os.tmpdir(), `modules-test-${crypto.randomUUID()}`);
+    await fs.cp(EXAMPLE_SHARD, tmpShard, { recursive: true });
+    await fs.mkdir(path.join(tmpShard, 'templates', 'extras'), { recursive: true });
+    await fs.writeFile(path.join(tmpShard, 'templates', 'extras', 'Feature.md.njk'), '# Extra Feature\n');
 
-    const skipPaths = result.skip.map(f => f.outputPath);
-    // extras module partial should be skipped
-    // Note: claude/_extras.md is not in extras.paths (["extras/"]) but the command is
-    expect(skipPaths).toContain('.claude/commands/example-command.md');
+    try {
+      const schema = await parseSchema(path.join(tmpShard, 'shard-schema.yaml'));
+      const selections = { brain: 'included' as const, extras: 'excluded' as const };
+      const result = await resolveModules(schema, selections, tmpShard);
 
-    // Brain files should still render
-    const renderPaths = result.render.map(f => f.outputPath);
-    expect(renderPaths).toContain('brain/North Star.md');
-    expect(renderPaths).toContain('CLAUDE.md');
+      const skipPaths = result.skip.map(f => f.outputPath);
+      // Command gated by extras module
+      expect(skipPaths).toContain('.claude/commands/example-command.md');
+      // Template under extras/ path
+      expect(skipPaths).toContain('extras/Feature.md');
+      // Partial declared in extras.partials
+      expect(skipPaths).toContain('claude/_extras.md');
+
+      // Brain files should still render
+      const renderPaths = result.render.map(f => f.outputPath);
+      expect(renderPaths).toContain('brain/North Star.md');
+      expect(renderPaths).toContain('CLAUDE.md');
+      expect(renderPaths).not.toContain('extras/Feature.md');
+    } finally {
+      await fs.rm(tmpShard, { recursive: true, force: true });
+    }
   });
 
   it('assigns correct module IDs to files', async () => {

--- a/tests/unit/modules.test.ts
+++ b/tests/unit/modules.test.ts
@@ -1,0 +1,161 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import crypto from 'node:crypto';
+import os from 'node:os';
+import { describe, it, expect } from 'vitest';
+import { resolveModules } from '../../source/core/modules.js';
+import { parseSchema } from '../../source/core/schema.js';
+
+const EXAMPLE_SHARD = path.resolve('examples/minimal-shard');
+
+async function loadSchema() {
+  return parseSchema(path.join(EXAMPLE_SHARD, 'shard-schema.yaml'));
+}
+
+describe('resolveModules', () => {
+  it('includes all files when all modules are included', async () => {
+    const schema = await loadSchema();
+    const selections = { brain: 'included' as const, extras: 'included' as const };
+    const result = await resolveModules(schema, selections, EXAMPLE_SHARD);
+
+    expect(result.skip).toHaveLength(0);
+    expect(result.render.length).toBeGreaterThan(0);
+
+    // All .njk files should be in render
+    const renderPaths = result.render.map(f => f.outputPath);
+    expect(renderPaths).toContain('CLAUDE.md');
+    expect(renderPaths).toContain('Home.md');
+    expect(renderPaths).toContain('brain/North Star.md');
+    expect(renderPaths).toContain('claude/_core.md');
+    expect(renderPaths).toContain('claude/_extras.md');
+
+    // Commands should be in copy
+    const copyPaths = result.copy.map(f => f.outputPath);
+    expect(copyPaths).toContain('.claude/commands/example-command.md');
+  });
+
+  it('skips excluded module files', async () => {
+    const schema = await loadSchema();
+    const selections = { brain: 'included' as const, extras: 'excluded' as const };
+    const result = await resolveModules(schema, selections, EXAMPLE_SHARD);
+
+    const skipPaths = result.skip.map(f => f.outputPath);
+    // extras module partial should be skipped
+    // Note: claude/_extras.md is not in extras.paths (["extras/"]) but the command is
+    expect(skipPaths).toContain('.claude/commands/example-command.md');
+
+    // Brain files should still render
+    const renderPaths = result.render.map(f => f.outputPath);
+    expect(renderPaths).toContain('brain/North Star.md');
+    expect(renderPaths).toContain('CLAUDE.md');
+  });
+
+  it('assigns correct module IDs to files', async () => {
+    const schema = await loadSchema();
+    const selections = { brain: 'included' as const, extras: 'included' as const };
+    const result = await resolveModules(schema, selections, EXAMPLE_SHARD);
+
+    const brainFile = result.render.find(f => f.outputPath === 'brain/North Star.md');
+    expect(brainFile?.module).toBe('brain');
+
+    const coreFile = result.render.find(f => f.outputPath === 'CLAUDE.md');
+    expect(coreFile?.module).toBeNull();
+
+    const homeFile = result.render.find(f => f.outputPath === 'Home.md');
+    expect(homeFile?.module).toBeNull();
+  });
+
+  it('.njk files go to render, non-.njk to copy', async () => {
+    const schema = await loadSchema();
+    const selections = { brain: 'included' as const, extras: 'included' as const };
+    const result = await resolveModules(schema, selections, EXAMPLE_SHARD);
+
+    // All render entries should have .njk source paths
+    for (const entry of result.render) {
+      expect(entry.sourcePath).toMatch(/\.njk$/);
+    }
+
+    // Copy entries from commands should not be .njk
+    const cmdCopy = result.copy.filter(f => f.outputPath.startsWith('.claude/commands/'));
+    for (const entry of cmdCopy) {
+      expect(entry.sourcePath).not.toMatch(/\.njk$/);
+    }
+  });
+
+  it('strips templates/ prefix and .njk suffix for output paths', async () => {
+    const schema = await loadSchema();
+    const selections = { brain: 'included' as const, extras: 'included' as const };
+    const result = await resolveModules(schema, selections, EXAMPLE_SHARD);
+
+    for (const entry of result.render) {
+      expect(entry.outputPath).not.toContain('templates/');
+      expect(entry.outputPath).not.toMatch(/\.njk$/);
+    }
+  });
+
+  it('detects _each iterator from parent directory name', async () => {
+    const tmpDir = path.join(os.tmpdir(), `modules-test-${crypto.randomUUID()}`);
+    const templateDir = path.join(tmpDir, 'templates', 'perf', 'competencies');
+    await fs.mkdir(templateDir, { recursive: true });
+    await fs.writeFile(path.join(templateDir, '_each.md.njk'), '# {{ item.name }}\n');
+    // Need shard.yaml and shard-schema.yaml for the shard to be valid
+    await fs.writeFile(path.join(tmpDir, 'shard.yaml'), 'apiVersion: v1\nname: test\nnamespace: dev\nversion: 1.0.0');
+    await fs.writeFile(path.join(tmpDir, 'shard-schema.yaml'), 'schema_version: 1\nvalues: {}\ngroups: []\nmodules:\n  perf:\n    label: Perf\n    paths: ["perf/"]\n    removable: true\nfrontmatter: {}\nmigrations: []');
+
+    try {
+      const schema = await parseSchema(path.join(tmpDir, 'shard-schema.yaml'));
+      const selections = { perf: 'included' as const };
+      const result = await resolveModules(schema, selections, tmpDir);
+
+      const eachFile = result.render.find(f => f.outputPath.includes('_each'));
+      expect(eachFile).toBeDefined();
+      expect(eachFile!.iterator).toBe('competencies');
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('detects volatile hint in template files', async () => {
+    const tmpDir = path.join(os.tmpdir(), `modules-test-${crypto.randomUUID()}`);
+    const templateDir = path.join(tmpDir, 'templates');
+    await fs.mkdir(templateDir, { recursive: true });
+    await fs.writeFile(path.join(templateDir, 'index.md.njk'), '{# shardmind: volatile #}\n# Index\n');
+
+    try {
+      const schema = { schema_version: 1, values: {}, groups: [], modules: {}, signals: [], frontmatter: {}, migrations: [] };
+      const result = await resolveModules(schema as any, {}, tmpDir);
+
+      const indexFile = result.render.find(f => f.outputPath === 'index.md');
+      expect(indexFile).toBeDefined();
+      expect(indexFile!.volatile).toBe(true);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('maps commands to .claude/commands/ output path', async () => {
+    const schema = await loadSchema();
+    const selections = { brain: 'included' as const, extras: 'included' as const };
+    const result = await resolveModules(schema, selections, EXAMPLE_SHARD);
+
+    const cmd = result.copy.find(f => f.outputPath === '.claude/commands/example-command.md');
+    expect(cmd).toBeDefined();
+    expect(cmd!.module).toBe('extras');
+  });
+
+  it('handles missing directories gracefully', async () => {
+    const tmpDir = path.join(os.tmpdir(), `modules-test-${crypto.randomUUID()}`);
+    await fs.mkdir(tmpDir, { recursive: true });
+
+    try {
+      const schema = { schema_version: 1, values: {}, groups: [], modules: {}, signals: [], frontmatter: {}, migrations: [] };
+      const result = await resolveModules(schema as any, {}, tmpDir);
+
+      expect(result.render).toHaveLength(0);
+      expect(result.copy).toHaveLength(0);
+      expect(result.skip).toHaveLength(0);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6

- `resolveModules(schema, selections, tempDir)` → `ModuleResolution { render, copy, skip }`
- Walks `templates/` recursively, matches files to modules via `module.paths[]`
- Walks `commands/`, `agents/` with module gating via `commands[]`/`agents[]` arrays
- Walks `scripts/`, `utilities/`, `skills/` (always copied), `codex/` (if present)
- Path mapping per spec: `templates/` → vault root (strip prefix + `.njk`), `commands/` → `.claude/commands/`, etc.
- Special case: `settings.json.njk` → `.claude/settings.json`
- Volatile hint detection (reads first line for `{# shardmind: volatile #}`)
- `_each` iterator extraction from parent directory name

## Test plan

- [x] 9 unit tests in `tests/unit/modules.test.ts`
  - All included → no skips, correct render/copy split
  - Extras excluded → commands and files skipped
  - Module IDs assigned correctly (brain, null for core)
  - .njk → render, non-.njk → copy
  - Output paths stripped correctly
  - _each iterator extracted from parent dir
  - Volatile hint detected
  - Commands mapped to `.claude/commands/`
  - Missing directories handled gracefully
- [x] `npm run typecheck` passes
- [x] `npm run build` clean
- [x] All 53 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)