### PR TITLE
feat: core/state.ts + core/registry.ts — vault state + shard resolution

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,13 +47,13 @@ Ship the core: install, update, status. Prove that vault template upgrades work 
 ### Milestone 5: Flagship Shard (Day 5)
 
 - [ ] obsidian-mind v4 — convert to shard format ([#14](https://github.com/breferrari/shardmind/issues/14))
-- [ ] Verify: `shardmind install breferrari/obsidian-mind` produces identical vault to git clone
+- [ ] Verify: `shardmind install github:breferrari/obsidian-mind` (direct mode) produces identical vault to git clone — the registry repo isn't created until Milestone 6
 
 ### Milestone 6: Ship (Day 6)
 
 - [ ] Research-wiki shard + E2E tests + npm publish ([#15](https://github.com/breferrari/shardmind/issues/15))
 - [ ] Create `shardmind/registry` repo with index.json (2 shards) — finalize schema per [#29](https://github.com/breferrari/shardmind/issues/29)
-- [ ] Final test: fresh machine → `npm install -g shardmind` → `shardmind install breferrari/obsidian-mind`
+- [ ] Final test: fresh machine → `npm install -g shardmind` → `shardmind install breferrari/obsidian-mind` (registry mode, proves #29 shape works end-to-end)
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,7 +52,7 @@ Ship the core: install, update, status. Prove that vault template upgrades work 
 ### Milestone 6: Ship (Day 6)
 
 - [ ] Research-wiki shard + E2E tests + npm publish ([#15](https://github.com/breferrari/shardmind/issues/15))
-- [ ] Create `shardmind/registry` repo with index.json (2 shards)
+- [ ] Create `shardmind/registry` repo with index.json (2 shards) — finalize schema per [#29](https://github.com/breferrari/shardmind/issues/29)
 - [ ] Final test: fresh machine → `npm install -g shardmind` → `shardmind install breferrari/obsidian-mind`
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ Ship the core: install, update, status. Prove that vault template upgrades work 
 
 ### Milestone 2: Install Command (Day 2)
 
-- [ ] `source/core/state.ts` + `core/registry.ts` ([#9](https://github.com/breferrari/shardmind/issues/9))
+- [x] `source/core/state.ts` + `core/registry.ts` ([#9](https://github.com/breferrari/shardmind/issues/9))
 - [ ] `commands/install.tsx` — full install flow with Ink wizard ([#8](https://github.com/breferrari/shardmind/issues/8))
 - [ ] Integration test: install pipeline against real obsidian-mind shard (temp dir)
 - [ ] Verify: `shardmind install breferrari/obsidian-mind` works end to end

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ Ship the core: install, update, status. Prove that vault template upgrades work 
 
 ### Milestone 2: Install Command (Day 2)
 
-- [x] `source/core/state.ts` + `core/registry.ts` ([#9](https://github.com/breferrari/shardmind/issues/9))
+- [x] `source/core/state.ts` + `source/core/registry.ts` ([#9](https://github.com/breferrari/shardmind/issues/9))
 - [ ] `commands/install.tsx` — full install flow with Ink wizard ([#8](https://github.com/breferrari/shardmind/issues/8))
 - [ ] Integration test: install pipeline against real obsidian-mind shard (temp dir)
 - [ ] Verify: `shardmind install breferrari/obsidian-mind` works end to end

--- a/source/core/registry.ts
+++ b/source/core/registry.ts
@@ -1,0 +1,235 @@
+import type { ResolvedShard } from '../runtime/types.js';
+import { ShardMindError } from '../runtime/types.js';
+
+const REGISTRY_INDEX_URL =
+  'https://raw.githubusercontent.com/shardmind/registry/main/index.json';
+
+interface RegistryEntry {
+  repo: string;
+  latest: string;
+  versions: string[];
+}
+
+interface RegistryIndex {
+  shards: Record<string, RegistryEntry>;
+}
+
+interface ParsedRef {
+  direct: boolean;
+  namespace: string;
+  name: string;
+  version: string | null;
+}
+
+const SHARD_REF_RE = /^(github:)?([a-z0-9][a-z0-9-]*)\/([a-z0-9][a-z0-9-]*)(?:@(.+))?$/i;
+
+export async function resolve(shardRef: string): Promise<ResolvedShard> {
+  const parsed = parseRef(shardRef);
+
+  let version: string;
+  let source: string;
+
+  if (parsed.direct) {
+    source = `github:${parsed.namespace}/${parsed.name}`;
+    version = parsed.version ?? (await fetchLatestRelease(parsed.namespace, parsed.name));
+  } else {
+    const index = await fetchRegistryIndex();
+    const key = `${parsed.namespace}/${parsed.name}`;
+    const entry = index.shards[key];
+
+    if (!entry) {
+      throw new ShardMindError(
+        `Shard '${key}' not found`,
+        'SHARD_NOT_FOUND',
+        'Check spelling or use github:owner/repo for direct install.',
+      );
+    }
+
+    if (parsed.version && !entry.versions.includes(parsed.version)) {
+      throw new ShardMindError(
+        `Version ${parsed.version} not found for ${key}. Available: ${entry.versions.join(', ')}`,
+        'VERSION_NOT_FOUND',
+        'Pick an available version or omit @version for the latest.',
+      );
+    }
+
+    version = parsed.version ?? entry.latest;
+    source = `github:${entry.repo}`;
+  }
+
+  const tarballUrl = `https://api.github.com/repos/${parsed.namespace}/${parsed.name}/tarball/v${version}`;
+  await verifyTag(tarballUrl, parsed.namespace, parsed.name, version);
+
+  return {
+    namespace: parsed.namespace,
+    name: parsed.name,
+    version,
+    source,
+    tarballUrl,
+  };
+}
+
+function parseRef(shardRef: string): ParsedRef {
+  const match = SHARD_REF_RE.exec(shardRef.trim());
+  if (!match) {
+    throw new ShardMindError(
+      `Invalid shard reference: '${shardRef}'`,
+      'REGISTRY_INVALID_REF',
+      'Expected "namespace/name", "namespace/name@version", or "github:namespace/name[@version]".',
+    );
+  }
+  const [, directPrefix, namespace, name, version] = match;
+  return {
+    direct: Boolean(directPrefix),
+    namespace: namespace!,
+    name: name!,
+    version: version ?? null,
+  };
+}
+
+async function fetchRegistryIndex(): Promise<RegistryIndex> {
+  const response = await safeFetch(REGISTRY_INDEX_URL);
+
+  if (!response.ok) {
+    throw new ShardMindError(
+      `Could not fetch shard registry: HTTP ${response.status}`,
+      'REGISTRY_NETWORK',
+      'The registry index is unavailable. Try again later or use github:owner/repo for direct install.',
+    );
+  }
+
+  let body: string;
+  try {
+    body = await response.text();
+  } catch (err) {
+    throw new ShardMindError(
+      'Failed to read registry response',
+      'REGISTRY_NETWORK',
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  try {
+    const parsed = JSON.parse(body) as RegistryIndex;
+    if (!parsed || typeof parsed !== 'object' || typeof parsed.shards !== 'object') {
+      throw new Error('Missing "shards" field');
+    }
+    return parsed;
+  } catch (err) {
+    throw new ShardMindError(
+      'Registry index is corrupt',
+      'REGISTRY_NETWORK',
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+async function fetchLatestRelease(namespace: string, name: string): Promise<string> {
+  const url = `https://api.github.com/repos/${namespace}/${name}/releases/latest`;
+  const response = await safeFetch(url, githubHeaders());
+
+  if (response.status === 403 && isRateLimited(response)) {
+    throw rateLimitError();
+  }
+
+  if (response.status === 404) {
+    throw new ShardMindError(
+      `No releases found for ${namespace}/${name}`,
+      'VERSION_NOT_FOUND',
+      'Specify a version explicitly with @version, or publish a GitHub release.',
+    );
+  }
+
+  if (!response.ok) {
+    throw new ShardMindError(
+      `Could not fetch latest release for ${namespace}/${name}: HTTP ${response.status}`,
+      'REGISTRY_NETWORK',
+      'GitHub API returned an unexpected status.',
+    );
+  }
+
+  let data: { tag_name?: string };
+  try {
+    data = (await response.json()) as { tag_name?: string };
+  } catch (err) {
+    throw new ShardMindError(
+      'Malformed response from GitHub releases API',
+      'REGISTRY_NETWORK',
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  const tag = data.tag_name;
+  if (typeof tag !== 'string' || tag.length === 0) {
+    throw new ShardMindError(
+      `Latest release for ${namespace}/${name} has no tag name`,
+      'REGISTRY_NETWORK',
+      'GitHub returned a release without tag_name.',
+    );
+  }
+
+  return tag.startsWith('v') ? tag.slice(1) : tag;
+}
+
+async function verifyTag(
+  tarballUrl: string,
+  namespace: string,
+  name: string,
+  version: string,
+): Promise<void> {
+  const response = await safeFetch(tarballUrl, { ...githubHeaders(), method: 'HEAD' });
+
+  if (response.ok || response.status === 302) return;
+
+  if (response.status === 403 && isRateLimited(response)) {
+    throw rateLimitError();
+  }
+
+  if (response.status === 404) {
+    throw new ShardMindError(
+      `Version ${version} not found for ${namespace}/${name}`,
+      'VERSION_NOT_FOUND',
+      `Tag v${version} does not exist on github.com/${namespace}/${name}.`,
+    );
+  }
+
+  throw new ShardMindError(
+    `Could not verify tag v${version} for ${namespace}/${name}: HTTP ${response.status}`,
+    'REGISTRY_NETWORK',
+    'GitHub API returned an unexpected status.',
+  );
+}
+
+function githubHeaders(): { headers: Record<string, string> } {
+  const headers: Record<string, string> = {
+    'Accept': 'application/vnd.github+json',
+  };
+  const token = process.env['GITHUB_TOKEN'];
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  return { headers };
+}
+
+function isRateLimited(response: Response): boolean {
+  const remaining = response.headers.get('x-ratelimit-remaining');
+  return remaining === '0';
+}
+
+function rateLimitError(): ShardMindError {
+  return new ShardMindError(
+    'GitHub API rate limit reached',
+    'REGISTRY_RATE_LIMITED',
+    'Set GITHUB_TOKEN for higher limits (5000 req/hr vs 60 unauthenticated).',
+  );
+}
+
+async function safeFetch(url: string, init?: RequestInit): Promise<Response> {
+  try {
+    return await fetch(url, init);
+  } catch (err) {
+    throw new ShardMindError(
+      `Could not reach ${new URL(url).host}`,
+      'REGISTRY_NETWORK',
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}

--- a/source/core/registry.ts
+++ b/source/core/registry.ts
@@ -21,17 +21,21 @@ interface ParsedRef {
   version: string | null;
 }
 
-const SHARD_REF_RE = /^(github:)?([a-z0-9][a-z0-9-]*)\/([a-z0-9][a-z0-9-]*)(?:@(.+))?$/i;
+const SHARD_REF_RE = /^(github:)?([a-z0-9][a-z0-9-]*)\/([a-z0-9][a-z0-9-]*)(?:@(.+))?$/;
 
 export async function resolve(shardRef: string): Promise<ResolvedShard> {
   const parsed = parseRef(shardRef);
 
   let version: string;
   let source: string;
+  let repoOwner: string;
+  let repoName: string;
 
   if (parsed.direct) {
-    source = `github:${parsed.namespace}/${parsed.name}`;
-    version = parsed.version ?? (await fetchLatestRelease(parsed.namespace, parsed.name));
+    repoOwner = parsed.namespace;
+    repoName = parsed.name;
+    source = `github:${repoOwner}/${repoName}`;
+    version = parsed.version ?? (await fetchLatestRelease(repoOwner, repoName));
   } else {
     const index = await fetchRegistryIndex();
     const key = `${parsed.namespace}/${parsed.name}`;
@@ -53,12 +57,22 @@ export async function resolve(shardRef: string): Promise<ResolvedShard> {
       );
     }
 
+    const repoParts = entry.repo.split('/');
+    if (repoParts.length !== 2 || !repoParts[0] || !repoParts[1]) {
+      throw new ShardMindError(
+        `Registry entry for '${key}' has invalid repo field: '${entry.repo}'`,
+        'REGISTRY_NETWORK',
+        'Expected "owner/name" format.',
+      );
+    }
+    repoOwner = repoParts[0];
+    repoName = repoParts[1];
     version = parsed.version ?? entry.latest;
     source = `github:${entry.repo}`;
   }
 
-  const tarballUrl = `https://api.github.com/repos/${parsed.namespace}/${parsed.name}/tarball/v${version}`;
-  await verifyTag(tarballUrl, parsed.namespace, parsed.name, version);
+  const tarballUrl = `https://api.github.com/repos/${repoOwner}/${repoName}/tarball/v${version}`;
+  await verifyTag(tarballUrl, repoOwner, repoName, version);
 
   return {
     namespace: parsed.namespace,
@@ -111,8 +125,14 @@ async function fetchRegistryIndex(): Promise<RegistryIndex> {
 
   try {
     const parsed = JSON.parse(body) as RegistryIndex;
-    if (!parsed || typeof parsed !== 'object' || typeof parsed.shards !== 'object') {
-      throw new Error('Missing "shards" field');
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      !parsed.shards ||
+      typeof parsed.shards !== 'object' ||
+      Array.isArray(parsed.shards)
+    ) {
+      throw new Error('Missing or invalid "shards" field');
     }
     return parsed;
   } catch (err) {

--- a/source/core/registry.ts
+++ b/source/core/registry.ts
@@ -4,6 +4,9 @@ import { ShardMindError } from '../runtime/types.js';
 const REGISTRY_INDEX_URL =
   'https://raw.githubusercontent.com/shardmind/registry/main/index.json';
 
+// Provisional index.json shape. Not yet ratified in IMPLEMENTATION.md §4.1 —
+// the registry repo is created at Milestone 6 and the format will be finalized
+// then. See #29 for the open questions and the "what to do" checklist.
 interface RegistryEntry {
   repo: string;
   latest: string;

--- a/source/core/state.ts
+++ b/source/core/state.ts
@@ -1,0 +1,118 @@
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import type { ShardState, ShardManifest, ShardSchema } from '../runtime/types.js';
+import { ShardMindError } from '../runtime/types.js';
+import { stringify as stringifyYaml } from 'yaml';
+
+const STATE_SCHEMA_VERSION = 1;
+
+export async function readState(vaultRoot: string): Promise<ShardState | null> {
+  const filePath = path.join(vaultRoot, '.shardmind', 'state.json');
+
+  let raw: string;
+  try {
+    raw = await fsp.readFile(filePath, 'utf-8');
+  } catch (err) {
+    const code = errnoCode(err);
+    if (code === 'ENOENT') return null;
+    throw new ShardMindError(
+      `Cannot read state.json: ${filePath}`,
+      'STATE_READ_FAILED',
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new ShardMindError(
+      `Corrupt state.json: ${filePath}`,
+      'STATE_CORRUPT',
+      'Delete .shardmind/ and reinstall, or fix the JSON manually.',
+    );
+  }
+
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    typeof (parsed as { schema_version?: unknown }).schema_version !== 'number'
+  ) {
+    throw new ShardMindError(
+      `Corrupt state.json: ${filePath}`,
+      'STATE_CORRUPT',
+      'Missing or invalid schema_version field.',
+    );
+  }
+
+  return parsed as ShardState;
+}
+
+export async function writeState(vaultRoot: string, state: ShardState): Promise<void> {
+  const shardDir = path.join(vaultRoot, '.shardmind');
+  const filePath = path.join(shardDir, 'state.json');
+
+  await fsp.mkdir(shardDir, { recursive: true });
+
+  if (state.schema_version !== STATE_SCHEMA_VERSION) {
+    throw new ShardMindError(
+      `Unsupported state schema_version: ${state.schema_version}`,
+      'STATE_UNSUPPORTED_VERSION',
+      `This version of shardmind writes schema_version ${STATE_SCHEMA_VERSION}.`,
+    );
+  }
+
+  const serialized = JSON.stringify(state, null, 2) + '\n';
+  await fsp.writeFile(filePath, serialized, 'utf-8');
+}
+
+export async function initShardDir(vaultRoot: string): Promise<void> {
+  const shardDir = path.join(vaultRoot, '.shardmind');
+  await fsp.mkdir(path.join(shardDir, 'templates'), { recursive: true });
+}
+
+export async function cacheTemplates(vaultRoot: string, tempDir: string): Promise<void> {
+  const src = path.join(tempDir, 'templates');
+  const dest = path.join(vaultRoot, '.shardmind', 'templates');
+
+  try {
+    await fsp.access(src);
+  } catch {
+    throw new ShardMindError(
+      `Missing templates/ directory in shard source: ${src}`,
+      'STATE_CACHE_MISSING_TEMPLATES',
+      'The downloaded shard does not contain a templates/ directory.',
+    );
+  }
+
+  await fsp.rm(dest, { recursive: true, force: true });
+  await fsp.mkdir(dest, { recursive: true });
+  await fsp.cp(src, dest, { recursive: true });
+}
+
+export async function cacheManifest(
+  vaultRoot: string,
+  manifest: ShardManifest,
+  schema: ShardSchema,
+): Promise<void> {
+  const shardDir = path.join(vaultRoot, '.shardmind');
+  await fsp.mkdir(shardDir, { recursive: true });
+
+  await fsp.writeFile(
+    path.join(shardDir, 'shard.yaml'),
+    stringifyYaml(manifest),
+    'utf-8',
+  );
+  await fsp.writeFile(
+    path.join(shardDir, 'shard-schema.yaml'),
+    stringifyYaml(schema),
+    'utf-8',
+  );
+}
+
+function errnoCode(err: unknown): string | undefined {
+  if (err instanceof Error && 'code' in err) {
+    return (err as NodeJS.ErrnoException).code;
+  }
+  return undefined;
+}

--- a/source/core/state.ts
+++ b/source/core/state.ts
@@ -45,6 +45,15 @@ export async function readState(vaultRoot: string): Promise<ShardState | null> {
     );
   }
 
+  const version = (parsed as { schema_version: number }).schema_version;
+  if (version !== STATE_SCHEMA_VERSION) {
+    throw new ShardMindError(
+      `Unsupported state schema_version: ${version}`,
+      'STATE_UNSUPPORTED_VERSION',
+      `This version of shardmind supports schema_version ${STATE_SCHEMA_VERSION}.`,
+    );
+  }
+
   return parsed as ShardState;
 }
 
@@ -98,14 +107,17 @@ export async function cacheManifest(
   const shardDir = path.join(vaultRoot, '.shardmind');
   await fsp.mkdir(shardDir, { recursive: true });
 
+  const serializedManifest = stringifyYaml(manifest, { lineWidth: 0 }).trimEnd() + '\n';
+  const serializedSchema = stringifyYaml(schema, { lineWidth: 0 }).trimEnd() + '\n';
+
   await fsp.writeFile(
     path.join(shardDir, 'shard.yaml'),
-    stringifyYaml(manifest),
+    serializedManifest,
     'utf-8',
   );
   await fsp.writeFile(
     path.join(shardDir, 'shard-schema.yaml'),
-    stringifyYaml(schema),
+    serializedSchema,
     'utf-8',
   );
 }

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { resolve } from '../../source/core/registry.js';
+import { ShardMindError } from '../../source/runtime/types.js';
+
+const REGISTRY_URL = 'https://raw.githubusercontent.com/shardmind/registry/main/index.json';
+
+function indexResponse(body: object, status = 200): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+function jsonResponse(body: object, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), { status, headers });
+}
+
+function headOk(): Response {
+  return new Response(null, { status: 200 });
+}
+
+function headNotFound(): Response {
+  return new Response(null, { status: 404 });
+}
+
+function rateLimited(): Response {
+  return new Response('rate limited', {
+    status: 403,
+    headers: { 'x-ratelimit-remaining': '0' },
+  });
+}
+
+describe('registry.resolve', () => {
+  const originalFetch = globalThis.fetch;
+  const originalToken = process.env['GITHUB_TOKEN'];
+
+  beforeEach(() => {
+    delete process.env['GITHUB_TOKEN'];
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalToken !== undefined) {
+      process.env['GITHUB_TOKEN'] = originalToken;
+    } else {
+      delete process.env['GITHUB_TOKEN'];
+    }
+  });
+
+  describe('parsing', () => {
+    it('rejects invalid shard references', async () => {
+      await expect(resolve('notashard')).rejects.toMatchObject({
+        code: 'REGISTRY_INVALID_REF',
+      });
+      await expect(resolve('')).rejects.toMatchObject({
+        code: 'REGISTRY_INVALID_REF',
+      });
+      await expect(resolve('namespace//name')).rejects.toMatchObject({
+        code: 'REGISTRY_INVALID_REF',
+      });
+    });
+  });
+
+  describe('registry mode', () => {
+    it('resolves namespace/name to latest version', async () => {
+      globalThis.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const u = typeof url === 'string' ? url : url.toString();
+        if (u === REGISTRY_URL) {
+          return indexResponse({
+            shards: {
+              'breferrari/obsidian-mind': {
+                repo: 'breferrari/obsidian-mind',
+                latest: '3.5.0',
+                versions: ['3.5.0', '3.4.0'],
+              },
+            },
+          });
+        }
+        if (u.includes('/tarball/v3.5.0') && init?.method === 'HEAD') return headOk();
+        throw new Error(`Unexpected fetch: ${u}`);
+      }) as typeof fetch;
+
+      const result = await resolve('breferrari/obsidian-mind');
+      expect(result).toEqual({
+        namespace: 'breferrari',
+        name: 'obsidian-mind',
+        version: '3.5.0',
+        source: 'github:breferrari/obsidian-mind',
+        tarballUrl: 'https://api.github.com/repos/breferrari/obsidian-mind/tarball/v3.5.0',
+      });
+    });
+
+    it('resolves namespace/name@version to that exact version', async () => {
+      globalThis.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const u = typeof url === 'string' ? url : url.toString();
+        if (u === REGISTRY_URL) {
+          return indexResponse({
+            shards: {
+              'breferrari/obsidian-mind': {
+                repo: 'breferrari/obsidian-mind',
+                latest: '3.5.0',
+                versions: ['3.5.0', '3.4.0'],
+              },
+            },
+          });
+        }
+        if (u.includes('/tarball/v3.4.0') && init?.method === 'HEAD') return headOk();
+        throw new Error(`Unexpected fetch: ${u}`);
+      }) as typeof fetch;
+
+      const result = await resolve('breferrari/obsidian-mind@3.4.0');
+      expect(result.version).toBe('3.4.0');
+      expect(result.tarballUrl).toContain('/tarball/v3.4.0');
+    });
+
+    it('throws SHARD_NOT_FOUND when shard is missing from registry', async () => {
+      globalThis.fetch = vi.fn(async () => indexResponse({ shards: {} })) as typeof fetch;
+
+      await expect(resolve('ghost/shard')).rejects.toMatchObject({
+        code: 'SHARD_NOT_FOUND',
+      });
+    });
+
+    it('throws VERSION_NOT_FOUND when requested version is not in index', async () => {
+      globalThis.fetch = vi.fn(async () =>
+        indexResponse({
+          shards: {
+            'breferrari/obsidian-mind': {
+              repo: 'breferrari/obsidian-mind',
+              latest: '3.5.0',
+              versions: ['3.5.0', '3.4.0'],
+            },
+          },
+        }),
+      ) as typeof fetch;
+
+      const err = await resolve('breferrari/obsidian-mind@9.9.9').catch((e) => e);
+      expect(err).toBeInstanceOf(ShardMindError);
+      expect(err.code).toBe('VERSION_NOT_FOUND');
+      expect(err.message).toContain('3.5.0');
+      expect(err.message).toContain('3.4.0');
+    });
+  });
+
+  describe('direct mode', () => {
+    it('skips registry and uses GitHub releases/latest when no version', async () => {
+      globalThis.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const u = typeof url === 'string' ? url : url.toString();
+        if (u.endsWith('/releases/latest')) {
+          return jsonResponse({ tag_name: 'v2.1.0' });
+        }
+        if (u.includes('/tarball/v2.1.0') && init?.method === 'HEAD') return headOk();
+        throw new Error(`Unexpected fetch: ${u}`);
+      }) as typeof fetch;
+
+      const result = await resolve('github:acme/widget');
+      expect(result.namespace).toBe('acme');
+      expect(result.name).toBe('widget');
+      expect(result.version).toBe('2.1.0');
+      expect(result.source).toBe('github:acme/widget');
+    });
+
+    it('strips v prefix from tag_name', async () => {
+      globalThis.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const u = typeof url === 'string' ? url : url.toString();
+        if (u.endsWith('/releases/latest')) return jsonResponse({ tag_name: 'v4.0.0' });
+        if (init?.method === 'HEAD') return headOk();
+        throw new Error(`Unexpected fetch: ${u}`);
+      }) as typeof fetch;
+
+      const result = await resolve('github:acme/widget');
+      expect(result.version).toBe('4.0.0');
+    });
+
+    it('uses explicit version without fetching releases/latest', async () => {
+      const calls: string[] = [];
+      globalThis.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const u = typeof url === 'string' ? url : url.toString();
+        calls.push(u);
+        if (init?.method === 'HEAD') return headOk();
+        throw new Error(`Unexpected fetch: ${u}`);
+      }) as typeof fetch;
+
+      const result = await resolve('github:acme/widget@1.2.3');
+      expect(result.version).toBe('1.2.3');
+      expect(calls.some((u) => u.includes('/releases/latest'))).toBe(false);
+    });
+
+    it('throws VERSION_NOT_FOUND when direct mode repo has no releases', async () => {
+      globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+        const u = typeof url === 'string' ? url : url.toString();
+        if (u.endsWith('/releases/latest')) return new Response(null, { status: 404 });
+        throw new Error(`Unexpected fetch: ${u}`);
+      }) as typeof fetch;
+
+      await expect(resolve('github:acme/widget')).rejects.toMatchObject({
+        code: 'VERSION_NOT_FOUND',
+      });
+    });
+  });
+
+  describe('tag verification', () => {
+    it('throws VERSION_NOT_FOUND when HEAD returns 404', async () => {
+      globalThis.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const u = typeof url === 'string' ? url : url.toString();
+        if (u === REGISTRY_URL) {
+          return indexResponse({
+            shards: {
+              'breferrari/obsidian-mind': {
+                repo: 'breferrari/obsidian-mind',
+                latest: '3.5.0',
+                versions: ['3.5.0'],
+              },
+            },
+          });
+        }
+        if (init?.method === 'HEAD') return headNotFound();
+        throw new Error(`Unexpected fetch: ${u}`);
+      }) as typeof fetch;
+
+      await expect(resolve('breferrari/obsidian-mind')).rejects.toMatchObject({
+        code: 'VERSION_NOT_FOUND',
+      });
+    });
+  });
+
+  describe('error mapping', () => {
+    it('maps fetch rejection to REGISTRY_NETWORK', async () => {
+      globalThis.fetch = vi.fn(async () => {
+        throw new TypeError('network offline');
+      }) as typeof fetch;
+
+      await expect(resolve('breferrari/obsidian-mind')).rejects.toMatchObject({
+        code: 'REGISTRY_NETWORK',
+      });
+    });
+
+    it('maps GitHub rate limit to REGISTRY_RATE_LIMITED', async () => {
+      globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+        const u = typeof url === 'string' ? url : url.toString();
+        if (u.endsWith('/releases/latest')) return rateLimited();
+        throw new Error(`Unexpected fetch: ${u}`);
+      }) as typeof fetch;
+
+      await expect(resolve('github:acme/widget')).rejects.toMatchObject({
+        code: 'REGISTRY_RATE_LIMITED',
+      });
+    });
+
+    it('sends GITHUB_TOKEN on api.github.com requests when set', async () => {
+      process.env['GITHUB_TOKEN'] = 'tok_abc';
+      const seen: Array<{ url: string; auth: string | null }> = [];
+
+      globalThis.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const u = typeof url === 'string' ? url : url.toString();
+        const headers = (init?.headers ?? {}) as Record<string, string>;
+        seen.push({ url: u, auth: headers['Authorization'] ?? null });
+        if (u.endsWith('/releases/latest')) return jsonResponse({ tag_name: 'v1.0.0' });
+        if (init?.method === 'HEAD') return headOk();
+        throw new Error(`Unexpected fetch: ${u}`);
+      }) as typeof fetch;
+
+      await resolve('github:acme/widget');
+
+      const apiCalls = seen.filter((c) => c.url.includes('api.github.com'));
+      expect(apiCalls.length).toBeGreaterThan(0);
+      for (const call of apiCalls) {
+        expect(call.auth).toBe('Bearer tok_abc');
+      }
+    });
+  });
+});

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -56,6 +56,15 @@ describe('registry.resolve', () => {
         code: 'REGISTRY_INVALID_REF',
       });
     });
+
+    it('rejects uppercase refs (enforces lowercase identifiers)', async () => {
+      await expect(resolve('Breferrari/obsidian-mind')).rejects.toMatchObject({
+        code: 'REGISTRY_INVALID_REF',
+      });
+      await expect(resolve('github:Acme/Widget')).rejects.toMatchObject({
+        code: 'REGISTRY_INVALID_REF',
+      });
+    });
   });
 
   describe('registry mode', () => {
@@ -115,6 +124,66 @@ describe('registry.resolve', () => {
 
       await expect(resolve('ghost/shard')).rejects.toMatchObject({
         code: 'SHARD_NOT_FOUND',
+      });
+    });
+
+    it('builds tarball URL from entry.repo when it differs from shard key', async () => {
+      const seen: string[] = [];
+      globalThis.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const u = typeof url === 'string' ? url : url.toString();
+        seen.push(u);
+        if (u === REGISTRY_URL) {
+          return indexResponse({
+            shards: {
+              'breferrari/obsidian-mind': {
+                repo: 'other-owner/mirror-repo',
+                latest: '3.5.0',
+                versions: ['3.5.0'],
+              },
+            },
+          });
+        }
+        if (init?.method === 'HEAD') return headOk();
+        throw new Error(`Unexpected fetch: ${u}`);
+      }) as typeof fetch;
+
+      const result = await resolve('breferrari/obsidian-mind');
+      expect(result.tarballUrl).toBe(
+        'https://api.github.com/repos/other-owner/mirror-repo/tarball/v3.5.0',
+      );
+      expect(result.source).toBe('github:other-owner/mirror-repo');
+      expect(result.namespace).toBe('breferrari');
+      expect(result.name).toBe('obsidian-mind');
+      expect(seen.some((u) => u.includes('/other-owner/mirror-repo/tarball/v3.5.0'))).toBe(true);
+    });
+
+    it('rejects registry entries with malformed repo field', async () => {
+      globalThis.fetch = vi.fn(async () =>
+        indexResponse({
+          shards: {
+            'ns/name': { repo: 'broken', latest: '1.0.0', versions: ['1.0.0'] },
+          },
+        }),
+      ) as typeof fetch;
+
+      await expect(resolve('ns/name')).rejects.toMatchObject({
+        code: 'REGISTRY_NETWORK',
+      });
+    });
+
+    it('rejects registry responses where shards is null', async () => {
+      globalThis.fetch = vi.fn(async () => indexResponse({ shards: null })) as typeof fetch;
+
+      await expect(resolve('ns/name')).rejects.toMatchObject({
+        code: 'REGISTRY_NETWORK',
+      });
+    });
+
+    it('rejects registry responses where shards is an array', async () => {
+      globalThis.fetch = vi.fn(async () => indexResponse({ shards: [] })) as typeof fetch;
+
+      await expect(resolve('ns/name')).rejects.toMatchObject({
+        code: 'REGISTRY_NETWORK',
       });
     });
 

--- a/tests/unit/state.test.ts
+++ b/tests/unit/state.test.ts
@@ -74,6 +74,19 @@ describe('core/state', () => {
         code: 'STATE_CORRUPT',
       });
     });
+
+    it('throws STATE_UNSUPPORTED_VERSION when schema_version differs from supported', async () => {
+      await fsp.mkdir(path.join(vault, '.shardmind'), { recursive: true });
+      await fsp.writeFile(
+        path.join(vault, '.shardmind', 'state.json'),
+        JSON.stringify(makeState({ schema_version: 2 })),
+        'utf-8',
+      );
+
+      await expect(readState(vault)).rejects.toMatchObject({
+        code: 'STATE_UNSUPPORTED_VERSION',
+      });
+    });
   });
 
   describe('writeState', () => {

--- a/tests/unit/state.test.ts
+++ b/tests/unit/state.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import {
+  readState,
+  writeState,
+  initShardDir,
+  cacheTemplates,
+  cacheManifest,
+} from '../../source/core/state.js';
+import type { ShardState, ShardManifest, ShardSchema } from '../../source/runtime/types.js';
+import { ShardMindError } from '../../source/runtime/types.js';
+
+function makeState(overrides: Partial<ShardState> = {}): ShardState {
+  return {
+    schema_version: 1,
+    shard: 'breferrari/obsidian-mind',
+    source: 'github:breferrari/obsidian-mind',
+    version: '3.5.0',
+    installed_at: '2026-04-18T00:00:00.000Z',
+    updated_at: '2026-04-18T00:00:00.000Z',
+    values_hash: 'abc123',
+    modules: { core: 'included', research: 'excluded' },
+    files: {},
+    ...overrides,
+  };
+}
+
+describe('core/state', () => {
+  let vault: string;
+
+  beforeEach(async () => {
+    vault = path.join(os.tmpdir(), `shardmind-test-${crypto.randomUUID()}`);
+    await fsp.mkdir(vault, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fsp.rm(vault, { recursive: true, force: true });
+  });
+
+  describe('readState', () => {
+    it('returns null when state.json does not exist', async () => {
+      const state = await readState(vault);
+      expect(state).toBeNull();
+    });
+
+    it('roundtrips a written state', async () => {
+      const original = makeState();
+      await writeState(vault, original);
+      const loaded = await readState(vault);
+      expect(loaded).toEqual(original);
+    });
+
+    it('throws STATE_CORRUPT on invalid JSON', async () => {
+      await fsp.mkdir(path.join(vault, '.shardmind'), { recursive: true });
+      await fsp.writeFile(path.join(vault, '.shardmind', 'state.json'), '{not json', 'utf-8');
+
+      await expect(readState(vault)).rejects.toMatchObject({
+        code: 'STATE_CORRUPT',
+      });
+    });
+
+    it('throws STATE_CORRUPT when schema_version is missing', async () => {
+      await fsp.mkdir(path.join(vault, '.shardmind'), { recursive: true });
+      await fsp.writeFile(
+        path.join(vault, '.shardmind', 'state.json'),
+        JSON.stringify({ shard: 'foo/bar' }),
+        'utf-8',
+      );
+
+      await expect(readState(vault)).rejects.toMatchObject({
+        code: 'STATE_CORRUPT',
+      });
+    });
+  });
+
+  describe('writeState', () => {
+    it('creates .shardmind/ if missing', async () => {
+      await writeState(vault, makeState());
+      const statePath = path.join(vault, '.shardmind', 'state.json');
+      await expect(fsp.access(statePath)).resolves.toBeUndefined();
+    });
+
+    it('serializes with 2-space indent and trailing newline', async () => {
+      await writeState(vault, makeState());
+      const raw = await fsp.readFile(path.join(vault, '.shardmind', 'state.json'), 'utf-8');
+      expect(raw).toMatch(/\n$/);
+      expect(raw).toContain('  "shard":');
+    });
+
+    it('rejects unsupported schema_version', async () => {
+      await expect(
+        writeState(vault, makeState({ schema_version: 99 })),
+      ).rejects.toMatchObject({ code: 'STATE_UNSUPPORTED_VERSION' });
+    });
+  });
+
+  describe('initShardDir', () => {
+    it('creates .shardmind/templates/', async () => {
+      await initShardDir(vault);
+      const templatesPath = path.join(vault, '.shardmind', 'templates');
+      const stat = await fsp.stat(templatesPath);
+      expect(stat.isDirectory()).toBe(true);
+    });
+
+    it('is idempotent', async () => {
+      await initShardDir(vault);
+      await initShardDir(vault);
+      const templatesPath = path.join(vault, '.shardmind', 'templates');
+      const stat = await fsp.stat(templatesPath);
+      expect(stat.isDirectory()).toBe(true);
+    });
+  });
+
+  describe('cacheTemplates', () => {
+    it('copies templates/ from temp to .shardmind/templates/', async () => {
+      const tempDir = path.join(os.tmpdir(), `shardmind-src-${crypto.randomUUID()}`);
+      await fsp.mkdir(path.join(tempDir, 'templates', 'nested'), { recursive: true });
+      await fsp.writeFile(path.join(tempDir, 'templates', 'a.md'), 'hello', 'utf-8');
+      await fsp.writeFile(path.join(tempDir, 'templates', 'nested', 'b.md'), 'world', 'utf-8');
+
+      try {
+        await cacheTemplates(vault, tempDir);
+        const aContent = await fsp.readFile(
+          path.join(vault, '.shardmind', 'templates', 'a.md'),
+          'utf-8',
+        );
+        const bContent = await fsp.readFile(
+          path.join(vault, '.shardmind', 'templates', 'nested', 'b.md'),
+          'utf-8',
+        );
+        expect(aContent).toBe('hello');
+        expect(bContent).toBe('world');
+      } finally {
+        await fsp.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('clears existing .shardmind/templates/ before copying', async () => {
+      const tempDir = path.join(os.tmpdir(), `shardmind-src-${crypto.randomUUID()}`);
+      await fsp.mkdir(path.join(tempDir, 'templates'), { recursive: true });
+      await fsp.writeFile(path.join(tempDir, 'templates', 'new.md'), 'new', 'utf-8');
+
+      await fsp.mkdir(path.join(vault, '.shardmind', 'templates'), { recursive: true });
+      await fsp.writeFile(
+        path.join(vault, '.shardmind', 'templates', 'stale.md'),
+        'stale',
+        'utf-8',
+      );
+
+      try {
+        await cacheTemplates(vault, tempDir);
+        await expect(
+          fsp.access(path.join(vault, '.shardmind', 'templates', 'stale.md')),
+        ).rejects.toThrow();
+      } finally {
+        await fsp.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('throws when source templates/ is missing', async () => {
+      const tempDir = path.join(os.tmpdir(), `shardmind-empty-${crypto.randomUUID()}`);
+      await fsp.mkdir(tempDir, { recursive: true });
+
+      try {
+        await expect(cacheTemplates(vault, tempDir)).rejects.toMatchObject({
+          code: 'STATE_CACHE_MISSING_TEMPLATES',
+        });
+      } finally {
+        await fsp.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('cacheManifest', () => {
+    it('writes shard.yaml and shard-schema.yaml', async () => {
+      const manifest: ShardManifest = {
+        apiVersion: 'v1',
+        name: 'obsidian-mind',
+        namespace: 'breferrari',
+        version: '3.5.0',
+        dependencies: [],
+        hooks: {},
+      };
+      const schema: ShardSchema = {
+        schema_version: 1,
+        values: {},
+        groups: [],
+        modules: {},
+        signals: [],
+        frontmatter: {},
+        migrations: [],
+      };
+
+      await cacheManifest(vault, manifest, schema);
+
+      const manifestYaml = await fsp.readFile(
+        path.join(vault, '.shardmind', 'shard.yaml'),
+        'utf-8',
+      );
+      const schemaYaml = await fsp.readFile(
+        path.join(vault, '.shardmind', 'shard-schema.yaml'),
+        'utf-8',
+      );
+
+      expect(manifestYaml).toContain('name: obsidian-mind');
+      expect(manifestYaml).toContain('namespace: breferrari');
+      expect(schemaYaml).toContain('schema_version: 1');
+    });
+  });
+
+  describe('errors are ShardMindError instances', () => {
+    it('readState STATE_CORRUPT is a ShardMindError', async () => {
+      await fsp.mkdir(path.join(vault, '.shardmind'), { recursive: true });
+      await fsp.writeFile(path.join(vault, '.shardmind', 'state.json'), '{', 'utf-8');
+
+      await expect(readState(vault)).rejects.toBeInstanceOf(ShardMindError);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #9. First pair of modules for Milestone 2 (Install Command).

- **`source/core/state.ts`** (IMPLEMENTATION.md §4.7): `readState`, `writeState`, `initShardDir`, `cacheTemplates`, `cacheManifest`. Takes an explicit `vaultRoot` so it stays independent of `runtime/state.ts` (read-only, auto-discovering, for hook scripts).
- **`source/core/registry.ts`** (IMPLEMENTATION.md §4.1): `resolve(shardRef)` handling three ref shapes:
  - `namespace/name[@version]` → registry index at `shardmind/registry/main/index.json`
  - `github:namespace/name[@version]` → direct mode; if no version, fetch `releases/latest` from GitHub
  - Tag verification via HEAD on the tarball URL
- `GITHUB_TOKEN` sent on `api.github.com` requests (not on raw.githubusercontent.com).
- Typed errors: `SHARD_NOT_FOUND`, `VERSION_NOT_FOUND`, `REGISTRY_NETWORK`, `REGISTRY_RATE_LIMITED`, `REGISTRY_INVALID_REF`, plus state errors `STATE_READ_FAILED`, `STATE_CORRUPT`, `STATE_UNSUPPORTED_VERSION`, `STATE_CACHE_MISSING_TEMPLATES`.

### Design note — registry index format

Spec doesn't pin this down; this PR assumes:

```json
{
  "shards": {
    "breferrari/obsidian-mind": {
      "repo": "breferrari/obsidian-mind",
      "latest": "3.5.0",
      "versions": ["3.5.0", "3.4.0"]
    }
  }
}
```

Matches the error-message shape in spec §4.1 (`Available: 3.4.0, 3.3.0`). The `shardmind/registry` repo can be created at Milestone 6 with this shape.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 96 passing (27 new: 14 state, 13 registry)
- [x] state.ts: roundtrips, null on missing, corrupt JSON → `STATE_CORRUPT`, schema_version guard, template caching clears stale files, manifest YAML written
- [x] registry.ts: invalid ref rejection, registry mode (latest + explicit version), direct mode (with and without version, strips `v` prefix), tag HEAD 404 → `VERSION_NOT_FOUND`, rate-limit detection via `x-ratelimit-remaining: 0`, `GITHUB_TOKEN` sent only to api.github.com

## Roadmap

- [x] ROADMAP.md Milestone 2 item 1 checked off