### PR TITLE
feat: install command — full Ink wizard + pipeline + rollback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ tmp/
 .tmp/
 .local/
 .artifacts/
+/.smoke/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,8 +26,8 @@ Ship the core: install, update, status. Prove that vault template upgrades work 
 ### Milestone 2: Install Command (Day 2)
 
 - [x] `source/core/state.ts` + `source/core/registry.ts` ([#9](https://github.com/breferrari/shardmind/issues/9))
-- [ ] `commands/install.tsx` — full install flow with Ink wizard ([#8](https://github.com/breferrari/shardmind/issues/8))
-- [ ] Integration test: install pipeline against real obsidian-mind shard (temp dir)
+- [x] `commands/install.tsx` — full install flow with Ink wizard ([#8](https://github.com/breferrari/shardmind/issues/8))
+- [x] Integration test: install pipeline against `examples/minimal-shard` (real obsidian-mind shard verified at Milestone 5)
 - [ ] Verify: `shardmind install breferrari/obsidian-mind` works end to end
 
 ### Milestone 3: Merge Engine (Day 3)
@@ -47,6 +47,7 @@ Ship the core: install, update, status. Prove that vault template upgrades work 
 ### Milestone 5: Flagship Shard (Day 5)
 
 - [ ] obsidian-mind v4 — convert to shard format ([#14](https://github.com/breferrari/shardmind/issues/14))
+- [ ] Finalize post-install hook runtime ([#30](https://github.com/breferrari/shardmind/issues/30)) — first real hook arrives with obsidian-mind
 - [ ] Verify: `shardmind install github:breferrari/obsidian-mind` (direct mode) produces identical vault to git clone — the registry repo isn't created until Milestone 6
 
 ### Milestone 6: Ship (Day 6)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test": "vitest run",
     "test:watch": "vitest watch",
     "test:merge": "vitest run tests/unit/drift.test.ts",
+    "smoke": "bash scripts/smoke-install.sh",
     "typecheck": "tsc --noEmit",
     "lint": "tsc --noEmit && vitest run",
     "prepublishOnly": "npm run typecheck && npm test && npm run build",

--- a/scripts/smoke-install.sh
+++ b/scripts/smoke-install.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Smoke-test the install command against a real GitHub-hosted shard.
+#
+# Prerequisite (one-time): publish a test shard to GitHub. Easiest way:
+#
+#   cp -r examples/minimal-shard /tmp/test-minimal-shard
+#   cd /tmp/test-minimal-shard
+#   git init && git add -A && git commit -m "initial"
+#   gh repo create <your-user>/test-minimal-shard --public --source=. --push
+#   git tag v0.1.0 && git push --tags
+#
+# Then export SHARDMIND_TEST_SHARD once:
+#
+#   export SHARDMIND_TEST_SHARD=github:<your-user>/test-minimal-shard
+#
+# Usage:
+#
+#   npm run smoke                 # runs non-interactive scenarios
+#   npm run smoke -- --interactive  # pauses for manual TUI scenarios too
+
+set -euo pipefail
+
+SHARD_REF="${SHARDMIND_TEST_SHARD:-github:breferrari/test-minimal-shard}"
+INTERACTIVE=false
+for arg in "$@"; do
+  case "$arg" in
+    --interactive) INTERACTIVE=true ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLI="$REPO_ROOT/dist/cli.js"
+SANDBOX="$REPO_ROOT/.smoke"
+
+say() { printf '\n\033[36m==>\033[0m %s\n' "$*"; }
+fail() { printf '\n\033[31mFAIL:\033[0m %s\n' "$*" >&2; exit 1; }
+pause() {
+  if $INTERACTIVE; then
+    printf '\n\033[33mPress Enter to continue...\033[0m'
+    read -r
+  fi
+}
+
+say "Building shardmind"
+(cd "$REPO_ROOT" && npm run build >/dev/null)
+[[ -f "$CLI" ]] || fail "Build did not produce $CLI"
+
+say "Preparing sandbox at $SANDBOX"
+rm -rf "$SANDBOX"
+mkdir -p "$SANDBOX"
+
+# Write a reusable values file for --yes runs
+cat > "$SANDBOX/values.yaml" <<EOF
+user_name: Smoke Tester
+org_name: Test Org
+vault_purpose: engineering
+qmd_enabled: true
+EOF
+
+say "Scenario 1: --dry-run (no writes expected)"
+(
+  mkdir -p "$SANDBOX/dry-run" && cd "$SANDBOX/dry-run"
+  node "$CLI" install "$SHARD_REF" --dry-run --values "$SANDBOX/values.yaml" --yes
+  # Verify no state was written
+  if [[ -d ".shardmind" ]]; then fail "dry-run wrote .shardmind/"; fi
+  if [[ -f "Home.md" ]]; then fail "dry-run wrote Home.md"; fi
+)
+say "Scenario 1 OK"
+pause
+
+say "Scenario 2: --yes non-interactive install"
+(
+  mkdir -p "$SANDBOX/yes" && cd "$SANDBOX/yes"
+  node "$CLI" install "$SHARD_REF" --values "$SANDBOX/values.yaml" --yes
+  [[ -f "Home.md" ]] || fail "Home.md not written"
+  [[ -f ".shardmind/state.json" ]] || fail "state.json not written"
+  [[ -f "shard-values.yaml" ]] || fail "shard-values.yaml not written"
+  grep -q "Smoke Tester" Home.md || fail "Home.md did not render user_name"
+)
+say "Scenario 2 OK"
+pause
+
+say "Scenario 3: --verbose on a fresh vault"
+(
+  mkdir -p "$SANDBOX/verbose" && cd "$SANDBOX/verbose"
+  node "$CLI" install "$SHARD_REF" --values "$SANDBOX/values.yaml" --yes --verbose
+  [[ -f "Home.md" ]] || fail "Home.md not written in verbose scenario"
+)
+say "Scenario 3 OK"
+pause
+
+say "Scenario 4: collision — pre-seed Home.md, install with --yes"
+(
+  mkdir -p "$SANDBOX/collision" && cd "$SANDBOX/collision"
+  printf 'user content\n' > Home.md
+  node "$CLI" install "$SHARD_REF" --values "$SANDBOX/values.yaml" --yes
+  # With --yes, policy is back-up-and-continue
+  if ! ls Home.md.shardmind-backup-* 1>/dev/null 2>&1; then
+    fail "expected a backup file Home.md.shardmind-backup-*"
+  fi
+  # New content installed
+  grep -q "Smoke Tester" Home.md || fail "Home.md not replaced with shard content"
+)
+say "Scenario 4 OK"
+pause
+
+say "Scenario 5: existing install — re-run in same dir (expect cancellation)"
+(
+  cd "$SANDBOX/yes"
+  # Without --yes this would open the gate; with --yes the gate has no
+  # non-interactive reinstall path, so we expect the CLI to surface an
+  # error / cancellation. We don't assert pass/fail here — this scenario
+  # is primarily informational to surface the current --yes policy.
+  set +e
+  node "$CLI" install "$SHARD_REF" --values "$SANDBOX/values.yaml" --yes
+  echo "(exit code above documents current --yes behavior on re-install)"
+  set -e
+)
+pause
+
+if $INTERACTIVE; then
+  say "Interactive scenarios — drive these manually:"
+  cat <<EOF
+  a) Fresh wizard:
+     mkdir $SANDBOX/interactive-wizard && cd $SANDBOX/interactive-wizard
+     node $CLI install $SHARD_REF
+
+     Check: all value prompts, Esc back-nav, computed-default preview,
+     module multiselect with live file-count, confirm screen Back option,
+     summary next-step hint.
+
+  b) Collision review:
+     mkdir $SANDBOX/interactive-collide && cd $SANDBOX/interactive-collide
+     echo "user" > Home.md
+     node $CLI install $SHARD_REF
+     Check: backup/overwrite/cancel choices all behave correctly.
+
+  c) Existing-install gate:
+     cd $SANDBOX/interactive-wizard
+     node $CLI install $SHARD_REF
+     Check: update/reinstall/cancel choices. Try typing wrong text at
+     the REINSTALL prompt and confirm it's rejected.
+EOF
+fi
+
+say "Smoke complete. Sandbox preserved at $SANDBOX for inspection."

--- a/source/commands/install.tsx
+++ b/source/commands/install.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef, type ReactNode } from 'react';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import { Box, Text, useApp } from 'ink';
@@ -72,6 +72,7 @@ interface PreparedContext {
   cleanup: () => Promise<void>;
   prefillValues: Record<string, unknown>;
   moduleFileCounts: Record<string, number>;
+  alwaysIncludedFileCount: number;
 }
 
 interface HookSummary {
@@ -88,6 +89,13 @@ export default function Install({ args, options }: Props) {
 
   const [phase, setPhase] = useState<Phase>({ kind: 'booting' });
 
+  // Refs tracked during runInstall so a SIGINT handler can roll back
+  // any files written so far and restore any backups created during
+  // collision handling.
+  const writtenPathsRef = useRef<string[]>([]);
+  const backupsRef = useRef<BackupRecord[]>([]);
+  const installingRef = useRef(false);
+
   const finish = useCallback(
     (next: Phase) => {
       setPhase(next);
@@ -97,6 +105,26 @@ export default function Install({ args, options }: Props) {
     },
     [exit],
   );
+
+  // SIGINT handler: if a render is in progress when the user hits Ctrl+C,
+  // roll back partial writes and restore backups before exiting. Default
+  // Ink behavior exits without knowing about our bookkeeping.
+  useEffect(() => {
+    const handler = () => {
+      if (installingRef.current && !dryRun) {
+        // Fire-and-forget; process is about to exit anyway.
+        rollbackInstall(vaultRoot, writtenPathsRef.current, backupsRef.current)
+          .catch(() => {})
+          .finally(() => process.exit(130));
+      } else {
+        process.exit(130);
+      }
+    };
+    process.on('SIGINT', handler);
+    return () => {
+      process.off('SIGINT', handler);
+    };
+  }, [dryRun, vaultRoot]);
 
   // Boot → preparation
   useEffect(() => {
@@ -121,7 +149,7 @@ export default function Install({ args, options }: Props) {
 
         // Precompute module file counts for the wizard preview (requires
         // scanning the temp directory with current default selections).
-        const { moduleFileCounts } = await planOutputs(
+        const { moduleFileCounts, alwaysIncludedFileCount } = await planOutputs(
           schema,
           temp.tempDir,
           defaultModuleSelections(schema),
@@ -135,6 +163,7 @@ export default function Install({ args, options }: Props) {
           cleanup: temp.cleanup,
           prefillValues: merged,
           moduleFileCounts,
+          alwaysIncludedFileCount,
         };
         ctxForCleanup = ctx;
 
@@ -223,6 +252,12 @@ export default function Install({ args, options }: Props) {
       const start = Date.now();
       const history: string[] = [];
 
+      // Register backups with the SIGINT handler before any write starts,
+      // so Ctrl+C between writes still restores them.
+      backupsRef.current = backups;
+      writtenPathsRef.current = [];
+      installingRef.current = true;
+
       setPhase({
         kind: 'installing',
         total: 0,
@@ -245,6 +280,9 @@ export default function Install({ args, options }: Props) {
           values: result.values,
           selections: result.selections,
           dryRun,
+          onFileWritten: (outputPath) => {
+            writtenPathsRef.current.push(outputPath);
+          },
           onProgress: (ev) => {
             if (ev.kind === 'start') {
               setPhase((prev) =>
@@ -278,6 +316,9 @@ export default function Install({ args, options }: Props) {
           : await runPostInstallHook(ctx.tempDir, ctx.manifest);
         const hookSummary = summarizeHook(hookResult);
 
+        // Install completed — SIGINT no longer needs to roll back.
+        installingRef.current = false;
+
         finish({
           kind: 'summary',
           manifest: ctx.manifest,
@@ -292,6 +333,7 @@ export default function Install({ args, options }: Props) {
         if (!dryRun) {
           await rollbackInstall(vaultRoot, written, backups).catch(() => {});
         }
+        installingRef.current = false;
         finish({
           kind: 'error',
           error: err as Error,
@@ -326,7 +368,7 @@ export default function Install({ args, options }: Props) {
       if (choice === 'update') {
         finish({
           kind: 'cancelled',
-          reason: 'Run `shardmind update` instead. (Install declined.)',
+          reason: 'Existing install preserved. `shardmind update` is not yet available (Milestone 4); re-run `install` and pick Reinstall when you want a fresh start.',
         });
         return;
       }
@@ -373,71 +415,91 @@ export default function Install({ args, options }: Props) {
     [phase, vaultRoot, yes, dryRun, finish, handleWizardComplete],
   );
 
-  // Render tree per phase.
+  // Render tree per phase — wrapped in RootFrame so dry-run and the
+  // keyboard legend stay visible across all phases.
   if (phase.kind === 'booting' || phase.kind === 'loading') {
     const msg = phase.kind === 'loading' ? phase.message : 'Starting…';
     return (
-      <Box gap={1}>
-        <Spinner />
-        <Text>{msg}</Text>
-      </Box>
+      <RootFrame dryRun={Boolean(dryRun)} showLegend={false}>
+        <Box gap={1}>
+          <Spinner />
+          <Text>{msg}</Text>
+        </Box>
+      </RootFrame>
     );
   }
 
   if (phase.kind === 'gate') {
-    return <ExistingInstallGate state={phase.state} onChoice={handleGateChoice} />;
+    return (
+      <RootFrame dryRun={Boolean(dryRun)}>
+        <ExistingInstallGate state={phase.state} onChoice={handleGateChoice} />
+      </RootFrame>
+    );
   }
 
   if (phase.kind === 'wizard') {
     return (
-      <InstallWizard
-        manifest={phase.ctx.manifest}
-        schema={phase.ctx.schema}
-        prefillValues={phase.ctx.prefillValues}
-        moduleFileCounts={phase.ctx.moduleFileCounts}
-        onComplete={(result) => handleWizardComplete(result, phase.ctx)}
-        onCancel={() => finish({ kind: 'cancelled', reason: 'User cancelled in wizard.' })}
-        onError={(err) => finish({ kind: 'error', error: err })}
-      />
+      <RootFrame dryRun={Boolean(dryRun)}>
+        <InstallWizard
+          manifest={phase.ctx.manifest}
+          schema={phase.ctx.schema}
+          prefillValues={phase.ctx.prefillValues}
+          moduleFileCounts={phase.ctx.moduleFileCounts}
+          alwaysIncludedFileCount={phase.ctx.alwaysIncludedFileCount}
+          onComplete={(result) => handleWizardComplete(result, phase.ctx)}
+          onCancel={() => finish({ kind: 'cancelled', reason: 'User cancelled in wizard.' })}
+          onError={(err) => finish({ kind: 'error', error: err })}
+        />
+      </RootFrame>
     );
   }
 
   if (phase.kind === 'collision') {
-    return <CollisionReview collisions={phase.collisions} onChoice={handleCollisionChoice} />;
+    return (
+      <RootFrame dryRun={Boolean(dryRun)}>
+        <CollisionReview collisions={phase.collisions} onChoice={handleCollisionChoice} />
+      </RootFrame>
+    );
   }
 
   if (phase.kind === 'installing') {
     return (
-      <InstallProgress
-        current={phase.current}
-        total={phase.total}
-        label={phase.label}
-        verbose={verbose}
-        history={phase.history}
-      />
+      <RootFrame dryRun={Boolean(dryRun)} showLegend={false}>
+        <InstallProgress
+          current={phase.current}
+          total={phase.total}
+          label={phase.label}
+          verbose={verbose}
+          history={phase.history}
+        />
+      </RootFrame>
     );
   }
 
   if (phase.kind === 'summary') {
     return (
-      <Summary
-        manifest={phase.manifest}
-        vaultRoot={phase.vaultRoot}
-        fileCount={phase.fileCount}
-        durationMs={phase.durationMs}
-        backups={phase.backups}
-        hookOutput={phase.hook}
-        dryRun={phase.dryRun}
-      />
+      <RootFrame dryRun={Boolean(dryRun)} showLegend={false}>
+        <Summary
+          manifest={phase.manifest}
+          vaultRoot={phase.vaultRoot}
+          fileCount={phase.fileCount}
+          durationMs={phase.durationMs}
+          backups={phase.backups}
+          hookOutput={phase.hook}
+          dryRun={phase.dryRun}
+        />
+      </RootFrame>
     );
   }
 
   if (phase.kind === 'cancelled') {
     return (
-      <Box flexDirection="column">
-        <Alert variant="info">Cancelled</Alert>
-        <Text dimColor>{phase.reason}</Text>
-      </Box>
+      <RootFrame dryRun={Boolean(dryRun)} showLegend={false}>
+        <Box flexDirection="column">
+          <Alert variant="info">Cancelled</Alert>
+          <Text dimColor>{phase.reason}</Text>
+        </Box>
+      </RootFrame>
     );
   }
 
@@ -446,11 +508,44 @@ export default function Install({ args, options }: Props) {
   const code = err instanceof ShardMindError ? err.code : null;
   const hint = err instanceof ShardMindError ? err.hint : null;
   return (
+    <RootFrame dryRun={Boolean(dryRun)} showLegend={false}>
+      <Box flexDirection="column" gap={1}>
+        <StatusMessage variant="error">{err.message}</StatusMessage>
+        {code && <Text dimColor>code: {code}</Text>}
+        {hint && <Text>{hint}</Text>}
+        {phase.detail && <Text dimColor>{phase.detail}</Text>}
+      </Box>
+    </RootFrame>
+  );
+}
+
+function RootFrame({
+  children,
+  dryRun,
+  showLegend = true,
+}: {
+  children: ReactNode;
+  dryRun: boolean;
+  showLegend?: boolean;
+}) {
+  return (
     <Box flexDirection="column" gap={1}>
-      <StatusMessage variant="error">{err.message}</StatusMessage>
-      {code && <Text dimColor>code: {code}</Text>}
-      {hint && <Text>{hint}</Text>}
-      {phase.detail && <Text dimColor>{phase.detail}</Text>}
+      {dryRun && (
+        <Box>
+          <Text backgroundColor="yellow" color="black">
+            {' DRY RUN '}
+          </Text>
+          <Text dimColor> no files will be written</Text>
+        </Box>
+      )}
+      {children}
+      {showLegend && (
+        <Box marginTop={1}>
+          <Text dimColor>
+            ↑↓ navigate · Space select (multi) · Enter confirm · Esc back · Ctrl+C cancel
+          </Text>
+        </Box>
+      )}
     </Box>
   );
 }

--- a/source/commands/install.tsx
+++ b/source/commands/install.tsx
@@ -352,8 +352,24 @@ export default function Install({ args, options }: Props) {
         finish({ kind: 'cancelled', reason: 'User cancelled at collision review.' });
         return;
       }
-      const backups = action === 'backup' ? await backupCollisions(collisions) : [];
-      await executeInstall(ctx, result, backups);
+
+      try {
+        if (action === 'backup') {
+          const backups = await backupCollisions(collisions);
+          await executeInstall(ctx, result, backups);
+          return;
+        }
+        // Overwrite: delete colliding paths (files AND directories) before
+        // install so writeFile doesn't fail with EISDIR when a directory
+        // sits at a planned file path. No backups — user explicitly chose
+        // to discard existing content.
+        for (const collision of collisions) {
+          await fsp.rm(collision.absolutePath, { recursive: true, force: true });
+        }
+        await executeInstall(ctx, result, []);
+      } catch (err) {
+        finish({ kind: 'error', error: err as Error });
+      }
     },
     [phase, finish, executeInstall],
   );

--- a/source/commands/install.tsx
+++ b/source/commands/install.tsx
@@ -200,8 +200,9 @@ export default function Install({ args, options }: Props) {
 
         if (collisions.length > 0) {
           if (yes) {
-            // Non-interactive policy: back up and continue.
-            const backups = await backupCollisions(collisions);
+            // Non-interactive policy: back up and continue — unless dry-run,
+            // which must not touch disk.
+            const backups = dryRun ? [] : await backupCollisions(collisions);
             await executeInstall(ctx, validatedResult, backups);
           } else {
             setPhase({ kind: 'collision', collisions, result: validatedResult, ctx });
@@ -253,6 +254,9 @@ export default function Install({ args, options }: Props) {
               );
             } else if (ev.kind === 'file') {
               if (verbose) history.push(ev.outputPath);
+              // Cap the visible history slice at 5 so we don't copy
+              // an ever-growing array on every file event.
+              const visibleHistory = verbose ? history.slice(-5) : [];
               setPhase((prev) =>
                 prev.kind === 'installing'
                   ? {
@@ -260,7 +264,7 @@ export default function Install({ args, options }: Props) {
                       current: ev.index,
                       total: ev.total,
                       label: ev.label,
-                      history: [...history],
+                      history: visibleHistory,
                     }
                   : prev,
               );
@@ -286,9 +290,13 @@ export default function Install({ args, options }: Props) {
         });
       } catch (err) {
         if (!dryRun) {
-          await rollbackInstall(vaultRoot, written).catch(() => {});
+          await rollbackInstall(vaultRoot, written, backups).catch(() => {});
         }
-        finish({ kind: 'error', error: err as Error, detail: 'Rolled back partial install.' });
+        finish({
+          kind: 'error',
+          error: err as Error,
+          detail: dryRun ? undefined : 'Rolled back partial install (including any pre-install backups).',
+        });
       }
     },
     [vaultRoot, verbose, dryRun, finish],
@@ -323,6 +331,15 @@ export default function Install({ args, options }: Props) {
         return;
       }
       if (choice === 'reinstall') {
+        // --dry-run must never touch disk, and reinstall unavoidably
+        // deletes state. Refuse explicitly rather than silently.
+        if (dryRun) {
+          finish({
+            kind: 'cancelled',
+            reason: 'Reinstall is destructive and cannot run under --dry-run. Drop --dry-run to reinstall.',
+          });
+          return;
+        }
         // Delete existing state + values, then fall through to wizard.
         (async () => {
           try {
@@ -353,7 +370,7 @@ export default function Install({ args, options }: Props) {
         })();
       }
     },
-    [phase, vaultRoot, yes, finish, handleWizardComplete],
+    [phase, vaultRoot, yes, dryRun, finish, handleWizardComplete],
   );
 
   // Render tree per phase.
@@ -380,6 +397,7 @@ export default function Install({ args, options }: Props) {
         moduleFileCounts={phase.ctx.moduleFileCounts}
         onComplete={(result) => handleWizardComplete(result, phase.ctx)}
         onCancel={() => finish({ kind: 'cancelled', reason: 'User cancelled in wizard.' })}
+        onError={(err) => finish({ kind: 'error', error: err })}
       />
     );
   }
@@ -452,7 +470,17 @@ async function loadValuesFile(
     );
   }
 
-  const parsed = parseYaml(raw);
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(raw);
+  } catch (err) {
+    throw new ShardMindError(
+      `--values file is not valid YAML: ${filePath}`,
+      'VALUES_FILE_INVALID',
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw new ShardMindError(
       `--values file must be a YAML mapping: ${filePath}`,

--- a/source/commands/install.tsx
+++ b/source/commands/install.tsx
@@ -95,6 +95,11 @@ export default function Install({ args, options }: Props) {
   const writtenPathsRef = useRef<string[]>([]);
   const backupsRef = useRef<BackupRecord[]>([]);
   const installingRef = useRef(false);
+  // Mutable pointer to the latest handleWizardComplete closure so
+  // runNonInteractive can call it without circular useCallback deps.
+  const handleWizardCompleteRef = useRef<(r: WizardResult, c: PreparedContext) => Promise<void>>(
+    async () => {},
+  );
 
   const finish = useCallback(
     (next: Phase) => {
@@ -126,7 +131,6 @@ export default function Install({ args, options }: Props) {
     };
   }, [dryRun, vaultRoot]);
 
-  // Boot → preparation
   useEffect(() => {
     let disposed = false;
     let ctxForCleanup: PreparedContext | null = null;
@@ -143,12 +147,9 @@ export default function Install({ args, options }: Props) {
         const manifest = await parseManifest(temp.manifest);
         const schema = await parseSchema(temp.schema);
 
-        // Prefill values from --values if given; merge with static defaults.
         const prefill = valuesFile ? await loadValuesFile(valuesFile, schema) : {};
         const merged = mergePrefill(schema, prefill);
 
-        // Precompute module file counts for the wizard preview (requires
-        // scanning the temp directory with current default selections).
         const { moduleFileCounts, alwaysIncludedFileCount } = await planOutputs(
           schema,
           temp.tempDir,
@@ -167,7 +168,6 @@ export default function Install({ args, options }: Props) {
         };
         ctxForCleanup = ctx;
 
-        // Check for existing install.
         const existing = await readState(vaultRoot);
         if (existing) {
           if (disposed) return;
@@ -176,34 +176,16 @@ export default function Install({ args, options }: Props) {
         }
 
         if (disposed) return;
-        await proceedToWizardOrYes(ctx);
+        if (yes) {
+          await runNonInteractive(ctx);
+        } else {
+          setPhase({ kind: 'wizard', ctx });
+        }
       } catch (err) {
         if (disposed) return;
         finish({ kind: 'error', error: err as Error });
       }
     })();
-
-    async function proceedToWizardOrYes(ctx: PreparedContext) {
-      if (yes) {
-        // Non-interactive: resolve computed defaults, use default module selections,
-        // run straight into collision/install phases.
-        const missing = missingValueKeys(ctx.schema, ctx.prefillValues);
-        if (missing.length > 0) {
-          throw new ShardMindError(
-            `Missing required values for --yes: ${missing.join(', ')}`,
-            'VALUES_MISSING',
-            'Provide them via --values <file> or drop --yes to prompt interactively.',
-          );
-        }
-        const validator = buildValuesValidator(ctx.schema);
-        const resolvedValues = resolveComputedDefaults(ctx.schema, ctx.prefillValues);
-        const validated = validator.parse(resolvedValues);
-        const selections = defaultModuleSelections(ctx.schema);
-        await handleWizardComplete({ values: validated, selections }, ctx);
-        return;
-      }
-      setPhase({ kind: 'wizard', ctx });
-    }
 
     return () => {
       disposed = true;
@@ -214,23 +196,41 @@ export default function Install({ args, options }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shardRef, valuesFile, yes]);
 
+  const runNonInteractive = useCallback(
+    async (ctx: PreparedContext) => {
+      const missing = missingValueKeys(ctx.schema, ctx.prefillValues);
+      if (missing.length > 0) {
+        throw new ShardMindError(
+          `Missing required values for --yes: ${missing.join(', ')}`,
+          'VALUES_MISSING',
+          'Provide them via --values <file> or drop --yes to prompt interactively.',
+        );
+      }
+      const validator = buildValuesValidator(ctx.schema);
+      const validated = validator.parse(
+        resolveComputedDefaults(ctx.schema, ctx.prefillValues),
+      ) as Record<string, unknown>;
+      await handleWizardCompleteRef.current(
+        { values: validated, selections: defaultModuleSelections(ctx.schema) },
+        ctx,
+      );
+    },
+    [],
+  );
+
   const handleWizardComplete = useCallback(
     async (result: WizardResult, ctx: PreparedContext) => {
       try {
-        // Validate values against generated zod validator.
         const validator = buildValuesValidator(ctx.schema);
         const validated = validator.parse(result.values) as Record<string, unknown>;
         const validatedResult: WizardResult = { values: validated, selections: result.selections };
 
-        // Enumerate planned outputs under the chosen selections.
         const { outputs } = await planOutputs(ctx.schema, ctx.tempDir, validatedResult.selections);
-        const paths = outputs.map((o) => o.outputPath);
-        const collisions = await detectCollisions(vaultRoot, paths);
+        const collisions = await detectCollisions(vaultRoot, outputs.map((o) => o.outputPath));
 
         if (collisions.length > 0) {
           if (yes) {
-            // Non-interactive policy: back up and continue — unless dry-run,
-            // which must not touch disk.
+            // --yes policy: auto-backup. Dry-run must skip the disk action.
             const backups = dryRun ? [] : await backupCollisions(collisions);
             await executeInstall(ctx, validatedResult, backups);
           } else {
@@ -244,16 +244,20 @@ export default function Install({ args, options }: Props) {
         finish({ kind: 'error', error: err as Error });
       }
     },
-    [yes, vaultRoot, finish],
+    [yes, dryRun, vaultRoot, finish],
   );
+
+  useEffect(() => {
+    handleWizardCompleteRef.current = handleWizardComplete;
+  }, [handleWizardComplete]);
 
   const executeInstall = useCallback(
     async (ctx: PreparedContext, result: WizardResult, backups: BackupRecord[]) => {
       const start = Date.now();
       const history: string[] = [];
 
-      // Register backups with the SIGINT handler before any write starts,
-      // so Ctrl+C between writes still restores them.
+      // Register backups + reset writtenPaths so the SIGINT handler sees
+      // live state from the first byte written.
       backupsRef.current = backups;
       writtenPathsRef.current = [];
       installingRef.current = true;
@@ -286,26 +290,26 @@ export default function Install({ args, options }: Props) {
           onProgress: (ev) => {
             if (ev.kind === 'start') {
               setPhase((prev) =>
-                prev.kind === 'installing'
+                prev.kind === 'installing' && (prev.total !== ev.total || prev.current !== 0)
                   ? { ...prev, total: ev.total, current: 0, label: 'Starting…' }
                   : prev,
               );
             } else if (ev.kind === 'file') {
-              if (verbose) history.push(ev.outputPath);
-              // Cap the visible history slice at 5 so we don't copy
-              // an ever-growing array on every file event.
-              const visibleHistory = verbose ? history.slice(-5) : [];
-              setPhase((prev) =>
-                prev.kind === 'installing'
-                  ? {
-                      ...prev,
-                      current: ev.index,
-                      total: ev.total,
-                      label: ev.label,
-                      history: visibleHistory,
-                    }
-                  : prev,
-              );
+              if (verbose) {
+                history.push(ev.outputPath);
+                if (history.length > 5) history.shift();
+              }
+              setPhase((prev) => {
+                if (prev.kind !== 'installing') return prev;
+                if (prev.current === ev.index && prev.label === ev.label) return prev;
+                return {
+                  ...prev,
+                  current: ev.index,
+                  total: ev.total,
+                  label: ev.label,
+                  history: verbose ? [...history] : prev.history,
+                };
+              });
             }
           },
         });
@@ -316,7 +320,6 @@ export default function Install({ args, options }: Props) {
           : await runPostInstallHook(ctx.tempDir, ctx.manifest);
         const hookSummary = summarizeHook(hookResult);
 
-        // Install completed — SIGINT no longer needs to roll back.
         installingRef.current = false;
 
         finish({
@@ -359,13 +362,11 @@ export default function Install({ args, options }: Props) {
           await executeInstall(ctx, result, backups);
           return;
         }
-        // Overwrite: delete colliding paths (files AND directories) before
-        // install so writeFile doesn't fail with EISDIR when a directory
-        // sits at a planned file path. No backups — user explicitly chose
-        // to discard existing content.
-        for (const collision of collisions) {
-          await fsp.rm(collision.absolutePath, { recursive: true, force: true });
-        }
+        // Overwrite: remove colliding paths so writeFile doesn't hit EISDIR
+        // when a directory sits at a planned file path. User authorized the loss.
+        await Promise.all(
+          collisions.map((c) => fsp.rm(c.absolutePath, { recursive: true, force: true })),
+        );
         await executeInstall(ctx, result, []);
       } catch (err) {
         finish({ kind: 'error', error: err as Error });
@@ -389,8 +390,6 @@ export default function Install({ args, options }: Props) {
         return;
       }
       if (choice === 'reinstall') {
-        // --dry-run must never touch disk, and reinstall unavoidably
-        // deletes state. Refuse explicitly rather than silently.
         if (dryRun) {
           finish({
             kind: 'cancelled',
@@ -398,27 +397,14 @@ export default function Install({ args, options }: Props) {
           });
           return;
         }
-        // Delete existing state + values, then fall through to wizard.
         (async () => {
           try {
-            await fsp.rm(path.join(vaultRoot, '.shardmind'), { recursive: true, force: true });
-            await fsp.rm(path.join(vaultRoot, 'shard-values.yaml'), { force: true });
+            await Promise.all([
+              fsp.rm(path.join(vaultRoot, '.shardmind'), { recursive: true, force: true }),
+              fsp.rm(path.join(vaultRoot, 'shard-values.yaml'), { force: true }),
+            ]);
             if (yes) {
-              const missing = missingValueKeys(phase.ctx.schema, phase.ctx.prefillValues);
-              if (missing.length > 0) {
-                throw new ShardMindError(
-                  `Missing required values for --yes: ${missing.join(', ')}`,
-                  'VALUES_MISSING',
-                  'Provide them via --values <file> or drop --yes to prompt interactively.',
-                );
-              }
-              const validator = buildValuesValidator(phase.ctx.schema);
-              const resolvedValues = resolveComputedDefaults(phase.ctx.schema, phase.ctx.prefillValues);
-              const validated = validator.parse(resolvedValues);
-              await handleWizardComplete(
-                { values: validated, selections: defaultModuleSelections(phase.ctx.schema) },
-                phase.ctx,
-              );
+              await runNonInteractive(phase.ctx);
             } else {
               setPhase({ kind: 'wizard', ctx: phase.ctx });
             }
@@ -428,11 +414,9 @@ export default function Install({ args, options }: Props) {
         })();
       }
     },
-    [phase, vaultRoot, yes, dryRun, finish, handleWizardComplete],
+    [phase, vaultRoot, yes, dryRun, finish, runNonInteractive],
   );
 
-  // Render tree per phase — wrapped in RootFrame so dry-run and the
-  // keyboard legend stay visible across all phases.
   if (phase.kind === 'booting' || phase.kind === 'loading') {
     const msg = phase.kind === 'loading' ? phase.message : 'Starting…';
     return (
@@ -519,7 +503,6 @@ export default function Install({ args, options }: Props) {
     );
   }
 
-  // error
   const err = phase.error;
   const code = err instanceof ShardMindError ? err.code : null;
   const hint = err instanceof ShardMindError ? err.hint : null;
@@ -600,8 +583,8 @@ async function loadValuesFile(
     );
   }
 
-  // Filter to known schema keys only — unknown keys are ignored silently
-  // so the file can be reused across shard versions.
+  // Unknown keys are silently ignored so a values file can be reused
+  // across shard versions that have added or removed entries.
   const filtered: Record<string, unknown> = {};
   for (const key of Object.keys(schema.values)) {
     if (key in (parsed as Record<string, unknown>)) {

--- a/source/commands/install.tsx
+++ b/source/commands/install.tsx
@@ -218,39 +218,6 @@ export default function Install({ args, options }: Props) {
     [],
   );
 
-  const handleWizardComplete = useCallback(
-    async (result: WizardResult, ctx: PreparedContext) => {
-      try {
-        const validator = buildValuesValidator(ctx.schema);
-        const validated = validator.parse(result.values) as Record<string, unknown>;
-        const validatedResult: WizardResult = { values: validated, selections: result.selections };
-
-        const { outputs } = await planOutputs(ctx.schema, ctx.tempDir, validatedResult.selections);
-        const collisions = await detectCollisions(vaultRoot, outputs.map((o) => o.outputPath));
-
-        if (collisions.length > 0) {
-          if (yes) {
-            // --yes policy: auto-backup. Dry-run must skip the disk action.
-            const backups = dryRun ? [] : await backupCollisions(collisions);
-            await executeInstall(ctx, validatedResult, backups);
-          } else {
-            setPhase({ kind: 'collision', collisions, result: validatedResult, ctx });
-          }
-          return;
-        }
-
-        await executeInstall(ctx, validatedResult, []);
-      } catch (err) {
-        finish({ kind: 'error', error: err as Error });
-      }
-    },
-    [yes, dryRun, vaultRoot, finish],
-  );
-
-  useEffect(() => {
-    handleWizardCompleteRef.current = handleWizardComplete;
-  }, [handleWizardComplete]);
-
   const executeInstall = useCallback(
     async (ctx: PreparedContext, result: WizardResult, backups: BackupRecord[]) => {
       const start = Date.now();
@@ -346,6 +313,39 @@ export default function Install({ args, options }: Props) {
     },
     [vaultRoot, verbose, dryRun, finish],
   );
+
+  const handleWizardComplete = useCallback(
+    async (result: WizardResult, ctx: PreparedContext) => {
+      try {
+        const validator = buildValuesValidator(ctx.schema);
+        const validated = validator.parse(result.values) as Record<string, unknown>;
+        const validatedResult: WizardResult = { values: validated, selections: result.selections };
+
+        const { outputs } = await planOutputs(ctx.schema, ctx.tempDir, validatedResult.selections);
+        const collisions = await detectCollisions(vaultRoot, outputs.map((o) => o.outputPath));
+
+        if (collisions.length > 0) {
+          if (yes) {
+            // --yes policy: auto-backup. Dry-run must skip the disk action.
+            const backups = dryRun ? [] : await backupCollisions(collisions);
+            await executeInstall(ctx, validatedResult, backups);
+          } else {
+            setPhase({ kind: 'collision', collisions, result: validatedResult, ctx });
+          }
+          return;
+        }
+
+        await executeInstall(ctx, validatedResult, []);
+      } catch (err) {
+        finish({ kind: 'error', error: err as Error });
+      }
+    },
+    [yes, dryRun, vaultRoot, executeInstall, finish],
+  );
+
+  useEffect(() => {
+    handleWizardCompleteRef.current = handleWizardComplete;
+  }, [handleWizardComplete]);
 
   const handleCollisionChoice = useCallback(
     async (action: CollisionAction) => {

--- a/source/commands/install.tsx
+++ b/source/commands/install.tsx
@@ -1,0 +1,488 @@
+import { useEffect, useState, useCallback } from 'react';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import { Box, Text, useApp } from 'ink';
+import { Spinner, StatusMessage, Alert } from '@inkjs/ui';
+import { parse as parseYaml } from 'yaml';
+import zod from 'zod';
+
+import type { ShardManifest, ShardSchema, ShardState, ResolvedShard } from '../runtime/types.js';
+import { ShardMindError } from '../runtime/types.js';
+
+import { resolve as resolveRef } from '../core/registry.js';
+import { downloadShard } from '../core/download.js';
+import { parseManifest } from '../core/manifest.js';
+import { parseSchema, buildValuesValidator } from '../core/schema.js';
+import { readState } from '../core/state.js';
+import {
+  planOutputs,
+  runInstall,
+  rollbackInstall,
+} from '../core/install-runner.js';
+import {
+  detectCollisions,
+  backupCollisions,
+  mergePrefill,
+  resolveComputedDefaults,
+  missingValueKeys,
+  defaultModuleSelections,
+  type Collision,
+  type BackupRecord,
+} from '../core/install-plan.js';
+import { runPostInstallHook, type HookResult } from '../core/hook.js';
+
+import InstallWizard, { type WizardResult } from '../components/InstallWizard.js';
+import CollisionReview, { type CollisionAction } from '../components/CollisionReview.js';
+import ExistingInstallGate, { type GateChoice } from '../components/ExistingInstallGate.js';
+import InstallProgress from '../components/InstallProgress.js';
+import Summary from '../components/Summary.js';
+
+export const args = zod.tuple([
+  zod.string().describe('Shard reference, e.g. "breferrari/obsidian-mind" or "github:owner/repo"'),
+]);
+
+export const options = zod.object({
+  values: zod.string().optional().describe('Path to a YAML file prefilling value answers'),
+  yes: zod.boolean().default(false).describe('Skip all prompts; accept defaults for everything'),
+  verbose: zod.boolean().default(false).describe('Show per-file rendering progress'),
+  dryRun: zod.boolean().default(false).describe('Preview what would be installed without writing'),
+});
+
+type Props = {
+  args: zod.infer<typeof args>;
+  options: zod.infer<typeof options>;
+};
+
+type Phase =
+  | { kind: 'booting' }
+  | { kind: 'loading'; message: string }
+  | { kind: 'gate'; state: ShardState; ctx: PreparedContext }
+  | { kind: 'wizard'; ctx: PreparedContext }
+  | { kind: 'collision'; collisions: Collision[]; result: WizardResult; ctx: PreparedContext }
+  | { kind: 'installing'; total: number; current: number; label: string; history: string[]; ctx: PreparedContext; result: WizardResult; backups: BackupRecord[] }
+  | { kind: 'summary'; manifest: ShardManifest; vaultRoot: string; fileCount: number; durationMs: number; backups: BackupRecord[]; hook: HookSummary | null; dryRun: boolean }
+  | { kind: 'cancelled'; reason: string }
+  | { kind: 'error'; error: ShardMindError | Error; detail?: string };
+
+interface PreparedContext {
+  resolved: ResolvedShard;
+  manifest: ShardManifest;
+  schema: ShardSchema;
+  tempDir: string;
+  cleanup: () => Promise<void>;
+  prefillValues: Record<string, unknown>;
+  moduleFileCounts: Record<string, number>;
+}
+
+interface HookSummary {
+  deferred?: boolean;
+  stdout?: string;
+  exitCode?: number;
+}
+
+export default function Install({ args, options }: Props) {
+  const [shardRef] = args;
+  const { values: valuesFile, yes, verbose, dryRun } = options;
+  const vaultRoot = process.cwd();
+  const { exit } = useApp();
+
+  const [phase, setPhase] = useState<Phase>({ kind: 'booting' });
+
+  const finish = useCallback(
+    (next: Phase) => {
+      setPhase(next);
+      if (next.kind === 'summary' || next.kind === 'cancelled' || next.kind === 'error') {
+        setTimeout(() => exit(), 100);
+      }
+    },
+    [exit],
+  );
+
+  // Boot → preparation
+  useEffect(() => {
+    let disposed = false;
+    let ctxForCleanup: PreparedContext | null = null;
+
+    (async () => {
+      try {
+        setPhase({ kind: 'loading', message: `Resolving ${shardRef}…` });
+        const resolved = await resolveRef(shardRef!);
+
+        setPhase({ kind: 'loading', message: `Downloading ${resolved.namespace}/${resolved.name}@${resolved.version}…` });
+        const temp = await downloadShard(resolved.tarballUrl);
+
+        setPhase({ kind: 'loading', message: 'Parsing manifest and schema…' });
+        const manifest = await parseManifest(temp.manifest);
+        const schema = await parseSchema(temp.schema);
+
+        // Prefill values from --values if given; merge with static defaults.
+        const prefill = valuesFile ? await loadValuesFile(valuesFile, schema) : {};
+        const merged = mergePrefill(schema, prefill);
+
+        // Precompute module file counts for the wizard preview (requires
+        // scanning the temp directory with current default selections).
+        const { moduleFileCounts } = await planOutputs(
+          schema,
+          temp.tempDir,
+          defaultModuleSelections(schema),
+        );
+
+        const ctx: PreparedContext = {
+          resolved,
+          manifest,
+          schema,
+          tempDir: temp.tempDir,
+          cleanup: temp.cleanup,
+          prefillValues: merged,
+          moduleFileCounts,
+        };
+        ctxForCleanup = ctx;
+
+        // Check for existing install.
+        const existing = await readState(vaultRoot);
+        if (existing) {
+          if (disposed) return;
+          setPhase({ kind: 'gate', state: existing, ctx });
+          return;
+        }
+
+        if (disposed) return;
+        await proceedToWizardOrYes(ctx);
+      } catch (err) {
+        if (disposed) return;
+        finish({ kind: 'error', error: err as Error });
+      }
+    })();
+
+    async function proceedToWizardOrYes(ctx: PreparedContext) {
+      if (yes) {
+        // Non-interactive: resolve computed defaults, use default module selections,
+        // run straight into collision/install phases.
+        const missing = missingValueKeys(ctx.schema, ctx.prefillValues);
+        if (missing.length > 0) {
+          throw new ShardMindError(
+            `Missing required values for --yes: ${missing.join(', ')}`,
+            'VALUES_MISSING',
+            'Provide them via --values <file> or drop --yes to prompt interactively.',
+          );
+        }
+        const validator = buildValuesValidator(ctx.schema);
+        const resolvedValues = resolveComputedDefaults(ctx.schema, ctx.prefillValues);
+        const validated = validator.parse(resolvedValues);
+        const selections = defaultModuleSelections(ctx.schema);
+        await handleWizardComplete({ values: validated, selections }, ctx);
+        return;
+      }
+      setPhase({ kind: 'wizard', ctx });
+    }
+
+    return () => {
+      disposed = true;
+      if (ctxForCleanup) {
+        ctxForCleanup.cleanup().catch(() => {});
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shardRef, valuesFile, yes]);
+
+  const handleWizardComplete = useCallback(
+    async (result: WizardResult, ctx: PreparedContext) => {
+      try {
+        // Validate values against generated zod validator.
+        const validator = buildValuesValidator(ctx.schema);
+        const validated = validator.parse(result.values) as Record<string, unknown>;
+        const validatedResult: WizardResult = { values: validated, selections: result.selections };
+
+        // Enumerate planned outputs under the chosen selections.
+        const { outputs } = await planOutputs(ctx.schema, ctx.tempDir, validatedResult.selections);
+        const paths = outputs.map((o) => o.outputPath);
+        const collisions = await detectCollisions(vaultRoot, paths);
+
+        if (collisions.length > 0) {
+          if (yes) {
+            // Non-interactive policy: back up and continue.
+            const backups = await backupCollisions(collisions);
+            await executeInstall(ctx, validatedResult, backups);
+          } else {
+            setPhase({ kind: 'collision', collisions, result: validatedResult, ctx });
+          }
+          return;
+        }
+
+        await executeInstall(ctx, validatedResult, []);
+      } catch (err) {
+        finish({ kind: 'error', error: err as Error });
+      }
+    },
+    [yes, vaultRoot, finish],
+  );
+
+  const executeInstall = useCallback(
+    async (ctx: PreparedContext, result: WizardResult, backups: BackupRecord[]) => {
+      const start = Date.now();
+      const history: string[] = [];
+
+      setPhase({
+        kind: 'installing',
+        total: 0,
+        current: 0,
+        label: 'Preparing…',
+        history,
+        ctx,
+        result,
+        backups,
+      });
+
+      let written: string[] = [];
+      try {
+        const runResult = await runInstall({
+          vaultRoot,
+          manifest: ctx.manifest,
+          schema: ctx.schema,
+          tempDir: ctx.tempDir,
+          resolved: ctx.resolved,
+          values: result.values,
+          selections: result.selections,
+          dryRun,
+          onProgress: (ev) => {
+            if (ev.kind === 'start') {
+              setPhase((prev) =>
+                prev.kind === 'installing'
+                  ? { ...prev, total: ev.total, current: 0, label: 'Starting…' }
+                  : prev,
+              );
+            } else if (ev.kind === 'file') {
+              if (verbose) history.push(ev.outputPath);
+              setPhase((prev) =>
+                prev.kind === 'installing'
+                  ? {
+                      ...prev,
+                      current: ev.index,
+                      total: ev.total,
+                      label: ev.label,
+                      history: [...history],
+                    }
+                  : prev,
+              );
+            }
+          },
+        });
+        written = runResult.writtenPaths;
+
+        const hookResult = dryRun
+          ? { kind: 'absent' as const }
+          : await runPostInstallHook(ctx.tempDir, ctx.manifest);
+        const hookSummary = summarizeHook(hookResult);
+
+        finish({
+          kind: 'summary',
+          manifest: ctx.manifest,
+          vaultRoot,
+          fileCount: runResult.fileCount,
+          durationMs: Date.now() - start,
+          backups,
+          hook: hookSummary,
+          dryRun: Boolean(dryRun),
+        });
+      } catch (err) {
+        if (!dryRun) {
+          await rollbackInstall(vaultRoot, written).catch(() => {});
+        }
+        finish({ kind: 'error', error: err as Error, detail: 'Rolled back partial install.' });
+      }
+    },
+    [vaultRoot, verbose, dryRun, finish],
+  );
+
+  const handleCollisionChoice = useCallback(
+    async (action: CollisionAction) => {
+      if (phase.kind !== 'collision') return;
+      const { collisions, result, ctx } = phase;
+      if (action === 'cancel') {
+        finish({ kind: 'cancelled', reason: 'User cancelled at collision review.' });
+        return;
+      }
+      const backups = action === 'backup' ? await backupCollisions(collisions) : [];
+      await executeInstall(ctx, result, backups);
+    },
+    [phase, finish, executeInstall],
+  );
+
+  const handleGateChoice = useCallback(
+    (choice: GateChoice) => {
+      if (phase.kind !== 'gate') return;
+      if (choice === 'cancel') {
+        finish({ kind: 'cancelled', reason: 'User cancelled at existing-install gate.' });
+        return;
+      }
+      if (choice === 'update') {
+        finish({
+          kind: 'cancelled',
+          reason: 'Run `shardmind update` instead. (Install declined.)',
+        });
+        return;
+      }
+      if (choice === 'reinstall') {
+        // Delete existing state + values, then fall through to wizard.
+        (async () => {
+          try {
+            await fsp.rm(path.join(vaultRoot, '.shardmind'), { recursive: true, force: true });
+            await fsp.rm(path.join(vaultRoot, 'shard-values.yaml'), { force: true });
+            if (yes) {
+              const missing = missingValueKeys(phase.ctx.schema, phase.ctx.prefillValues);
+              if (missing.length > 0) {
+                throw new ShardMindError(
+                  `Missing required values for --yes: ${missing.join(', ')}`,
+                  'VALUES_MISSING',
+                  'Provide them via --values <file> or drop --yes to prompt interactively.',
+                );
+              }
+              const validator = buildValuesValidator(phase.ctx.schema);
+              const resolvedValues = resolveComputedDefaults(phase.ctx.schema, phase.ctx.prefillValues);
+              const validated = validator.parse(resolvedValues);
+              await handleWizardComplete(
+                { values: validated, selections: defaultModuleSelections(phase.ctx.schema) },
+                phase.ctx,
+              );
+            } else {
+              setPhase({ kind: 'wizard', ctx: phase.ctx });
+            }
+          } catch (err) {
+            finish({ kind: 'error', error: err as Error });
+          }
+        })();
+      }
+    },
+    [phase, vaultRoot, yes, finish, handleWizardComplete],
+  );
+
+  // Render tree per phase.
+  if (phase.kind === 'booting' || phase.kind === 'loading') {
+    const msg = phase.kind === 'loading' ? phase.message : 'Starting…';
+    return (
+      <Box gap={1}>
+        <Spinner />
+        <Text>{msg}</Text>
+      </Box>
+    );
+  }
+
+  if (phase.kind === 'gate') {
+    return <ExistingInstallGate state={phase.state} onChoice={handleGateChoice} />;
+  }
+
+  if (phase.kind === 'wizard') {
+    return (
+      <InstallWizard
+        manifest={phase.ctx.manifest}
+        schema={phase.ctx.schema}
+        prefillValues={phase.ctx.prefillValues}
+        moduleFileCounts={phase.ctx.moduleFileCounts}
+        onComplete={(result) => handleWizardComplete(result, phase.ctx)}
+        onCancel={() => finish({ kind: 'cancelled', reason: 'User cancelled in wizard.' })}
+      />
+    );
+  }
+
+  if (phase.kind === 'collision') {
+    return <CollisionReview collisions={phase.collisions} onChoice={handleCollisionChoice} />;
+  }
+
+  if (phase.kind === 'installing') {
+    return (
+      <InstallProgress
+        current={phase.current}
+        total={phase.total}
+        label={phase.label}
+        verbose={verbose}
+        history={phase.history}
+      />
+    );
+  }
+
+  if (phase.kind === 'summary') {
+    return (
+      <Summary
+        manifest={phase.manifest}
+        vaultRoot={phase.vaultRoot}
+        fileCount={phase.fileCount}
+        durationMs={phase.durationMs}
+        backups={phase.backups}
+        hookOutput={phase.hook}
+        dryRun={phase.dryRun}
+      />
+    );
+  }
+
+  if (phase.kind === 'cancelled') {
+    return (
+      <Box flexDirection="column">
+        <Alert variant="info">Cancelled</Alert>
+        <Text dimColor>{phase.reason}</Text>
+      </Box>
+    );
+  }
+
+  // error
+  const err = phase.error;
+  const code = err instanceof ShardMindError ? err.code : null;
+  const hint = err instanceof ShardMindError ? err.hint : null;
+  return (
+    <Box flexDirection="column" gap={1}>
+      <StatusMessage variant="error">{err.message}</StatusMessage>
+      {code && <Text dimColor>code: {code}</Text>}
+      {hint && <Text>{hint}</Text>}
+      {phase.detail && <Text dimColor>{phase.detail}</Text>}
+    </Box>
+  );
+}
+
+async function loadValuesFile(
+  filePath: string,
+  schema: ShardSchema,
+): Promise<Record<string, unknown>> {
+  let raw: string;
+  try {
+    raw = await fsp.readFile(filePath, 'utf-8');
+  } catch (err) {
+    throw new ShardMindError(
+      `Could not read --values file: ${filePath}`,
+      'VALUES_FILE_READ_FAILED',
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  const parsed = parseYaml(raw);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new ShardMindError(
+      `--values file must be a YAML mapping: ${filePath}`,
+      'VALUES_FILE_INVALID',
+      'Top level must be { key: value } entries matching shard schema value IDs.',
+    );
+  }
+
+  // Filter to known schema keys only — unknown keys are ignored silently
+  // so the file can be reused across shard versions.
+  const filtered: Record<string, unknown> = {};
+  for (const key of Object.keys(schema.values)) {
+    if (key in (parsed as Record<string, unknown>)) {
+      filtered[key] = (parsed as Record<string, unknown>)[key];
+    }
+  }
+  return filtered;
+}
+
+function summarizeHook(result: HookResult): HookSummary | null {
+  switch (result.kind) {
+    case 'absent':
+      return null;
+    case 'deferred':
+      return { deferred: true };
+    case 'ran':
+      return { stdout: result.stdout, exitCode: result.exitCode };
+    case 'failed':
+      return { stdout: result.message, exitCode: 1 };
+  }
+}
+
+export const description = 'Install a shard into the current directory';

--- a/source/components/CollisionReview.tsx
+++ b/source/components/CollisionReview.tsx
@@ -1,0 +1,70 @@
+import { Box, Text } from 'ink';
+import { Select, Alert } from '@inkjs/ui';
+import type { Collision } from '../core/install-plan.js';
+
+export type CollisionAction = 'backup' | 'overwrite' | 'cancel';
+
+interface CollisionReviewProps {
+  collisions: Collision[];
+  onChoice: (action: CollisionAction) => void;
+}
+
+export default function CollisionReview({ collisions, onChoice }: CollisionReviewProps) {
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Alert variant="warning">
+        {collisions.length} existing file{collisions.length === 1 ? '' : 's'} will be affected
+      </Alert>
+
+      <Box flexDirection="column">
+        {collisions.slice(0, 15).map((c) => (
+          <Text key={c.absolutePath}>
+            <Text>· {c.outputPath}</Text>
+            <Text dimColor>  ({formatSize(c.size)}, modified {formatMtime(c.mtime)})</Text>
+          </Text>
+        ))}
+        {collisions.length > 15 && (
+          <Text dimColor>  …and {collisions.length - 15} more</Text>
+        )}
+      </Box>
+
+      <Box flexDirection="column">
+        <Text bold>How should I handle these?</Text>
+        <Select
+          options={[
+            {
+              label: 'Back up existing files and install (safest)',
+              value: 'backup',
+            },
+            {
+              label: 'Overwrite — existing content is lost',
+              value: 'overwrite',
+            },
+            {
+              label: 'Cancel',
+              value: 'cancel',
+            },
+          ]}
+          onChange={(v) => onChoice(v as CollisionAction)}
+        />
+      </Box>
+    </Box>
+  );
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)}MB`;
+}
+
+function formatMtime(date: Date): string {
+  const now = Date.now();
+  const diffMs = now - date.getTime();
+  const diffMin = Math.round(diffMs / 60000);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.round(diffMin / 60);
+  if (diffHr < 48) return `${diffHr}h ago`;
+  const diffDays = Math.round(diffHr / 24);
+  return `${diffDays}d ago`;
+}

--- a/source/components/CollisionReview.tsx
+++ b/source/components/CollisionReview.tsx
@@ -10,17 +10,23 @@ interface CollisionReviewProps {
 }
 
 export default function CollisionReview({ collisions, onChoice }: CollisionReviewProps) {
+  const fileCount = collisions.filter((c) => c.kind === 'file').length;
+  const dirCount = collisions.length - fileCount;
+
   return (
     <Box flexDirection="column" gap={1}>
       <Alert variant="warning">
-        {collisions.length} existing file{collisions.length === 1 ? '' : 's'} will be affected
+        {collisions.length} existing path{collisions.length === 1 ? '' : 's'} will be affected
+        {dirCount > 0 && ` (${fileCount} file${fileCount === 1 ? '' : 's'}, ${dirCount} director${dirCount === 1 ? 'y' : 'ies'})`}
       </Alert>
 
       <Box flexDirection="column">
         {collisions.slice(0, 15).map((c) => (
           <Text key={c.absolutePath}>
             <Text>· {c.outputPath}</Text>
-            <Text dimColor>  ({formatSize(c.size)}, modified {formatMtime(c.mtime)})</Text>
+            <Text dimColor>
+              {'  '}[{c.kind}]{c.kind === 'file' ? ` ${formatSize(c.size)},` : ''} modified {formatMtime(c.mtime)}
+            </Text>
           </Text>
         ))}
         {collisions.length > 15 && (
@@ -33,11 +39,14 @@ export default function CollisionReview({ collisions, onChoice }: CollisionRevie
         <Select
           options={[
             {
-              label: 'Back up existing files and install (safest)',
+              label: 'Back up (rename with timestamp) and install — safest',
               value: 'backup',
             },
             {
-              label: 'Overwrite — existing content is lost',
+              label:
+                dirCount > 0
+                  ? 'Overwrite — existing files AND directories will be deleted first'
+                  : 'Overwrite — existing content is lost',
               value: 'overwrite',
             },
             {

--- a/source/components/ExistingInstallGate.tsx
+++ b/source/components/ExistingInstallGate.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react';
+import { Box, Text } from 'ink';
+import { Select, TextInput, Alert, StatusMessage } from '@inkjs/ui';
+import type { ShardState } from '../runtime/types.js';
+
+export type GateChoice = 'update' | 'reinstall' | 'cancel';
+
+interface ExistingInstallGateProps {
+  state: ShardState;
+  onChoice: (choice: GateChoice) => void;
+}
+
+type Screen = 'choose' | 'confirm-reinstall';
+
+export default function ExistingInstallGate({ state, onChoice }: ExistingInstallGateProps) {
+  const [screen, setScreen] = useState<Screen>('choose');
+  const [confirmText, setConfirmText] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  if (screen === 'confirm-reinstall') {
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Alert variant="error">Reinstall will destroy your values and cached state</Alert>
+        <Box flexDirection="column">
+          <Text>This will permanently remove:</Text>
+          <Text>  · .shardmind/ (engine state, cached templates, shard manifest)</Text>
+          <Text>  · shard-values.yaml (your answered values — there is no backup)</Text>
+          <Text dimColor>Rendered notes in your vault are not deleted, but may be overwritten on the new install.</Text>
+        </Box>
+        <Box flexDirection="column">
+          <Text bold>Type REINSTALL to proceed:</Text>
+          <TextInput
+            placeholder="REINSTALL"
+            onChange={(v) => {
+              setConfirmText(v);
+              if (error) setError(null);
+            }}
+            onSubmit={(v) => {
+              if (v === 'REINSTALL') {
+                onChoice('reinstall');
+              } else {
+                setError('Exact text required. Press Esc or Ctrl+C to cancel.');
+              }
+            }}
+          />
+          {error && <StatusMessage variant="error">{error}</StatusMessage>}
+          <Text dimColor>Current input: {confirmText || '(empty)'}</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Alert variant="info">
+        This vault already has a shard installed
+      </Alert>
+
+      <Box flexDirection="column">
+        <Text>
+          <Text bold>Shard:</Text> {state.shard}
+          <Text dimColor> @ {state.version}</Text>
+        </Text>
+        <Text>
+          <Text bold>Installed:</Text>
+          <Text dimColor> {formatDate(state.installed_at)}</Text>
+        </Text>
+        <Text>
+          <Text bold>Modules:</Text>
+          <Text dimColor> {summarizeModules(state.modules)}</Text>
+        </Text>
+      </Box>
+
+      <Box flexDirection="column">
+        <Text bold>What would you like to do?</Text>
+        <Select
+          options={[
+            { label: 'Run shardmind update instead (recommended)', value: 'update' },
+            { label: 'Reinstall from scratch — destructive', value: 'reinstall' },
+            { label: 'Cancel', value: 'cancel' },
+          ]}
+          onChange={(v) => {
+            const choice = v as GateChoice;
+            if (choice === 'reinstall') {
+              setScreen('confirm-reinstall');
+            } else {
+              onChoice(choice);
+            }
+          }}
+        />
+      </Box>
+    </Box>
+  );
+}
+
+function formatDate(iso: string): string {
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return d.toISOString().slice(0, 16).replace('T', ' ') + ' UTC';
+  } catch {
+    return iso;
+  }
+}
+
+function summarizeModules(modules: Record<string, 'included' | 'excluded'>): string {
+  const entries = Object.entries(modules);
+  const included = entries.filter(([, s]) => s === 'included').length;
+  return `${included} of ${entries.length} included`;
+}

--- a/source/components/ExistingInstallGate.tsx
+++ b/source/components/ExistingInstallGate.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Box, Text } from 'ink';
 import { Select, TextInput, Alert, StatusMessage } from '@inkjs/ui';
-import type { ShardState } from '../runtime/types.js';
+import type { ShardState, ModuleSelections } from '../runtime/types.js';
 
 export type GateChoice = 'update' | 'reinstall' | 'cancel';
 
@@ -100,7 +100,7 @@ function formatDate(iso: string): string {
   }
 }
 
-function summarizeModules(modules: Record<string, 'included' | 'excluded'>): string {
+function summarizeModules(modules: ModuleSelections): string {
   const entries = Object.entries(modules);
   const included = entries.filter(([, s]) => s === 'included').length;
   return `${included} of ${entries.length} included`;

--- a/source/components/ExistingInstallGate.tsx
+++ b/source/components/ExistingInstallGate.tsx
@@ -14,7 +14,6 @@ type Screen = 'choose' | 'confirm-reinstall';
 
 export default function ExistingInstallGate({ state, onChoice }: ExistingInstallGateProps) {
   const [screen, setScreen] = useState<Screen>('choose');
-  const [confirmText, setConfirmText] = useState('');
   const [error, setError] = useState<string | null>(null);
 
   if (screen === 'confirm-reinstall') {
@@ -31,12 +30,11 @@ export default function ExistingInstallGate({ state, onChoice }: ExistingInstall
           <Text bold>Type REINSTALL to proceed:</Text>
           <TextInput
             placeholder="REINSTALL"
-            onChange={(v) => {
-              setConfirmText(v);
+            onChange={() => {
               if (error) setError(null);
             }}
             onSubmit={(v) => {
-              if (v === 'REINSTALL') {
+              if (v.trim() === 'REINSTALL') {
                 onChoice('reinstall');
               } else {
                 setError('Exact text required. Press Esc or Ctrl+C to cancel.');
@@ -44,7 +42,6 @@ export default function ExistingInstallGate({ state, onChoice }: ExistingInstall
             }}
           />
           {error && <StatusMessage variant="error">{error}</StatusMessage>}
-          <Text dimColor>Current input: {confirmText || '(empty)'}</Text>
         </Box>
       </Box>
     );
@@ -75,7 +72,7 @@ export default function ExistingInstallGate({ state, onChoice }: ExistingInstall
         <Text bold>What would you like to do?</Text>
         <Select
           options={[
-            { label: 'Run shardmind update instead (recommended)', value: 'update' },
+            { label: 'Keep the existing install (recommended — `shardmind update` arrives in Milestone 4)', value: 'update' },
             { label: 'Reinstall from scratch — destructive', value: 'reinstall' },
             { label: 'Cancel', value: 'cancel' },
           ]}

--- a/source/components/Header.tsx
+++ b/source/components/Header.tsx
@@ -1,0 +1,33 @@
+import { Box, Text } from 'ink';
+import { Badge } from '@inkjs/ui';
+import type { ShardManifest } from '../runtime/types.js';
+
+interface HeaderProps {
+  manifest: ShardManifest;
+}
+
+export default function Header({ manifest }: HeaderProps) {
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Box gap={1}>
+        <Text bold color="cyan">
+          {manifest.namespace}/{manifest.name}
+        </Text>
+        <Badge color="blue">v{manifest.version}</Badge>
+      </Box>
+      {manifest.description && (
+        <Box marginTop={1}>
+          <Text dimColor>{manifest.description}</Text>
+        </Box>
+      )}
+      {manifest.persona && (
+        <Box marginTop={1}>
+          <Text>
+            <Text dimColor>for </Text>
+            <Text italic>{manifest.persona}</Text>
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/source/components/InstallProgress.tsx
+++ b/source/components/InstallProgress.tsx
@@ -30,7 +30,7 @@ export default function InstallProgress({
       <ProgressBar value={percent} />
       {verbose && history && history.length > 0 && (
         <Box flexDirection="column">
-          {history.slice(-5).map((line, i) => (
+          {history.map((line, i) => (
             <Text key={`${i}-${line}`} dimColor>
               · {line}
             </Text>

--- a/source/components/InstallProgress.tsx
+++ b/source/components/InstallProgress.tsx
@@ -1,0 +1,42 @@
+import { Box, Text } from 'ink';
+import { ProgressBar, Spinner } from '@inkjs/ui';
+
+interface InstallProgressProps {
+  current: number;
+  total: number;
+  label: string;
+  verbose?: boolean;
+  history?: string[];
+}
+
+export default function InstallProgress({
+  current,
+  total,
+  label,
+  verbose,
+  history,
+}: InstallProgressProps) {
+  const percent = total === 0 ? 0 : Math.min(100, Math.round((current / total) * 100));
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Box gap={1}>
+        <Spinner />
+        <Text>
+          <Text dimColor>[{current}/{total}]</Text>
+          <Text> {label}</Text>
+        </Text>
+      </Box>
+      <ProgressBar value={percent} />
+      {verbose && history && history.length > 0 && (
+        <Box flexDirection="column">
+          {history.slice(-5).map((line, i) => (
+            <Text key={`${i}-${line}`} dimColor>
+              · {line}
+            </Text>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/source/components/InstallWizard.tsx
+++ b/source/components/InstallWizard.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { Select } from '@inkjs/ui';
-import type { ShardManifest, ShardSchema, ValueDefinition } from '../runtime/types.js';
+import type { ShardManifest, ShardSchema, ValueDefinition, ModuleSelections } from '../runtime/types.js';
 import Header from './Header.js';
 import ValueInput from './ValueInput.js';
 import ModuleReview from './ModuleReview.js';
@@ -14,7 +14,7 @@ import { isComputedDefault } from '../core/schema.js';
 
 export interface WizardResult {
   values: Record<string, unknown>;
-  selections: Record<string, 'included' | 'excluded'>;
+  selections: ModuleSelections;
 }
 
 interface InstallWizardProps {
@@ -57,7 +57,7 @@ export default function InstallWizard({
     return { kind: 'modules' };
   });
   const [values, setValues] = useState<Record<string, unknown>>(prefillValues);
-  const [selections, setSelections] = useState<Record<string, 'included' | 'excluded'>>(
+  const [selections, setSelections] = useState<ModuleSelections>(
     () => defaultModuleSelections(schema),
   );
   const [resolvedValues, setResolvedValues] = useState<Record<string, unknown>>(prefillValues);
@@ -95,7 +95,7 @@ export default function InstallWizard({
           if (valueKeys.length === 0) return { kind: 'header' };
           return { kind: 'value', index: valueKeys.length - 1 };
         case 'modules':
-          if (hasComputedDefaults(schema)) return { kind: 'computed-preview' };
+          if (hasComputed) return { kind: 'computed-preview' };
           if (valueKeys.length === 0) return { kind: 'header' };
           return { kind: 'value', index: valueKeys.length - 1 };
         case 'confirm':
@@ -108,7 +108,6 @@ export default function InstallWizard({
     const nextValues = { ...values, [key]: value };
     setValues(nextValues);
 
-    // Not the last value? advance within the value screens.
     const currentIndex = step.kind === 'value' ? step.index : -1;
     if (currentIndex === -1) return;
     if (currentIndex + 1 < valueKeys.length) {
@@ -116,7 +115,6 @@ export default function InstallWizard({
       return;
     }
 
-    // Last value → resolve computed defaults, then advance.
     try {
       const resolved = resolveComputedDefaults(schema, nextValues);
       setResolvedValues(resolved);
@@ -126,7 +124,7 @@ export default function InstallWizard({
     }
   }
 
-  function submitSelections(next: Record<string, 'included' | 'excluded'>) {
+  function submitSelections(next: ModuleSelections) {
     setSelections(next);
     setStep({ kind: 'confirm' });
   }
@@ -287,7 +285,7 @@ function ConfirmStep({
 }: {
   manifest: ShardManifest;
   values: Record<string, unknown>;
-  selections: Record<string, 'included' | 'excluded'>;
+  selections: ModuleSelections;
   schemaValues: Record<string, ValueDefinition>;
   onChoice: (c: 'install' | 'back' | 'cancel') => void;
 }) {

--- a/source/components/InstallWizard.tsx
+++ b/source/components/InstallWizard.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { Select } from '@inkjs/ui';
 import type { ShardManifest, ShardSchema, ValueDefinition } from '../runtime/types.js';
@@ -22,6 +22,7 @@ interface InstallWizardProps {
   schema: ShardSchema;
   prefillValues: Record<string, unknown>;
   moduleFileCounts: Record<string, number>;
+  alwaysIncludedFileCount: number;
   onComplete: (result: WizardResult) => void;
   onCancel: () => void;
   onError: (err: Error) => void;
@@ -39,6 +40,7 @@ export default function InstallWizard({
   schema,
   prefillValues,
   moduleFileCounts,
+  alwaysIncludedFileCount,
   onComplete,
   onCancel,
   onError,
@@ -58,20 +60,22 @@ export default function InstallWizard({
   const [selections, setSelections] = useState<Record<string, 'included' | 'excluded'>>(
     () => defaultModuleSelections(schema),
   );
-  const [resolvedValues, setResolvedValues] = useState<Record<string, unknown>>(() => {
-    // If we're opening straight into computed-preview we need the resolved
-    // values for that screen. Failures here surface immediately to the caller.
+  const [resolvedValues, setResolvedValues] = useState<Record<string, unknown>>(prefillValues);
+
+  // If we're opening directly into computed-preview, resolve on mount.
+  // Using an effect keeps the useState initializer pure (no side effect)
+  // and avoids React 18 strict-mode double-fire of onError.
+  useEffect(() => {
     if (valueKeys.length === 0 && hasComputed) {
       try {
-        return resolveComputedDefaults(schema, prefillValues);
+        setResolvedValues(resolveComputedDefaults(schema, prefillValues));
       } catch (err) {
-        // Defer the onError call to a microtask so we don't call it during render.
-        queueMicrotask(() => onError(err as Error));
-        return prefillValues;
+        onError(err as Error);
       }
     }
-    return prefillValues;
-  });
+    // Mount-only — schema/prefill don't change within a wizard session.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useInput((_input, key) => {
     if (key.escape) {
@@ -196,6 +200,7 @@ export default function InstallWizard({
         <ModuleReview
           modules={schema.modules}
           moduleFileCounts={moduleFileCounts}
+          alwaysIncludedFileCount={alwaysIncludedFileCount}
           initialSelections={selections}
           onSubmit={submitSelections}
         />
@@ -210,8 +215,6 @@ export default function InstallWizard({
           onChoice={submitConfirm}
         />
       )}
-
-      <KeyboardLegend />
     </Box>
   );
 }
@@ -329,16 +332,6 @@ function ConfirmStep({
         ]}
         onChange={(v) => onChoice(v as 'install' | 'back' | 'cancel')}
       />
-    </Box>
-  );
-}
-
-function KeyboardLegend() {
-  return (
-    <Box marginTop={1}>
-      <Text dimColor>
-        ↑↓ navigate · Space select (multi) · Enter confirm · Esc back · Ctrl+C cancel
-      </Text>
     </Box>
   );
 }

--- a/source/components/InstallWizard.tsx
+++ b/source/components/InstallWizard.tsx
@@ -24,6 +24,7 @@ interface InstallWizardProps {
   moduleFileCounts: Record<string, number>;
   onComplete: (result: WizardResult) => void;
   onCancel: () => void;
+  onError: (err: Error) => void;
 }
 
 type Step =
@@ -40,20 +41,37 @@ export default function InstallWizard({
   moduleFileCounts,
   onComplete,
   onCancel,
+  onError,
 }: InstallWizardProps) {
   const valueKeys = useMemo(
     () => missingValueKeys(schema, prefillValues),
     [schema, prefillValues],
   );
+  const hasComputed = useMemo(() => hasComputedDefaults(schema), [schema]);
 
-  const [step, setStep] = useState<Step>(() =>
-    valueKeys.length > 0 ? { kind: 'header' } : { kind: 'modules' },
-  );
+  const [step, setStep] = useState<Step>(() => {
+    if (valueKeys.length > 0) return { kind: 'header' };
+    if (hasComputed) return { kind: 'computed-preview' };
+    return { kind: 'modules' };
+  });
   const [values, setValues] = useState<Record<string, unknown>>(prefillValues);
   const [selections, setSelections] = useState<Record<string, 'included' | 'excluded'>>(
     () => defaultModuleSelections(schema),
   );
-  const [resolvedValues, setResolvedValues] = useState<Record<string, unknown>>(prefillValues);
+  const [resolvedValues, setResolvedValues] = useState<Record<string, unknown>>(() => {
+    // If we're opening straight into computed-preview we need the resolved
+    // values for that screen. Failures here surface immediately to the caller.
+    if (valueKeys.length === 0 && hasComputed) {
+      try {
+        return resolveComputedDefaults(schema, prefillValues);
+      } catch (err) {
+        // Defer the onError call to a microtask so we don't call it during render.
+        queueMicrotask(() => onError(err as Error));
+        return prefillValues;
+      }
+    }
+    return prefillValues;
+  });
 
   useInput((_input, key) => {
     if (key.escape) {
@@ -85,23 +103,23 @@ export default function InstallWizard({
   function submitValue(key: string, value: unknown) {
     const nextValues = { ...values, [key]: value };
     setValues(nextValues);
-    setStep((s) => {
-      if (s.kind !== 'value') return s;
-      if (s.index + 1 < valueKeys.length) {
-        return { kind: 'value', index: s.index + 1 };
-      }
-      // All values collected → resolve computed + advance
-      try {
-        const resolved = resolveComputedDefaults(schema, nextValues);
-        setResolvedValues(resolved);
-        if (hasComputedDefaults(schema)) return { kind: 'computed-preview' };
-      } catch {
-        // Fall through — computed-preview will re-throw on render and
-        // the wizard caller sees the error.
-        setResolvedValues(nextValues);
-      }
-      return { kind: 'modules' };
-    });
+
+    // Not the last value? advance within the value screens.
+    const currentIndex = step.kind === 'value' ? step.index : -1;
+    if (currentIndex === -1) return;
+    if (currentIndex + 1 < valueKeys.length) {
+      setStep({ kind: 'value', index: currentIndex + 1 });
+      return;
+    }
+
+    // Last value → resolve computed defaults, then advance.
+    try {
+      const resolved = resolveComputedDefaults(schema, nextValues);
+      setResolvedValues(resolved);
+      setStep(hasComputed ? { kind: 'computed-preview' } : { kind: 'modules' });
+    } catch (err) {
+      onError(err as Error);
+    }
   }
 
   function submitSelections(next: Record<string, 'included' | 'excluded'>) {
@@ -129,13 +147,18 @@ export default function InstallWizard({
           onContinue={() => {
             if (valueKeys.length > 0) {
               setStep({ kind: 'value', index: 0 });
-            } else if (hasComputedDefaults(schema)) {
-              const resolved = resolveComputedDefaults(schema, values);
-              setResolvedValues(resolved);
-              setStep({ kind: 'computed-preview' });
-            } else {
-              setStep({ kind: 'modules' });
+              return;
             }
+            if (hasComputed) {
+              try {
+                setResolvedValues(resolveComputedDefaults(schema, values));
+                setStep({ kind: 'computed-preview' });
+              } catch (err) {
+                onError(err as Error);
+              }
+              return;
+            }
+            setStep({ kind: 'modules' });
           }}
         />
       )}

--- a/source/components/InstallWizard.tsx
+++ b/source/components/InstallWizard.tsx
@@ -1,0 +1,330 @@
+import { useState, useMemo } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { Select } from '@inkjs/ui';
+import type { ShardManifest, ShardSchema, ValueDefinition } from '../runtime/types.js';
+import Header from './Header.js';
+import ValueInput from './ValueInput.js';
+import ModuleReview from './ModuleReview.js';
+import {
+  missingValueKeys,
+  resolveComputedDefaults,
+  defaultModuleSelections,
+} from '../core/install-plan.js';
+import { isComputedDefault } from '../core/schema.js';
+
+export interface WizardResult {
+  values: Record<string, unknown>;
+  selections: Record<string, 'included' | 'excluded'>;
+}
+
+interface InstallWizardProps {
+  manifest: ShardManifest;
+  schema: ShardSchema;
+  prefillValues: Record<string, unknown>;
+  moduleFileCounts: Record<string, number>;
+  onComplete: (result: WizardResult) => void;
+  onCancel: () => void;
+}
+
+type Step =
+  | { kind: 'header' }
+  | { kind: 'value'; index: number }
+  | { kind: 'computed-preview' }
+  | { kind: 'modules' }
+  | { kind: 'confirm' };
+
+export default function InstallWizard({
+  manifest,
+  schema,
+  prefillValues,
+  moduleFileCounts,
+  onComplete,
+  onCancel,
+}: InstallWizardProps) {
+  const valueKeys = useMemo(
+    () => missingValueKeys(schema, prefillValues),
+    [schema, prefillValues],
+  );
+
+  const [step, setStep] = useState<Step>(() =>
+    valueKeys.length > 0 ? { kind: 'header' } : { kind: 'modules' },
+  );
+  const [values, setValues] = useState<Record<string, unknown>>(prefillValues);
+  const [selections, setSelections] = useState<Record<string, 'included' | 'excluded'>>(
+    () => defaultModuleSelections(schema),
+  );
+  const [resolvedValues, setResolvedValues] = useState<Record<string, unknown>>(prefillValues);
+
+  useInput((_input, key) => {
+    if (key.escape) {
+      goBack();
+    }
+  });
+
+  function goBack() {
+    setStep((s) => {
+      switch (s.kind) {
+        case 'header':
+          return s;
+        case 'value':
+          if (s.index === 0) return { kind: 'header' };
+          return { kind: 'value', index: s.index - 1 };
+        case 'computed-preview':
+          if (valueKeys.length === 0) return { kind: 'header' };
+          return { kind: 'value', index: valueKeys.length - 1 };
+        case 'modules':
+          if (hasComputedDefaults(schema)) return { kind: 'computed-preview' };
+          if (valueKeys.length === 0) return { kind: 'header' };
+          return { kind: 'value', index: valueKeys.length - 1 };
+        case 'confirm':
+          return { kind: 'modules' };
+      }
+    });
+  }
+
+  function submitValue(key: string, value: unknown) {
+    const nextValues = { ...values, [key]: value };
+    setValues(nextValues);
+    setStep((s) => {
+      if (s.kind !== 'value') return s;
+      if (s.index + 1 < valueKeys.length) {
+        return { kind: 'value', index: s.index + 1 };
+      }
+      // All values collected → resolve computed + advance
+      try {
+        const resolved = resolveComputedDefaults(schema, nextValues);
+        setResolvedValues(resolved);
+        if (hasComputedDefaults(schema)) return { kind: 'computed-preview' };
+      } catch {
+        // Fall through — computed-preview will re-throw on render and
+        // the wizard caller sees the error.
+        setResolvedValues(nextValues);
+      }
+      return { kind: 'modules' };
+    });
+  }
+
+  function submitSelections(next: Record<string, 'included' | 'excluded'>) {
+    setSelections(next);
+    setStep({ kind: 'confirm' });
+  }
+
+  function submitConfirm(choice: 'install' | 'back' | 'cancel') {
+    if (choice === 'install') {
+      onComplete({ values: resolvedValues, selections });
+    } else if (choice === 'back') {
+      setStep({ kind: 'modules' });
+    } else {
+      onCancel();
+    }
+  }
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Header manifest={manifest} />
+
+      {step.kind === 'header' && (
+        <HeaderStep
+          missingValueCount={valueKeys.length}
+          onContinue={() => {
+            if (valueKeys.length > 0) {
+              setStep({ kind: 'value', index: 0 });
+            } else if (hasComputedDefaults(schema)) {
+              const resolved = resolveComputedDefaults(schema, values);
+              setResolvedValues(resolved);
+              setStep({ kind: 'computed-preview' });
+            } else {
+              setStep({ kind: 'modules' });
+            }
+          }}
+        />
+      )}
+
+      {step.kind === 'value' && (() => {
+        const key = valueKeys[step.index]!;
+        const def = schema.values[key]!;
+        return (
+          <Box flexDirection="column">
+            <Text dimColor>
+              Step {step.index + 1} of {valueKeys.length}
+              {def.group && schema.groups.find((g) => g.id === def.group)
+                ? ` · ${schema.groups.find((g) => g.id === def.group)!.label}`
+                : ''}
+            </Text>
+            <ValueInput
+              id={key}
+              def={def}
+              initialValue={values[key]}
+              onSubmit={(v) => submitValue(key, v)}
+            />
+          </Box>
+        );
+      })()}
+
+      {step.kind === 'computed-preview' && (
+        <ComputedPreview
+          schema={schema}
+          resolved={resolvedValues}
+          onContinue={() => setStep({ kind: 'modules' })}
+        />
+      )}
+
+      {step.kind === 'modules' && (
+        <ModuleReview
+          modules={schema.modules}
+          moduleFileCounts={moduleFileCounts}
+          initialSelections={selections}
+          onSubmit={submitSelections}
+        />
+      )}
+
+      {step.kind === 'confirm' && (
+        <ConfirmStep
+          manifest={manifest}
+          values={resolvedValues}
+          selections={selections}
+          schemaValues={schema.values}
+          onChoice={submitConfirm}
+        />
+      )}
+
+      <KeyboardLegend />
+    </Box>
+  );
+}
+
+function hasComputedDefaults(schema: ShardSchema): boolean {
+  return Object.values(schema.values).some(
+    (def) => def.default !== undefined && isComputedDefault(def.default),
+  );
+}
+
+function HeaderStep({
+  missingValueCount,
+  onContinue,
+}: {
+  missingValueCount: number;
+  onContinue: () => void;
+}) {
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Text>
+        {missingValueCount === 0
+          ? 'Pre-fill complete. Ready to review modules.'
+          : `${missingValueCount} question${missingValueCount === 1 ? '' : 's'} to answer, then module review.`}
+      </Text>
+      <Select
+        options={[{ label: 'Start', value: 'start' }]}
+        onChange={() => onContinue()}
+      />
+    </Box>
+  );
+}
+
+function ComputedPreview({
+  schema,
+  resolved,
+  onContinue,
+}: {
+  schema: ShardSchema;
+  resolved: Record<string, unknown>;
+  onContinue: () => void;
+}) {
+  const computed = Object.entries(schema.values).filter(
+    ([, def]) => def.default !== undefined && isComputedDefault(def.default),
+  );
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Text bold>Auto-filled values</Text>
+      {computed.map(([key, def]) => (
+        <Box key={key} flexDirection="column">
+          <Text>
+            <Text bold>{key}</Text>
+            <Text>: </Text>
+            <Text color="cyan">{formatValue(resolved[key])}</Text>
+          </Text>
+          <Text dimColor>  expression: {String(def.default)}</Text>
+        </Box>
+      ))}
+      <Select options={[{ label: 'Continue', value: 'continue' }]} onChange={() => onContinue()} />
+    </Box>
+  );
+}
+
+function ConfirmStep({
+  manifest,
+  values,
+  selections,
+  schemaValues,
+  onChoice,
+}: {
+  manifest: ShardManifest;
+  values: Record<string, unknown>;
+  selections: Record<string, 'included' | 'excluded'>;
+  schemaValues: Record<string, ValueDefinition>;
+  onChoice: (c: 'install' | 'back' | 'cancel') => void;
+}) {
+  const included = Object.entries(selections).filter(([, s]) => s === 'included').map(([id]) => id);
+  const excluded = Object.entries(selections).filter(([, s]) => s === 'excluded').map(([id]) => id);
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Text bold>Ready to install</Text>
+
+      <Box flexDirection="column">
+        <Text dimColor>Shard:</Text>
+        <Text>  {manifest.namespace}/{manifest.name}@{manifest.version}</Text>
+      </Box>
+
+      <Box flexDirection="column">
+        <Text dimColor>Values:</Text>
+        {Object.keys(schemaValues).map((key) => (
+          <Text key={key}>
+            <Text>  {key}: </Text>
+            <Text color="cyan">{formatValue(values[key])}</Text>
+          </Text>
+        ))}
+      </Box>
+
+      <Box flexDirection="column">
+        <Text dimColor>Modules included ({included.length}):</Text>
+        <Text>  {included.join(', ') || '(none)'}</Text>
+        {excluded.length > 0 && (
+          <>
+            <Text dimColor>Modules excluded ({excluded.length}):</Text>
+            <Text>  {excluded.join(', ')}</Text>
+          </>
+        )}
+      </Box>
+
+      <Select
+        options={[
+          { label: 'Install', value: 'install' },
+          { label: 'Back to module review', value: 'back' },
+          { label: 'Cancel', value: 'cancel' },
+        ]}
+        onChange={(v) => onChoice(v as 'install' | 'back' | 'cancel')}
+      />
+    </Box>
+  );
+}
+
+function KeyboardLegend() {
+  return (
+    <Box marginTop={1}>
+      <Text dimColor>
+        ↑↓ navigate · Space select (multi) · Enter confirm · Esc back · Ctrl+C cancel
+      </Text>
+    </Box>
+  );
+}
+
+function formatValue(value: unknown): string {
+  if (value === undefined) return '(unset)';
+  if (value === null) return 'null';
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (Array.isArray(value)) return value.length === 0 ? '(empty)' : value.map(String).join(', ');
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}

--- a/source/components/ModuleReview.tsx
+++ b/source/components/ModuleReview.tsx
@@ -1,0 +1,103 @@
+import { useState, useMemo } from 'react';
+import { Box, Text } from 'ink';
+import { MultiSelect } from '@inkjs/ui';
+import type { ModuleDefinition } from '../runtime/types.js';
+
+interface ModuleReviewProps {
+  modules: Record<string, ModuleDefinition>;
+  moduleFileCounts: Record<string, number>;
+  initialSelections: Record<string, 'included' | 'excluded'>;
+  onSubmit: (selections: Record<string, 'included' | 'excluded'>) => void;
+}
+
+/**
+ * Module multiselect. Non-removable modules are listed as always-on
+ * above the checkbox group. Live "will install N files" total updates
+ * as removable modules toggle.
+ */
+export default function ModuleReview({
+  modules,
+  moduleFileCounts,
+  initialSelections,
+  onSubmit,
+}: ModuleReviewProps) {
+  const [removable, locked] = useMemo(() => {
+    const removable: Array<[string, ModuleDefinition]> = [];
+    const locked: Array<[string, ModuleDefinition]> = [];
+    for (const entry of Object.entries(modules)) {
+      (entry[1].removable ? removable : locked).push(entry);
+    }
+    return [removable, locked];
+  }, [modules]);
+
+  const initiallyIncluded = useMemo(
+    () =>
+      removable
+        .filter(([id]) => initialSelections[id] !== 'excluded')
+        .map(([id]) => id),
+    [removable, initialSelections],
+  );
+
+  const [currentIncluded, setCurrentIncluded] = useState<string[]>(initiallyIncluded);
+
+  const totalFiles = useMemo(() => {
+    let sum = 0;
+    for (const [id] of locked) sum += moduleFileCounts[id] ?? 0;
+    for (const id of currentIncluded) sum += moduleFileCounts[id] ?? 0;
+    return sum;
+  }, [locked, currentIncluded, moduleFileCounts]);
+
+  const options = removable.map(([id, def]) => ({
+    label: formatOption(id, def, moduleFileCounts[id] ?? 0),
+    value: id,
+  }));
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Text bold>Choose modules to install</Text>
+
+      {locked.length > 0 && (
+        <Box flexDirection="column">
+          <Text dimColor>Always included:</Text>
+          {locked.map(([id, def]) => (
+            <Text key={id}>
+              <Text color="green">✓ </Text>
+              <Text>{def.label ?? id}</Text>
+              <Text dimColor> · {moduleFileCounts[id] ?? 0} files</Text>
+            </Text>
+          ))}
+        </Box>
+      )}
+
+      {removable.length > 0 ? (
+        <Box flexDirection="column">
+          <Text dimColor>Optional (space to toggle, enter to confirm):</Text>
+          <MultiSelect
+            options={options}
+            defaultValue={initiallyIncluded}
+            onChange={(selected) => setCurrentIncluded(selected)}
+            onSubmit={(selected) => {
+              const next: Record<string, 'included' | 'excluded'> = {};
+              for (const [id] of locked) next[id] = 'included';
+              for (const [id] of removable) {
+                next[id] = selected.includes(id) ? 'included' : 'excluded';
+              }
+              onSubmit(next);
+            }}
+          />
+        </Box>
+      ) : (
+        <Text dimColor>No optional modules — all are always included.</Text>
+      )}
+
+      <Text>
+        <Text bold>Will install:</Text> {totalFiles} file{totalFiles === 1 ? '' : 's'}
+      </Text>
+    </Box>
+  );
+}
+
+function formatOption(id: string, def: ModuleDefinition, fileCount: number): string {
+  const label = def.label ?? id;
+  return `${label}  ·  ${fileCount} file${fileCount === 1 ? '' : 's'}`;
+}

--- a/source/components/ModuleReview.tsx
+++ b/source/components/ModuleReview.tsx
@@ -6,6 +6,12 @@ import type { ModuleDefinition } from '../runtime/types.js';
 interface ModuleReviewProps {
   modules: Record<string, ModuleDefinition>;
   moduleFileCounts: Record<string, number>;
+  /**
+   * Count of files that are always installed regardless of module
+   * selection (scripts/, utilities/, skills/, codex/). Added into the
+   * live total so the "Will install N files" line reflects reality.
+   */
+  alwaysIncludedFileCount: number;
   initialSelections: Record<string, 'included' | 'excluded'>;
   onSubmit: (selections: Record<string, 'included' | 'excluded'>) => void;
 }
@@ -18,6 +24,7 @@ interface ModuleReviewProps {
 export default function ModuleReview({
   modules,
   moduleFileCounts,
+  alwaysIncludedFileCount,
   initialSelections,
   onSubmit,
 }: ModuleReviewProps) {
@@ -41,11 +48,11 @@ export default function ModuleReview({
   const [currentIncluded, setCurrentIncluded] = useState<string[]>(initiallyIncluded);
 
   const totalFiles = useMemo(() => {
-    let sum = 0;
+    let sum = alwaysIncludedFileCount;
     for (const [id] of locked) sum += moduleFileCounts[id] ?? 0;
     for (const id of currentIncluded) sum += moduleFileCounts[id] ?? 0;
     return sum;
-  }, [locked, currentIncluded, moduleFileCounts]);
+  }, [locked, currentIncluded, moduleFileCounts, alwaysIncludedFileCount]);
 
   const options = removable.map(([id, def]) => ({
     label: formatOption(id, def, moduleFileCounts[id] ?? 0),
@@ -56,7 +63,7 @@ export default function ModuleReview({
     <Box flexDirection="column" gap={1}>
       <Text bold>Choose modules to install</Text>
 
-      {locked.length > 0 && (
+      {(locked.length > 0 || alwaysIncludedFileCount > 0) && (
         <Box flexDirection="column">
           <Text dimColor>Always included:</Text>
           {locked.map(([id, def]) => (
@@ -66,6 +73,13 @@ export default function ModuleReview({
               <Text dimColor> · {moduleFileCounts[id] ?? 0} files</Text>
             </Text>
           ))}
+          {alwaysIncludedFileCount > 0 && (
+            <Text>
+              <Text color="green">✓ </Text>
+              <Text>Framework files</Text>
+              <Text dimColor> · {alwaysIncludedFileCount} files (scripts, utilities, agent config)</Text>
+            </Text>
+          )}
         </Box>
       )}
 

--- a/source/components/ModuleReview.tsx
+++ b/source/components/ModuleReview.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react';
 import { Box, Text } from 'ink';
 import { MultiSelect } from '@inkjs/ui';
-import type { ModuleDefinition } from '../runtime/types.js';
+import type { ModuleDefinition, ModuleSelections } from '../runtime/types.js';
 
 interface ModuleReviewProps {
   modules: Record<string, ModuleDefinition>;
@@ -12,8 +12,8 @@ interface ModuleReviewProps {
    * live total so the "Will install N files" line reflects reality.
    */
   alwaysIncludedFileCount: number;
-  initialSelections: Record<string, 'included' | 'excluded'>;
-  onSubmit: (selections: Record<string, 'included' | 'excluded'>) => void;
+  initialSelections: ModuleSelections;
+  onSubmit: (selections: ModuleSelections) => void;
 }
 
 /**
@@ -91,7 +91,7 @@ export default function ModuleReview({
             defaultValue={initiallyIncluded}
             onChange={(selected) => setCurrentIncluded(selected)}
             onSubmit={(selected) => {
-              const next: Record<string, 'included' | 'excluded'> = {};
+              const next: ModuleSelections = {};
               for (const [id] of locked) next[id] = 'included';
               for (const [id] of removable) {
                 next[id] = selected.includes(id) ? 'included' : 'excluded';

--- a/source/components/Summary.tsx
+++ b/source/components/Summary.tsx
@@ -1,0 +1,80 @@
+import os from 'node:os';
+import { Box, Text } from 'ink';
+import { StatusMessage } from '@inkjs/ui';
+import type { ShardManifest } from '../runtime/types.js';
+import type { BackupRecord } from '../core/install-plan.js';
+
+interface SummaryProps {
+  manifest: ShardManifest;
+  vaultRoot: string;
+  fileCount: number;
+  durationMs: number;
+  backups: BackupRecord[];
+  hookOutput: { deferred?: boolean; stdout?: string; exitCode?: number } | null;
+  dryRun?: boolean;
+}
+
+export default function Summary({
+  manifest,
+  vaultRoot,
+  fileCount,
+  durationMs,
+  backups,
+  hookOutput,
+  dryRun,
+}: SummaryProps) {
+  const seconds = (durationMs / 1000).toFixed(1);
+  const openCmd = openCommandForPlatform(vaultRoot);
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <StatusMessage variant={dryRun ? 'info' : 'success'}>
+        {dryRun
+          ? `Dry run complete — ${fileCount} files would be written`
+          : `Installed ${manifest.namespace}/${manifest.name}@${manifest.version} — ${fileCount} files in ${seconds}s`}
+      </StatusMessage>
+
+      {backups.length > 0 && (
+        <Box flexDirection="column">
+          <Text bold>Backed up {backups.length} existing file{backups.length === 1 ? '' : 's'}:</Text>
+          {backups.slice(0, 10).map((b) => (
+            <Text key={b.originalPath} dimColor>
+              · {b.backupPath}
+            </Text>
+          ))}
+          {backups.length > 10 && <Text dimColor>  …and {backups.length - 10} more</Text>}
+        </Box>
+      )}
+
+      {hookOutput?.deferred && (
+        <Box flexDirection="column">
+          <Text color="yellow">Post-install hook detected but not executed.</Text>
+          <Text dimColor>
+            Hook runtime is deferred (see #30). Install succeeded without running it.
+          </Text>
+        </Box>
+      )}
+
+      {hookOutput?.stdout && (
+        <Box flexDirection="column">
+          <Text bold>Post-install output:</Text>
+          <Text>{hookOutput.stdout}</Text>
+        </Box>
+      )}
+
+      {!dryRun && (
+        <Box flexDirection="column">
+          <Text bold>Next:</Text>
+          <Text>  {openCmd}</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+function openCommandForPlatform(vaultRoot: string): string {
+  const platform = os.platform();
+  if (platform === 'darwin') return `open "${vaultRoot}"`;
+  if (platform === 'win32') return `start "" "${vaultRoot}"`;
+  return `xdg-open "${vaultRoot}"`;
+}

--- a/source/components/ValueInput.tsx
+++ b/source/components/ValueInput.tsx
@@ -185,7 +185,23 @@ function buildValidator(def: ValueDefinition): (raw: unknown) => ValidationOutco
         }
         return { ok: true, value: raw };
       }
-      case 'multiselect':
+      case 'multiselect': {
+        if (!Array.isArray(raw)) {
+          return { ok: false, message: 'Must be a list' };
+        }
+        if (def.required && raw.length === 0) {
+          return { ok: false, message: 'At least one entry required' };
+        }
+        const allowed = new Set((def.options ?? []).map((o) => o.value));
+        const invalid = raw.filter((v) => typeof v !== 'string' || !allowed.has(v));
+        if (invalid.length > 0) {
+          return {
+            ok: false,
+            message: `Unknown option${invalid.length === 1 ? '' : 's'}: ${invalid.map(String).join(', ')}`,
+          };
+        }
+        return { ok: true, value: raw };
+      }
       case 'list':
         if (!Array.isArray(raw)) {
           return { ok: false, message: 'Must be a list' };

--- a/source/components/ValueInput.tsx
+++ b/source/components/ValueInput.tsx
@@ -1,0 +1,199 @@
+import { useMemo, useState, type ReactElement } from 'react';
+import { Box, Text } from 'ink';
+import { TextInput, Select, ConfirmInput, StatusMessage } from '@inkjs/ui';
+import type { ValueDefinition } from '../runtime/types.js';
+
+interface ValueInputProps {
+  id: string;
+  def: ValueDefinition;
+  initialValue: unknown;
+  onSubmit: (value: unknown) => void;
+}
+
+/**
+ * Single value prompt. Renders the right input per `def.type`, shows the
+ * question, hint, and inline validation. Caller passes an initialValue so
+ * back-navigation re-enters with the previous answer.
+ */
+export default function ValueInput({ id, def, initialValue, onSubmit }: ValueInputProps) {
+  const [error, setError] = useState<string | null>(null);
+
+  const validate = useMemo(
+    () => buildValidator(def),
+    [def],
+  );
+
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text bold>{def.message}</Text>
+        {def.required && <Text color="red"> *</Text>}
+      </Box>
+
+      {def.hint && <Text dimColor>{def.hint}</Text>}
+
+      <Box marginTop={1}>
+        {renderInput(id, def, initialValue, (value) => {
+          const result = validate(value);
+          if (result.ok) {
+            setError(null);
+            onSubmit(result.value);
+          } else {
+            setError(result.message);
+          }
+        })}
+      </Box>
+
+      {error && (
+        <Box marginTop={1}>
+          <StatusMessage variant="error">{error}</StatusMessage>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+function renderInput(
+  id: string,
+  def: ValueDefinition,
+  initialValue: unknown,
+  onSubmit: (value: unknown) => void,
+): ReactElement {
+  const key = `${id}-${def.type}`;
+
+  switch (def.type) {
+    case 'string': {
+      const initial = typeof initialValue === 'string' ? initialValue : typeof def.default === 'string' ? def.default : '';
+      return (
+        <TextInput
+          key={key}
+          defaultValue={initial}
+          placeholder={def.placeholder ?? ''}
+          onSubmit={(v) => onSubmit(v)}
+        />
+      );
+    }
+    case 'number': {
+      const initial =
+        typeof initialValue === 'number'
+          ? String(initialValue)
+          : typeof def.default === 'number'
+          ? String(def.default)
+          : '';
+      return (
+        <TextInput
+          key={key}
+          defaultValue={initial}
+          placeholder={def.placeholder ?? ''}
+          onSubmit={(v) => onSubmit(v)}
+        />
+      );
+    }
+    case 'boolean': {
+      const fallback = typeof def.default === 'boolean' ? def.default : false;
+      const initial = typeof initialValue === 'boolean' ? initialValue : fallback;
+      return (
+        <ConfirmInput
+          key={key}
+          defaultChoice={initial ? 'confirm' : 'cancel'}
+          onConfirm={() => onSubmit(true)}
+          onCancel={() => onSubmit(false)}
+        />
+      );
+    }
+    case 'select': {
+      const options = (def.options ?? []).map((o) => ({ label: o.label, value: o.value }));
+      const initial = typeof initialValue === 'string'
+        ? initialValue
+        : typeof def.default === 'string'
+        ? def.default
+        : undefined;
+      return (
+        <Select
+          key={key}
+          options={options}
+          defaultValue={initial}
+          onChange={(v) => onSubmit(v)}
+        />
+      );
+    }
+    case 'multiselect': {
+      // @inkjs/ui MultiSelect not yet imported here; fall through to a
+      // textual comma-separated input for v0.1 if multiselect is used
+      // (minimal-shard and obsidian-mind don't use multiselect).
+      const initial = Array.isArray(initialValue) ? (initialValue as string[]).join(', ') : '';
+      return (
+        <TextInput
+          key={key}
+          defaultValue={initial}
+          placeholder="comma,separated,values"
+          onSubmit={(v) => onSubmit(v.split(',').map((s) => s.trim()).filter(Boolean))}
+        />
+      );
+    }
+    case 'list': {
+      const initial = Array.isArray(initialValue) ? (initialValue as string[]).join(', ') : '';
+      return (
+        <TextInput
+          key={key}
+          defaultValue={initial}
+          placeholder="comma,separated,values"
+          onSubmit={(v) => onSubmit(v.split(',').map((s) => s.trim()).filter(Boolean))}
+        />
+      );
+    }
+  }
+}
+
+type ValidationOutcome =
+  | { ok: true; value: unknown }
+  | { ok: false; message: string };
+
+function buildValidator(def: ValueDefinition): (raw: unknown) => ValidationOutcome {
+  return (raw: unknown): ValidationOutcome => {
+    switch (def.type) {
+      case 'string': {
+        const str = typeof raw === 'string' ? raw : '';
+        if (def.required && str.trim() === '') {
+          return { ok: false, message: 'Required' };
+        }
+        return { ok: true, value: str };
+      }
+      case 'number': {
+        const str = typeof raw === 'string' ? raw : String(raw ?? '');
+        if (def.required && str.trim() === '') {
+          return { ok: false, message: 'Required' };
+        }
+        const n = Number(str);
+        if (!Number.isFinite(n)) {
+          return { ok: false, message: 'Must be a number' };
+        }
+        if (def.min !== undefined && n < def.min) {
+          return { ok: false, message: `Must be ≥ ${def.min}` };
+        }
+        if (def.max !== undefined && n > def.max) {
+          return { ok: false, message: `Must be ≤ ${def.max}` };
+        }
+        return { ok: true, value: n };
+      }
+      case 'boolean':
+        return { ok: true, value: Boolean(raw) };
+      case 'select': {
+        const allowed = new Set((def.options ?? []).map((o) => o.value));
+        if (typeof raw !== 'string' || !allowed.has(raw)) {
+          return { ok: false, message: 'Pick one of the options' };
+        }
+        return { ok: true, value: raw };
+      }
+      case 'multiselect':
+      case 'list':
+        if (!Array.isArray(raw)) {
+          return { ok: false, message: 'Must be a list' };
+        }
+        if (def.required && raw.length === 0) {
+          return { ok: false, message: 'At least one entry required' };
+        }
+        return { ok: true, value: raw };
+    }
+  };
+}

--- a/source/components/ValueInput.tsx
+++ b/source/components/ValueInput.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, type ReactElement } from 'react';
 import { Box, Text } from 'ink';
 import { TextInput, Select, ConfirmInput, StatusMessage } from '@inkjs/ui';
 import type { ValueDefinition } from '../runtime/types.js';
+import { assertNever } from '../runtime/types.js';
 
 interface ValueInputProps {
   id: string;
@@ -142,6 +143,8 @@ function renderInput(
         />
       );
     }
+    default:
+      return assertNever(def.type);
   }
 }
 
@@ -210,6 +213,8 @@ function buildValidator(def: ValueDefinition): (raw: unknown) => ValidationOutco
           return { ok: false, message: 'At least one entry required' };
         }
         return { ok: true, value: raw };
+      default:
+        return assertNever(def.type);
     }
   };
 }

--- a/source/core/fs-utils.ts
+++ b/source/core/fs-utils.ts
@@ -1,0 +1,20 @@
+import fsp from 'node:fs/promises';
+import crypto from 'node:crypto';
+import path from 'node:path';
+
+export async function pathExists(absolutePath: string): Promise<boolean> {
+  try {
+    await fsp.access(absolutePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function sha256(input: string | Buffer): string {
+  return crypto.createHash('sha256').update(input).digest('hex');
+}
+
+export function toPosix(from: string, to: string): string {
+  return path.relative(from, to).replace(/\\/g, '/');
+}

--- a/source/core/hook.ts
+++ b/source/core/hook.ts
@@ -1,0 +1,38 @@
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import type { ShardManifest } from '../runtime/types.js';
+
+export type HookResult =
+  | { kind: 'absent' }
+  | { kind: 'deferred'; hookPath: string }
+  | { kind: 'ran'; stdout: string; exitCode: number }
+  | { kind: 'failed'; message: string };
+
+/**
+ * Locate and optionally invoke a post-install hook.
+ *
+ * v0.1 implementation: detects the hook file from the shard manifest's
+ * `hooks.post-install` pointer. Execution is deferred — we do not yet
+ * have a TypeScript runtime bundled with shardmind. Returns a
+ * `deferred` result so the Summary component can surface the skip
+ * to the user.
+ *
+ * The execution mechanism (tsx spawn vs jiti dynamic import) will be
+ * decided in #30, linked from ROADMAP Milestone 5.
+ */
+export async function runPostInstallHook(
+  tempDir: string,
+  manifest: ShardManifest,
+): Promise<HookResult> {
+  const hookRelPath = manifest.hooks?.['post-install'];
+  if (!hookRelPath) return { kind: 'absent' };
+
+  const hookPath = path.join(tempDir, hookRelPath);
+  try {
+    await fsp.access(hookPath);
+  } catch {
+    return { kind: 'absent' };
+  }
+
+  return { kind: 'deferred', hookPath };
+}

--- a/source/core/hook.ts
+++ b/source/core/hook.ts
@@ -1,6 +1,6 @@
-import fsp from 'node:fs/promises';
 import path from 'node:path';
 import type { ShardManifest } from '../runtime/types.js';
+import { pathExists } from './fs-utils.js';
 
 export type HookResult =
   | { kind: 'absent' }
@@ -28,11 +28,6 @@ export async function runPostInstallHook(
   if (!hookRelPath) return { kind: 'absent' };
 
   const hookPath = path.join(tempDir, hookRelPath);
-  try {
-    await fsp.access(hookPath);
-  } catch {
-    return { kind: 'absent' };
-  }
-
+  if (!(await pathExists(hookPath))) return { kind: 'absent' };
   return { kind: 'deferred', hookPath };
 }

--- a/source/core/install-plan.ts
+++ b/source/core/install-plan.ts
@@ -2,7 +2,7 @@ import fsp from 'node:fs/promises';
 import path from 'node:path';
 import nunjucks from 'nunjucks';
 import type { ShardSchema, ValueDefinition } from '../runtime/types.js';
-import { ShardMindError } from '../runtime/types.js';
+import { ShardMindError, assertNever } from '../runtime/types.js';
 import { isComputedDefault } from './schema.js';
 
 export interface Collision {
@@ -95,6 +95,8 @@ function coerceToType(raw: string, def: ValueDefinition, key: string): unknown {
           'Nunjucks expressions for list/multiselect values must evaluate to a JSON array.',
         );
       }
+    default:
+      return assertNever(def.type);
   }
 }
 

--- a/source/core/install-plan.ts
+++ b/source/core/install-plan.ts
@@ -1,0 +1,223 @@
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import nunjucks from 'nunjucks';
+import type { ShardSchema, ValueDefinition } from '../runtime/types.js';
+import { ShardMindError } from '../runtime/types.js';
+import { isComputedDefault } from './schema.js';
+
+export interface Collision {
+  outputPath: string;
+  absolutePath: string;
+  size: number;
+  mtime: Date;
+}
+
+export interface BackupRecord {
+  originalPath: string;
+  backupPath: string;
+}
+
+/**
+ * Resolve values whose default is a computed expression (`{{ ... }}`).
+ * Runs after non-computed values have been collected from the wizard or
+ * a --values file.
+ *
+ * The expression is rendered through a standalone Nunjucks environment
+ * (autoescape off) with the already-collected values as context.
+ * The resulting string is coerced back into the value's declared type.
+ */
+export function resolveComputedDefaults(
+  schema: ShardSchema,
+  collected: Record<string, unknown>,
+): Record<string, unknown> {
+  const env = new nunjucks.Environment(null, { autoescape: false });
+  const result: Record<string, unknown> = { ...collected };
+
+  for (const [key, def] of Object.entries(schema.values)) {
+    if (result[key] !== undefined) continue; // user already answered
+    if (def.default === undefined) continue;
+    if (!isComputedDefault(def.default)) continue;
+
+    const expression = def.default as string;
+    let rendered: string;
+    try {
+      rendered = env.renderString(expression, result).trim();
+    } catch (err) {
+      throw new ShardMindError(
+        `Failed to evaluate computed default for '${key}'`,
+        'COMPUTED_DEFAULT_FAILED',
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+
+    result[key] = coerceToType(rendered, def, key);
+  }
+
+  return result;
+}
+
+function coerceToType(raw: string, def: ValueDefinition, key: string): unknown {
+  switch (def.type) {
+    case 'string':
+      return raw;
+    case 'boolean':
+      if (raw === 'true') return true;
+      if (raw === 'false') return false;
+      throw new ShardMindError(
+        `Computed default for '${key}' returned '${raw}', expected boolean`,
+        'COMPUTED_DEFAULT_INVALID',
+        'Nunjucks expressions for boolean values must evaluate to "true" or "false".',
+      );
+    case 'number': {
+      const n = Number(raw);
+      if (!Number.isFinite(n)) {
+        throw new ShardMindError(
+          `Computed default for '${key}' returned '${raw}', expected number`,
+          'COMPUTED_DEFAULT_INVALID',
+          'Nunjucks expressions for number values must evaluate to a finite number.',
+        );
+      }
+      return n;
+    }
+    case 'select':
+      return raw;
+    case 'multiselect':
+    case 'list':
+      try {
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) throw new Error('not an array');
+        return parsed;
+      } catch {
+        throw new ShardMindError(
+          `Computed default for '${key}' returned '${raw}', expected JSON array`,
+          'COMPUTED_DEFAULT_INVALID',
+          'Nunjucks expressions for list/multiselect values must evaluate to a JSON array.',
+        );
+      }
+  }
+}
+
+/**
+ * Detect which planned output paths already exist on disk.
+ * Returns one Collision per existing file with size + mtime so the user
+ * can make an informed choice between backup / overwrite / cancel.
+ */
+export async function detectCollisions(
+  vaultRoot: string,
+  plannedOutputs: string[],
+): Promise<Collision[]> {
+  const collisions: Collision[] = [];
+
+  for (const outputPath of plannedOutputs) {
+    const absolutePath = path.join(vaultRoot, outputPath);
+    try {
+      const stat = await fsp.stat(absolutePath);
+      if (stat.isFile()) {
+        collisions.push({
+          outputPath,
+          absolutePath,
+          size: stat.size,
+          mtime: stat.mtime,
+        });
+      }
+    } catch (err) {
+      const code = err instanceof Error && 'code' in err ? (err as NodeJS.ErrnoException).code : undefined;
+      if (code !== 'ENOENT') {
+        throw new ShardMindError(
+          `Could not check existing file: ${absolutePath}`,
+          'COLLISION_CHECK_FAILED',
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
+  }
+
+  return collisions;
+}
+
+/**
+ * Rename each colliding file to `<original>.shardmind-backup-<timestamp>`.
+ * Timestamp is ISO-8601 compact (no colons) so the name is filesystem-safe.
+ * Returns a record for each backup so callers can surface them in the summary.
+ */
+export async function backupCollisions(
+  collisions: Collision[],
+  timestamp: Date = new Date(),
+): Promise<BackupRecord[]> {
+  const stamp = timestamp.toISOString().replace(/:/g, '-').replace(/\..+$/, '');
+  const records: BackupRecord[] = [];
+
+  for (const collision of collisions) {
+    const backupPath = `${collision.absolutePath}.shardmind-backup-${stamp}`;
+    try {
+      await fsp.rename(collision.absolutePath, backupPath);
+    } catch (err) {
+      throw new ShardMindError(
+        `Could not back up existing file: ${collision.absolutePath}`,
+        'BACKUP_FAILED',
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+    records.push({ originalPath: collision.absolutePath, backupPath });
+  }
+
+  return records;
+}
+
+/**
+ * Merge default values from the schema with prefill values provided via
+ * `--values file.yaml`. Prefill wins over schema defaults. Computed
+ * defaults are left unresolved (caller runs `resolveComputedDefaults`
+ * after all prompts complete).
+ */
+export function mergePrefill(
+  schema: ShardSchema,
+  prefill: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = {};
+
+  for (const [key, def] of Object.entries(schema.values)) {
+    if (prefill[key] !== undefined) {
+      merged[key] = prefill[key];
+      continue;
+    }
+    if (def.default !== undefined && !isComputedDefault(def.default)) {
+      merged[key] = def.default;
+    }
+  }
+
+  return merged;
+}
+
+/**
+ * Which schema value IDs still need prompting — not present in the
+ * (prefill + static defaults) snapshot, not computed. Preserves schema
+ * declaration order so the wizard walks values in the author's order.
+ */
+export function missingValueKeys(
+  schema: ShardSchema,
+  snapshot: Record<string, unknown>,
+): string[] {
+  const missing: string[] = [];
+  for (const [key, def] of Object.entries(schema.values)) {
+    if (snapshot[key] !== undefined) continue;
+    if (def.default !== undefined && isComputedDefault(def.default)) continue;
+    missing.push(key);
+  }
+  return missing;
+}
+
+/**
+ * Initial module selections: every module present in schema, with
+ * `removable: false` locked to 'included' and `removable: true`
+ * defaulting to 'included' (user unchecks to exclude).
+ */
+export function defaultModuleSelections(
+  schema: ShardSchema,
+): Record<string, 'included' | 'excluded'> {
+  const selections: Record<string, 'included' | 'excluded'> = {};
+  for (const id of Object.keys(schema.modules)) {
+    selections[id] = 'included';
+  }
+  return selections;
+}

--- a/source/core/install-plan.ts
+++ b/source/core/install-plan.ts
@@ -1,9 +1,10 @@
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import nunjucks from 'nunjucks';
-import type { ShardSchema, ValueDefinition } from '../runtime/types.js';
+import type { ShardSchema, ValueDefinition, ModuleSelections } from '../runtime/types.js';
 import { ShardMindError, assertNever } from '../runtime/types.js';
 import { isComputedDefault } from './schema.js';
+import { pathExists } from './fs-utils.js';
 
 export interface Collision {
   outputPath: string;
@@ -188,15 +189,6 @@ async function uniqueBackupPath(absolutePath: string, stamp: string): Promise<st
   );
 }
 
-async function pathExists(p: string): Promise<boolean> {
-  try {
-    await fsp.access(p);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 /**
  * Restore backups to their original paths. Used during rollback after
  * a failed install so the user's pre-install content comes back intact.
@@ -277,8 +269,8 @@ export function missingValueKeys(
  */
 export function defaultModuleSelections(
   schema: ShardSchema,
-): Record<string, 'included' | 'excluded'> {
-  const selections: Record<string, 'included' | 'excluded'> = {};
+): ModuleSelections {
+  const selections: ModuleSelections = {};
   for (const id of Object.keys(schema.modules)) {
     selections[id] = 'included';
   }

--- a/source/core/install-plan.ts
+++ b/source/core/install-plan.ts
@@ -10,6 +10,7 @@ export interface Collision {
   absolutePath: string;
   size: number;
   mtime: Date;
+  kind: 'file' | 'directory';
 }
 
 export interface BackupRecord {
@@ -112,12 +113,16 @@ export async function detectCollisions(
     const absolutePath = path.join(vaultRoot, outputPath);
     try {
       const stat = await fsp.stat(absolutePath);
-      if (stat.isFile()) {
+      // Flag both files and directories — a directory at a planned file
+      // path would cause EISDIR during write. The UI shows both with
+      // clear labels so the user sees the real blocker.
+      if (stat.isFile() || stat.isDirectory()) {
         collisions.push({
           outputPath,
           absolutePath,
           size: stat.size,
           mtime: stat.mtime,
+          kind: stat.isDirectory() ? 'directory' : 'file',
         });
       }
     } catch (err) {
@@ -138,7 +143,10 @@ export async function detectCollisions(
 /**
  * Rename each colliding file to `<original>.shardmind-backup-<timestamp>`.
  * Timestamp is ISO-8601 compact (no colons) so the name is filesystem-safe.
- * Returns a record for each backup so callers can surface them in the summary.
+ * If multiple collisions share the same timestamp suffix (same second,
+ * or an earlier backup still on disk), we increment a counter to keep
+ * backup names unique. Returns a record per backup so callers can
+ * surface them in the summary and the rollback path can restore them.
  */
 export async function backupCollisions(
   collisions: Collision[],
@@ -148,7 +156,7 @@ export async function backupCollisions(
   const records: BackupRecord[] = [];
 
   for (const collision of collisions) {
-    const backupPath = `${collision.absolutePath}.shardmind-backup-${stamp}`;
+    const backupPath = await uniqueBackupPath(collision.absolutePath, stamp);
     try {
       await fsp.rename(collision.absolutePath, backupPath);
     } catch (err) {
@@ -162,6 +170,59 @@ export async function backupCollisions(
   }
 
   return records;
+}
+
+async function uniqueBackupPath(absolutePath: string, stamp: string): Promise<string> {
+  const base = `${absolutePath}.shardmind-backup-${stamp}`;
+  if (!(await pathExists(base))) return base;
+  for (let i = 1; i < 1000; i++) {
+    const candidate = `${base}.${i}`;
+    if (!(await pathExists(candidate))) return candidate;
+  }
+  throw new ShardMindError(
+    `Could not find a unique backup name for ${absolutePath}`,
+    'BACKUP_FAILED',
+    'Too many existing backups with the same timestamp — clean up old .shardmind-backup-* files and retry.',
+  );
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await fsp.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Restore backups to their original paths. Used during rollback after
+ * a failed install so the user's pre-install content comes back intact.
+ * Best-effort per entry — individual failures are logged via the return
+ * value but don't abort the rest of the restore.
+ */
+export async function restoreBackups(
+  records: BackupRecord[],
+): Promise<{ restored: BackupRecord[]; failed: Array<BackupRecord & { reason: string }> }> {
+  const restored: BackupRecord[] = [];
+  const failed: Array<BackupRecord & { reason: string }> = [];
+
+  for (const record of records) {
+    try {
+      // Remove whatever the partial install wrote at the original path,
+      // then move the backup back.
+      await fsp.rm(record.originalPath, { recursive: true, force: true });
+      await fsp.rename(record.backupPath, record.originalPath);
+      restored.push(record);
+    } catch (err) {
+      failed.push({
+        ...record,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return { restored, failed };
 }
 
 /**

--- a/source/core/install-runner.ts
+++ b/source/core/install-runner.ts
@@ -1,15 +1,14 @@
 import fsp from 'node:fs/promises';
 import path from 'node:path';
-import crypto from 'node:crypto';
 import { stringify as stringifyYaml } from 'yaml';
 import type {
   ShardManifest,
   ShardSchema,
   ShardState,
   FileState,
-  FileEntry,
   RenderContext,
   ResolvedShard,
+  ModuleSelections,
 } from '../runtime/types.js';
 import { ShardMindError } from '../runtime/types.js';
 import { resolveModules } from './modules.js';
@@ -21,12 +20,7 @@ import {
   writeState,
 } from './state.js';
 import { restoreBackups, type BackupRecord } from './install-plan.js';
-
-export interface RenderPlan {
-  renderEntries: FileEntry[];
-  copyEntries: FileEntry[];
-  totalFiles: number;
-}
+import { sha256, toPosix } from './fs-utils.js';
 
 export interface PlannedOutput {
   outputPath: string;
@@ -40,7 +34,7 @@ export interface InstallRunnerOptions {
   tempDir: string;
   resolved: ResolvedShard;
   values: Record<string, unknown>;
-  selections: Record<string, 'included' | 'excluded'>;
+  selections: ModuleSelections;
   onProgress?: (event: ProgressEvent) => void;
   /**
    * Fires after each successful write with the vault-relative output path.
@@ -68,10 +62,9 @@ export type ProgressEvent =
 export async function planOutputs(
   schema: ShardSchema,
   tempDir: string,
-  selections: Record<string, 'included' | 'excluded'>,
+  selections: ModuleSelections,
 ): Promise<{
   outputs: PlannedOutput[];
-  plan: RenderPlan;
   moduleFileCounts: Record<string, number>;
   alwaysIncludedFileCount: number;
 }> {
@@ -84,30 +77,18 @@ export async function planOutputs(
     moduleFileCounts[id] = 0;
   }
 
-  for (const entry of resolution.render) {
-    outputs.push({ outputPath: entry.outputPath, source: 'render' });
+  const tally = (entry: { outputPath: string; module: string | null }, source: 'render' | 'copy') => {
+    outputs.push({ outputPath: entry.outputPath, source });
     if (entry.module && entry.module in moduleFileCounts) {
       moduleFileCounts[entry.module]!++;
     } else if (!entry.module) {
       alwaysIncludedFileCount++;
     }
-  }
-  for (const entry of resolution.copy) {
-    outputs.push({ outputPath: entry.outputPath, source: 'copy' });
-    if (entry.module && entry.module in moduleFileCounts) {
-      moduleFileCounts[entry.module]!++;
-    } else if (!entry.module) {
-      alwaysIncludedFileCount++;
-    }
-  }
-
-  const plan: RenderPlan = {
-    renderEntries: resolution.render,
-    copyEntries: resolution.copy,
-    totalFiles: resolution.render.length + resolution.copy.length,
   };
+  for (const entry of resolution.render) tally(entry, 'render');
+  for (const entry of resolution.copy) tally(entry, 'copy');
 
-  return { outputs, plan, moduleFileCounts, alwaysIncludedFileCount };
+  return { outputs, moduleFileCounts, alwaysIncludedFileCount };
 }
 
 /**
@@ -138,7 +119,6 @@ export async function runInstall(opts: InstallRunnerOptions): Promise<InstallRes
 
   let index = 0;
 
-  // Render .njk files
   for (const entry of resolution.render) {
     index++;
     onProgress?.({
@@ -164,7 +144,7 @@ export async function runInstall(opts: InstallRunnerOptions): Promise<InstallRes
         onFileWritten?.(file.outputPath);
       }
       fileStates[file.outputPath] = {
-        template: path.relative(tempDir, entry.sourcePath).replace(/\\/g, '/'),
+        template: toPosix(tempDir, entry.sourcePath),
         rendered_hash: file.hash,
         ownership: 'managed',
         ...(entry.iterator ? { iterator_key: entry.iterator } : {}),
@@ -172,7 +152,6 @@ export async function runInstall(opts: InstallRunnerOptions): Promise<InstallRes
     }
   }
 
-  // Copy verbatim files
   for (const entry of resolution.copy) {
     index++;
     onProgress?.({
@@ -184,14 +163,14 @@ export async function runInstall(opts: InstallRunnerOptions): Promise<InstallRes
     });
 
     const buffer = await fsp.readFile(entry.sourcePath);
-    const hash = crypto.createHash('sha256').update(buffer).digest('hex');
+    const hash = sha256(buffer);
     if (!dryRun) {
       await writeVaultFileBuffer(vaultRoot, entry.outputPath, buffer);
       writtenPaths.push(entry.outputPath);
       onFileWritten?.(entry.outputPath);
     }
     fileStates[entry.outputPath] = {
-      template: path.relative(tempDir, entry.sourcePath).replace(/\\/g, '/'),
+      template: toPosix(tempDir, entry.sourcePath),
       rendered_hash: hash,
       ownership: 'managed',
     };
@@ -212,39 +191,19 @@ export async function runInstall(opts: InstallRunnerOptions): Promise<InstallRes
   };
 
   if (!dryRun) {
-    // Guard: shard-values.yaml is user-owned. If it already exists we
-    // refuse to overwrite — prior install flow should have routed
-    // through ExistingInstallGate, and without an active install this
-    // file has no engine context to merge against.
-    const valuesAbsPath = path.join(vaultRoot, 'shard-values.yaml');
-    if (await fileExists(valuesAbsPath)) {
-      throw new ShardMindError(
-        'shard-values.yaml already exists at the install target',
-        'VALUES_FILE_COLLISION',
-        'Move or remove shard-values.yaml before installing. `shardmind update` (Milestone 4) will handle this automatically once available.',
-      );
-    }
-
     await initShardDir(vaultRoot);
     await cacheTemplates(vaultRoot, tempDir);
     await cacheManifest(vaultRoot, manifest, schema);
     await writeState(vaultRoot, state);
+    // shard-values.yaml is user-owned; install must create it fresh.
+    // Use `wx` so an existing file races cleanly to EEXIST instead of
+    // being silently overwritten if ExistingInstallGate was bypassed.
     await writeValuesFile(vaultRoot, values);
-    // Track shard-values.yaml in writtenPaths so rollback can clean it up.
     writtenPaths.push('shard-values.yaml');
     onFileWritten?.('shard-values.yaml');
   }
 
   return { writtenPaths, state, fileCount: totalFiles };
-}
-
-async function fileExists(absolutePath: string): Promise<boolean> {
-  try {
-    await fsp.access(absolutePath);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 /**
@@ -303,8 +262,7 @@ export async function rollbackInstall(
 }
 
 export function hashValues(values: Record<string, unknown>): string {
-  const serialized = JSON.stringify(values, Object.keys(values).sort());
-  return crypto.createHash('sha256').update(serialized).digest('hex');
+  return sha256(JSON.stringify(values, Object.keys(values).sort()));
 }
 
 async function writeVaultFile(
@@ -333,7 +291,19 @@ async function writeValuesFile(
 ): Promise<void> {
   const abs = path.join(vaultRoot, 'shard-values.yaml');
   const serialized = stringifyYaml(values, { lineWidth: 0 }).trimEnd() + '\n';
-  await fsp.writeFile(abs, serialized, 'utf-8');
+  try {
+    await fsp.writeFile(abs, serialized, { encoding: 'utf-8', flag: 'wx' });
+  } catch (err) {
+    const code = err instanceof Error && 'code' in err ? (err as NodeJS.ErrnoException).code : undefined;
+    if (code === 'EEXIST') {
+      throw new ShardMindError(
+        'shard-values.yaml already exists at the install target',
+        'VALUES_FILE_COLLISION',
+        'Move or remove shard-values.yaml before installing. `shardmind update` (Milestone 4) will handle this automatically once available.',
+      );
+    }
+    throw err;
+  }
 }
 
 function wrapRenderError(outputPath: string, err: unknown): ShardMindError {

--- a/source/core/install-runner.ts
+++ b/source/core/install-runner.ts
@@ -1,0 +1,298 @@
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { stringify as stringifyYaml } from 'yaml';
+import type {
+  ShardManifest,
+  ShardSchema,
+  ShardState,
+  FileState,
+  FileEntry,
+  RenderContext,
+  ResolvedShard,
+} from '../runtime/types.js';
+import { ShardMindError } from '../runtime/types.js';
+import { resolveModules } from './modules.js';
+import { createRenderer, renderFile } from './renderer.js';
+import {
+  initShardDir,
+  cacheTemplates,
+  cacheManifest,
+  writeState,
+} from './state.js';
+
+export interface RenderPlan {
+  renderEntries: FileEntry[];
+  copyEntries: FileEntry[];
+  totalFiles: number;
+}
+
+export interface PlannedOutput {
+  outputPath: string;
+  source: 'render' | 'copy';
+}
+
+export interface InstallRunnerOptions {
+  vaultRoot: string;
+  manifest: ShardManifest;
+  schema: ShardSchema;
+  tempDir: string;
+  resolved: ResolvedShard;
+  values: Record<string, unknown>;
+  selections: Record<string, 'included' | 'excluded'>;
+  onProgress?: (event: ProgressEvent) => void;
+  dryRun?: boolean;
+}
+
+export interface InstallResult {
+  writtenPaths: string[];
+  state: ShardState;
+  fileCount: number;
+}
+
+export type ProgressEvent =
+  | { kind: 'start'; total: number }
+  | { kind: 'file'; index: number; total: number; label: string; outputPath: string }
+  | { kind: 'done'; total: number };
+
+/**
+ * Enumerate every file that would be written given the selected modules.
+ * Used for collision detection and module file counting before install.
+ */
+export async function planOutputs(
+  schema: ShardSchema,
+  tempDir: string,
+  selections: Record<string, 'included' | 'excluded'>,
+): Promise<{ outputs: PlannedOutput[]; plan: RenderPlan; moduleFileCounts: Record<string, number> }> {
+  const resolution = await resolveModules(schema, selections, tempDir);
+  const outputs: PlannedOutput[] = [];
+  const moduleFileCounts: Record<string, number> = {};
+
+  for (const id of Object.keys(schema.modules)) {
+    moduleFileCounts[id] = 0;
+  }
+
+  for (const entry of resolution.render) {
+    outputs.push({ outputPath: entry.outputPath, source: 'render' });
+    if (entry.module && entry.module in moduleFileCounts) {
+      moduleFileCounts[entry.module]!++;
+    }
+  }
+  for (const entry of resolution.copy) {
+    outputs.push({ outputPath: entry.outputPath, source: 'copy' });
+    if (entry.module && entry.module in moduleFileCounts) {
+      moduleFileCounts[entry.module]!++;
+    }
+  }
+
+  const plan: RenderPlan = {
+    renderEntries: resolution.render,
+    copyEntries: resolution.copy,
+    totalFiles: resolution.render.length + resolution.copy.length,
+  };
+
+  return { outputs, plan, moduleFileCounts };
+}
+
+/**
+ * Execute the install pipeline: render + copy + write + cache + state.
+ * Returns paths written so the caller can roll back on later failure.
+ */
+export async function runInstall(opts: InstallRunnerOptions): Promise<InstallResult> {
+  const { vaultRoot, manifest, schema, tempDir, resolved, values, selections, onProgress, dryRun } = opts;
+
+  const resolution = await resolveModules(schema, selections, tempDir);
+  const totalFiles = resolution.render.length + resolution.copy.length;
+  const writtenPaths: string[] = [];
+  const fileStates: Record<string, FileState> = {};
+
+  onProgress?.({ kind: 'start', total: totalFiles });
+
+  const env = createRenderer(path.join(tempDir, 'templates'));
+  const includedModules = Object.entries(selections)
+    .filter(([, s]) => s === 'included')
+    .map(([id]) => id);
+  const context: RenderContext = {
+    values,
+    included_modules: includedModules,
+    shard: { name: manifest.name, version: manifest.version },
+    install_date: new Date().toISOString(),
+    year: new Date().getUTCFullYear().toString(),
+  };
+
+  let index = 0;
+
+  // Render .njk files
+  for (const entry of resolution.render) {
+    index++;
+    onProgress?.({
+      kind: 'file',
+      index,
+      total: totalFiles,
+      label: entry.outputPath,
+      outputPath: entry.outputPath,
+    });
+
+    let rendered;
+    try {
+      rendered = await renderFile(entry, context, env);
+    } catch (err) {
+      throw wrapRenderError(entry.outputPath, err);
+    }
+
+    const files = Array.isArray(rendered) ? rendered : [rendered];
+    for (const file of files) {
+      if (!dryRun) {
+        await writeVaultFile(vaultRoot, file.outputPath, file.content);
+        writtenPaths.push(file.outputPath);
+      }
+      fileStates[file.outputPath] = {
+        template: path.relative(tempDir, entry.sourcePath).replace(/\\/g, '/'),
+        rendered_hash: file.hash,
+        ownership: 'managed',
+        ...(entry.iterator ? { iterator_key: entry.iterator } : {}),
+      };
+    }
+  }
+
+  // Copy verbatim files
+  for (const entry of resolution.copy) {
+    index++;
+    onProgress?.({
+      kind: 'file',
+      index,
+      total: totalFiles,
+      label: entry.outputPath,
+      outputPath: entry.outputPath,
+    });
+
+    const buffer = await fsp.readFile(entry.sourcePath);
+    const hash = crypto.createHash('sha256').update(buffer).digest('hex');
+    if (!dryRun) {
+      await writeVaultFileBuffer(vaultRoot, entry.outputPath, buffer);
+      writtenPaths.push(entry.outputPath);
+    }
+    fileStates[entry.outputPath] = {
+      template: path.relative(tempDir, entry.sourcePath).replace(/\\/g, '/'),
+      rendered_hash: hash,
+      ownership: 'managed',
+    };
+  }
+
+  onProgress?.({ kind: 'done', total: totalFiles });
+
+  const state: ShardState = {
+    schema_version: 1,
+    shard: `${manifest.namespace}/${manifest.name}`,
+    source: resolved.source,
+    version: manifest.version,
+    installed_at: context.install_date,
+    updated_at: context.install_date,
+    values_hash: hashValues(values),
+    modules: selections,
+    files: fileStates,
+  };
+
+  if (!dryRun) {
+    await initShardDir(vaultRoot);
+    await cacheTemplates(vaultRoot, tempDir);
+    await cacheManifest(vaultRoot, manifest, schema);
+    await writeState(vaultRoot, state);
+    await writeValuesFile(vaultRoot, values);
+  }
+
+  return { writtenPaths, state, fileCount: totalFiles };
+}
+
+/**
+ * Roll back a partial install. Removes all written files, cleans up
+ * empty parent directories, and deletes .shardmind/ if present.
+ * Best-effort — errors during rollback are swallowed because the
+ * primary failure is already being reported.
+ */
+export async function rollbackInstall(
+  vaultRoot: string,
+  writtenPaths: string[],
+): Promise<void> {
+  const sortedByDepth = [...writtenPaths].sort(
+    (a, b) => b.split('/').length - a.split('/').length,
+  );
+  for (const rel of sortedByDepth) {
+    const abs = path.join(vaultRoot, rel);
+    try {
+      await fsp.unlink(abs);
+    } catch {
+      // already gone
+    }
+  }
+
+  // Remove empty parent directories (best-effort, deepest first)
+  const dirs = new Set<string>();
+  for (const rel of writtenPaths) {
+    let dir = path.dirname(rel);
+    while (dir && dir !== '.' && dir !== '/') {
+      dirs.add(dir);
+      dir = path.dirname(dir);
+    }
+  }
+  const sortedDirs = [...dirs].sort((a, b) => b.split('/').length - a.split('/').length);
+  for (const rel of sortedDirs) {
+    try {
+      await fsp.rmdir(path.join(vaultRoot, rel));
+    } catch {
+      // non-empty or already gone
+    }
+  }
+
+  try {
+    await fsp.rm(path.join(vaultRoot, '.shardmind'), { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+}
+
+export function hashValues(values: Record<string, unknown>): string {
+  const serialized = JSON.stringify(values, Object.keys(values).sort());
+  return crypto.createHash('sha256').update(serialized).digest('hex');
+}
+
+async function writeVaultFile(
+  vaultRoot: string,
+  outputPath: string,
+  content: string,
+): Promise<void> {
+  const abs = path.join(vaultRoot, outputPath);
+  await fsp.mkdir(path.dirname(abs), { recursive: true });
+  await fsp.writeFile(abs, content, 'utf-8');
+}
+
+async function writeVaultFileBuffer(
+  vaultRoot: string,
+  outputPath: string,
+  content: Buffer,
+): Promise<void> {
+  const abs = path.join(vaultRoot, outputPath);
+  await fsp.mkdir(path.dirname(abs), { recursive: true });
+  await fsp.writeFile(abs, content);
+}
+
+async function writeValuesFile(
+  vaultRoot: string,
+  values: Record<string, unknown>,
+): Promise<void> {
+  const abs = path.join(vaultRoot, 'shard-values.yaml');
+  const serialized = stringifyYaml(values, { lineWidth: 0 }).trimEnd() + '\n';
+  await fsp.writeFile(abs, serialized, 'utf-8');
+}
+
+function wrapRenderError(outputPath: string, err: unknown): ShardMindError {
+  if (err instanceof ShardMindError) {
+    return err;
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return new ShardMindError(
+    `Template render failed: ${outputPath}`,
+    'RENDER_FAILED',
+    message,
+  );
+}

--- a/source/core/install-runner.ts
+++ b/source/core/install-runner.ts
@@ -262,7 +262,25 @@ export async function rollbackInstall(
 }
 
 export function hashValues(values: Record<string, unknown>): string {
-  return sha256(JSON.stringify(values, Object.keys(values).sort()));
+  return sha256(JSON.stringify(stableJson(values)));
+}
+
+/**
+ * Recursively reorder object keys alphabetically so `JSON.stringify`
+ * produces a deterministic byte sequence. Arrays keep their order;
+ * primitives pass through. Unlike the `replacer` array overload of
+ * JSON.stringify, this does NOT drop nested object keys.
+ */
+function stableJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableJson);
+  if (value && typeof value === 'object') {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      sorted[key] = stableJson((value as Record<string, unknown>)[key]);
+    }
+    return sorted;
+  }
+  return value;
 }
 
 async function writeVaultFile(

--- a/source/core/install-runner.ts
+++ b/source/core/install-runner.ts
@@ -20,6 +20,7 @@ import {
   cacheManifest,
   writeState,
 } from './state.js';
+import { restoreBackups, type BackupRecord } from './install-plan.js';
 
 export interface RenderPlan {
   renderEntries: FileEntry[];
@@ -63,10 +64,16 @@ export async function planOutputs(
   schema: ShardSchema,
   tempDir: string,
   selections: Record<string, 'included' | 'excluded'>,
-): Promise<{ outputs: PlannedOutput[]; plan: RenderPlan; moduleFileCounts: Record<string, number> }> {
+): Promise<{
+  outputs: PlannedOutput[];
+  plan: RenderPlan;
+  moduleFileCounts: Record<string, number>;
+  alwaysIncludedFileCount: number;
+}> {
   const resolution = await resolveModules(schema, selections, tempDir);
   const outputs: PlannedOutput[] = [];
   const moduleFileCounts: Record<string, number> = {};
+  let alwaysIncludedFileCount = 0;
 
   for (const id of Object.keys(schema.modules)) {
     moduleFileCounts[id] = 0;
@@ -76,12 +83,16 @@ export async function planOutputs(
     outputs.push({ outputPath: entry.outputPath, source: 'render' });
     if (entry.module && entry.module in moduleFileCounts) {
       moduleFileCounts[entry.module]!++;
+    } else if (!entry.module) {
+      alwaysIncludedFileCount++;
     }
   }
   for (const entry of resolution.copy) {
     outputs.push({ outputPath: entry.outputPath, source: 'copy' });
     if (entry.module && entry.module in moduleFileCounts) {
       moduleFileCounts[entry.module]!++;
+    } else if (!entry.module) {
+      alwaysIncludedFileCount++;
     }
   }
 
@@ -91,7 +102,7 @@ export async function planOutputs(
     totalFiles: resolution.render.length + resolution.copy.length,
   };
 
-  return { outputs, plan, moduleFileCounts };
+  return { outputs, plan, moduleFileCounts, alwaysIncludedFileCount };
 }
 
 /**
@@ -194,25 +205,51 @@ export async function runInstall(opts: InstallRunnerOptions): Promise<InstallRes
   };
 
   if (!dryRun) {
+    // Guard: shard-values.yaml is user-owned. If it already exists we
+    // refuse to overwrite — prior install flow should have routed
+    // through ExistingInstallGate, and without an active install this
+    // file has no engine context to merge against.
+    const valuesAbsPath = path.join(vaultRoot, 'shard-values.yaml');
+    if (await fileExists(valuesAbsPath)) {
+      throw new ShardMindError(
+        'shard-values.yaml already exists at the install target',
+        'VALUES_FILE_COLLISION',
+        'Run `shardmind update` if this vault already has a shard, or move/remove shard-values.yaml to install fresh.',
+      );
+    }
+
     await initShardDir(vaultRoot);
     await cacheTemplates(vaultRoot, tempDir);
     await cacheManifest(vaultRoot, manifest, schema);
     await writeState(vaultRoot, state);
     await writeValuesFile(vaultRoot, values);
+    // Track shard-values.yaml in writtenPaths so rollback can clean it up.
+    writtenPaths.push('shard-values.yaml');
   }
 
   return { writtenPaths, state, fileCount: totalFiles };
 }
 
+async function fileExists(absolutePath: string): Promise<boolean> {
+  try {
+    await fsp.access(absolutePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Roll back a partial install. Removes all written files, cleans up
- * empty parent directories, and deletes .shardmind/ if present.
+ * empty parent directories, deletes .shardmind/ if present, and
+ * restores any backups created during collision handling.
  * Best-effort — errors during rollback are swallowed because the
  * primary failure is already being reported.
  */
 export async function rollbackInstall(
   vaultRoot: string,
   writtenPaths: string[],
+  backups: BackupRecord[] = [],
 ): Promise<void> {
   const sortedByDepth = [...writtenPaths].sort(
     (a, b) => b.split('/').length - a.split('/').length,
@@ -248,6 +285,12 @@ export async function rollbackInstall(
     await fsp.rm(path.join(vaultRoot, '.shardmind'), { recursive: true, force: true });
   } catch {
     // ignore
+  }
+
+  // Restore any backups last, so they land on paths that have been
+  // freed by the file removal above.
+  if (backups.length > 0) {
+    await restoreBackups(backups);
   }
 }
 

--- a/source/core/install-runner.ts
+++ b/source/core/install-runner.ts
@@ -42,6 +42,11 @@ export interface InstallRunnerOptions {
   values: Record<string, unknown>;
   selections: Record<string, 'included' | 'excluded'>;
   onProgress?: (event: ProgressEvent) => void;
+  /**
+   * Fires after each successful write with the vault-relative output path.
+   * Used by the command layer to maintain a live rollback list for SIGINT.
+   */
+  onFileWritten?: (outputPath: string) => void;
   dryRun?: boolean;
 }
 
@@ -110,7 +115,7 @@ export async function planOutputs(
  * Returns paths written so the caller can roll back on later failure.
  */
 export async function runInstall(opts: InstallRunnerOptions): Promise<InstallResult> {
-  const { vaultRoot, manifest, schema, tempDir, resolved, values, selections, onProgress, dryRun } = opts;
+  const { vaultRoot, manifest, schema, tempDir, resolved, values, selections, onProgress, onFileWritten, dryRun } = opts;
 
   const resolution = await resolveModules(schema, selections, tempDir);
   const totalFiles = resolution.render.length + resolution.copy.length;
@@ -156,6 +161,7 @@ export async function runInstall(opts: InstallRunnerOptions): Promise<InstallRes
       if (!dryRun) {
         await writeVaultFile(vaultRoot, file.outputPath, file.content);
         writtenPaths.push(file.outputPath);
+        onFileWritten?.(file.outputPath);
       }
       fileStates[file.outputPath] = {
         template: path.relative(tempDir, entry.sourcePath).replace(/\\/g, '/'),
@@ -182,6 +188,7 @@ export async function runInstall(opts: InstallRunnerOptions): Promise<InstallRes
     if (!dryRun) {
       await writeVaultFileBuffer(vaultRoot, entry.outputPath, buffer);
       writtenPaths.push(entry.outputPath);
+      onFileWritten?.(entry.outputPath);
     }
     fileStates[entry.outputPath] = {
       template: path.relative(tempDir, entry.sourcePath).replace(/\\/g, '/'),
@@ -214,7 +221,7 @@ export async function runInstall(opts: InstallRunnerOptions): Promise<InstallRes
       throw new ShardMindError(
         'shard-values.yaml already exists at the install target',
         'VALUES_FILE_COLLISION',
-        'Run `shardmind update` if this vault already has a shard, or move/remove shard-values.yaml to install fresh.',
+        'Move or remove shard-values.yaml before installing. `shardmind update` (Milestone 4) will handle this automatically once available.',
       );
     }
 
@@ -225,6 +232,7 @@ export async function runInstall(opts: InstallRunnerOptions): Promise<InstallRes
     await writeValuesFile(vaultRoot, values);
     // Track shard-values.yaml in writtenPaths so rollback can clean it up.
     writtenPaths.push('shard-values.yaml');
+    onFileWritten?.('shard-values.yaml');
   }
 
   return { writtenPaths, state, fileCount: totalFiles };

--- a/source/core/modules.ts
+++ b/source/core/modules.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import type { ShardSchema, ModuleResolution, FileEntry } from '../runtime/types.js';
+import type { ShardSchema, ModuleResolution, FileEntry, ModuleSelections } from '../runtime/types.js';
 
 const VOLATILE_MARKER = '{# shardmind: volatile #}';
 
@@ -9,7 +9,7 @@ const ALWAYS_COPY_DIRS = ['scripts', 'utilities', 'skills'] as const;
 
 export async function resolveModules(
   schema: ShardSchema,
-  selections: Record<string, 'included' | 'excluded'>,
+  selections: ModuleSelections,
   tempDir: string,
 ): Promise<ModuleResolution> {
   const render: FileEntry[] = [];

--- a/source/core/state.ts
+++ b/source/core/state.ts
@@ -84,19 +84,21 @@ export async function cacheTemplates(vaultRoot: string, tempDir: string): Promis
   const src = path.join(tempDir, 'templates');
   const dest = path.join(vaultRoot, '.shardmind', 'templates');
 
-  try {
-    await fsp.access(src);
-  } catch {
-    throw new ShardMindError(
-      `Missing templates/ directory in shard source: ${src}`,
-      'STATE_CACHE_MISSING_TEMPLATES',
-      'The downloaded shard does not contain a templates/ directory.',
-    );
-  }
-
   await fsp.rm(dest, { recursive: true, force: true });
   await fsp.mkdir(dest, { recursive: true });
-  await fsp.cp(src, dest, { recursive: true });
+  try {
+    await fsp.cp(src, dest, { recursive: true });
+  } catch (err) {
+    const code = err instanceof Error && 'code' in err ? (err as NodeJS.ErrnoException).code : undefined;
+    if (code === 'ENOENT') {
+      throw new ShardMindError(
+        `Missing templates/ directory in shard source: ${src}`,
+        'STATE_CACHE_MISSING_TEMPLATES',
+        'The downloaded shard does not contain a templates/ directory.',
+      );
+    }
+    throw err;
+  }
 }
 
 export async function cacheManifest(

--- a/source/runtime/types.ts
+++ b/source/runtime/types.ts
@@ -93,6 +93,8 @@ export type MigrationChange =
   | { type: 'removed'; key: string }
   | { type: 'type_changed'; key: string; from: string; to: string; transform: string };
 
+export type ModuleSelections = Record<string, 'included' | 'excluded'>;
+
 export interface ShardState {
   schema_version: number;
   shard: string;
@@ -101,7 +103,7 @@ export interface ShardState {
   installed_at: string;
   updated_at: string;
   values_hash: string;
-  modules: Record<string, 'included' | 'excluded'>;
+  modules: ModuleSelections;
   files: Record<string, FileState>;
 }
 
@@ -223,7 +225,7 @@ export interface MigrationResult {
 export interface HookContext {
   vaultRoot: string;
   values: Record<string, unknown>;
-  modules: Record<string, 'included' | 'excluded'>;
+  modules: ModuleSelections;
   shard: { name: string; version: string };
   previousVersion?: string;
 }

--- a/source/runtime/types.ts
+++ b/source/runtime/types.ts
@@ -238,3 +238,12 @@ export class ShardMindError extends Error {
     this.name = 'ShardMindError';
   }
 }
+
+/**
+ * Compile-time exhaustiveness helper. Placing this in a `default` branch
+ * of a discriminated-union switch forces TypeScript to fail the build
+ * if a new variant is added without a corresponding case.
+ */
+export function assertNever(value: never): never {
+  throw new Error(`Unhandled variant: ${JSON.stringify(value)}`);
+}

--- a/tests/integration/install.test.ts
+++ b/tests/integration/install.test.ts
@@ -192,9 +192,9 @@ describe('install pipeline (against examples/minimal-shard)', () => {
   it('planOutputs reports per-module file counts', async () => {
     const schema = await parseSchema(path.join(MINIMAL_SHARD, 'shard-schema.yaml'));
     const selections = defaultModuleSelections(schema);
-    const { moduleFileCounts, plan } = await planOutputs(schema, MINIMAL_SHARD, selections);
+    const { moduleFileCounts, outputs } = await planOutputs(schema, MINIMAL_SHARD, selections);
 
-    expect(plan.totalFiles).toBeGreaterThan(0);
+    expect(outputs.length).toBeGreaterThan(0);
     expect(moduleFileCounts['brain']).toBeGreaterThan(0);
     // extras contributes a command and a partial; the partial has no output file on its own
     expect(moduleFileCounts['extras']).toBeGreaterThanOrEqual(1);

--- a/tests/integration/install.test.ts
+++ b/tests/integration/install.test.ts
@@ -226,6 +226,66 @@ describe('install pipeline (against examples/minimal-shard)', () => {
     await expect(fsp.access(backups[0]!.backupPath)).resolves.toBeUndefined();
   });
 
+  it('refuses to install when shard-values.yaml already exists', async () => {
+    await fsp.writeFile(path.join(vault, 'shard-values.yaml'), 'user_name: Old\n', 'utf-8');
+
+    const manifest = await parseManifest(path.join(MINIMAL_SHARD, 'shard.yaml'));
+    const schema = await parseSchema(path.join(MINIMAL_SHARD, 'shard-schema.yaml'));
+    const selections = defaultModuleSelections(schema);
+    const validator = buildValuesValidator(schema);
+    const values = validator.parse(resolveComputedDefaults(schema, VALUES));
+
+    await expect(
+      runInstall({
+        vaultRoot: vault,
+        manifest,
+        schema,
+        tempDir: MINIMAL_SHARD,
+        resolved: RESOLVED,
+        values,
+        selections,
+      }),
+    ).rejects.toMatchObject({ code: 'VALUES_FILE_COLLISION' });
+  });
+
+  it('planOutputs reports alwaysIncludedFileCount for module-null files', async () => {
+    const schema = await parseSchema(path.join(MINIMAL_SHARD, 'shard-schema.yaml'));
+    const selections = defaultModuleSelections(schema);
+    const { alwaysIncludedFileCount } = await planOutputs(schema, MINIMAL_SHARD, selections);
+    // minimal-shard: CLAUDE.md.njk and Home.md.njk have no module (no paths match)
+    expect(alwaysIncludedFileCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it('rollback restores backed-up files', async () => {
+    const original = path.join(vault, 'Home.md');
+    await fsp.writeFile(original, 'user content', 'utf-8');
+
+    const manifest = await parseManifest(path.join(MINIMAL_SHARD, 'shard.yaml'));
+    const schema = await parseSchema(path.join(MINIMAL_SHARD, 'shard-schema.yaml'));
+    const selections = defaultModuleSelections(schema);
+    const validator = buildValuesValidator(schema);
+    const values = validator.parse(resolveComputedDefaults(schema, VALUES));
+    const { outputs } = await planOutputs(schema, MINIMAL_SHARD, selections);
+    const collisions = await detectCollisions(vault, outputs.map((o) => o.outputPath));
+    const backups = await backupCollisions(collisions);
+
+    const result = await runInstall({
+      vaultRoot: vault,
+      manifest,
+      schema,
+      tempDir: MINIMAL_SHARD,
+      resolved: RESOLVED,
+      values,
+      selections,
+    });
+
+    // Simulate a post-install failure and roll back
+    await rollbackInstall(vault, result.writtenPaths, backups);
+
+    const restored = await fsp.readFile(original, 'utf-8');
+    expect(restored).toBe('user content');
+  });
+
   it('rollback removes all written files and the .shardmind directory', async () => {
     const manifest = await parseManifest(path.join(MINIMAL_SHARD, 'shard.yaml'));
     const schema = await parseSchema(path.join(MINIMAL_SHARD, 'shard-schema.yaml'));

--- a/tests/integration/install.test.ts
+++ b/tests/integration/install.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+import { parseManifest } from '../../source/core/manifest.js';
+import { parseSchema, buildValuesValidator } from '../../source/core/schema.js';
+import { readState } from '../../source/core/state.js';
+import {
+  planOutputs,
+  runInstall,
+  rollbackInstall,
+} from '../../source/core/install-runner.js';
+import {
+  resolveComputedDefaults,
+  defaultModuleSelections,
+  detectCollisions,
+  backupCollisions,
+} from '../../source/core/install-plan.js';
+import type { ResolvedShard, ShardState } from '../../source/runtime/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MINIMAL_SHARD = path.resolve(__dirname, '../../examples/minimal-shard');
+
+const RESOLVED: ResolvedShard = {
+  namespace: 'shardmind',
+  name: 'minimal',
+  version: '0.1.0',
+  source: 'github:shardmind/minimal',
+  tarballUrl: 'n/a (local fixture)',
+};
+
+const VALUES = {
+  user_name: 'Alice',
+  org_name: 'Acme Labs',
+  vault_purpose: 'engineering' as const,
+  qmd_enabled: true,
+};
+
+describe('install pipeline (against examples/minimal-shard)', () => {
+  let vault: string;
+
+  beforeEach(async () => {
+    vault = path.join(os.tmpdir(), `shardmind-install-${crypto.randomUUID()}`);
+    await fsp.mkdir(vault, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fsp.rm(vault, { recursive: true, force: true });
+  });
+
+  it('installs with all modules included and writes the full output tree', async () => {
+    const manifest = await parseManifest(path.join(MINIMAL_SHARD, 'shard.yaml'));
+    const schema = await parseSchema(path.join(MINIMAL_SHARD, 'shard-schema.yaml'));
+
+    const selections = defaultModuleSelections(schema);
+    const validator = buildValuesValidator(schema);
+    const values = validator.parse(resolveComputedDefaults(schema, VALUES));
+
+    const result = await runInstall({
+      vaultRoot: vault,
+      manifest,
+      schema,
+      tempDir: MINIMAL_SHARD,
+      resolved: RESOLVED,
+      values,
+      selections,
+    });
+
+    expect(result.fileCount).toBeGreaterThan(0);
+
+    // state.json exists and looks right
+    const state = (await readState(vault)) as ShardState;
+    expect(state).not.toBeNull();
+    expect(state.schema_version).toBe(1);
+    expect(state.shard).toBe('shardmind/minimal');
+    expect(state.version).toBe('0.1.0');
+    expect(state.modules).toEqual(selections);
+    expect(Object.keys(state.files).length).toBe(result.fileCount);
+
+    // shard-values.yaml written, parseable, round-trips the values
+    const valuesYaml = await fsp.readFile(path.join(vault, 'shard-values.yaml'), 'utf-8');
+    expect(valuesYaml).toContain('user_name: Alice');
+    expect(valuesYaml).toContain('vault_purpose: engineering');
+
+    // Home.md rendered with substituted values
+    const home = await fsp.readFile(path.join(vault, 'Home.md'), 'utf-8');
+    expect(home).toContain('Welcome to your vault, Alice.');
+    expect(home).toContain('Vault entry point for Acme Labs');
+
+    // brain module file exists (required module)
+    const northStar = await fsp.readFile(path.join(vault, 'brain/North Star.md'), 'utf-8');
+    expect(northStar).toContain('Goals and focus areas for Alice');
+
+    // extras module files exist (included by default): its command renders to .claude/commands/
+    await expect(
+      fsp.access(path.join(vault, '.claude/commands/example-command.md')),
+    ).resolves.toBeUndefined();
+
+    // Cached state artifacts
+    await expect(fsp.access(path.join(vault, '.shardmind/state.json'))).resolves.toBeUndefined();
+    await expect(fsp.access(path.join(vault, '.shardmind/shard.yaml'))).resolves.toBeUndefined();
+    await expect(fsp.access(path.join(vault, '.shardmind/shard-schema.yaml'))).resolves.toBeUndefined();
+    await expect(fsp.access(path.join(vault, '.shardmind/templates'))).resolves.toBeUndefined();
+  });
+
+  it('excludes files for modules marked excluded', async () => {
+    const manifest = await parseManifest(path.join(MINIMAL_SHARD, 'shard.yaml'));
+    const schema = await parseSchema(path.join(MINIMAL_SHARD, 'shard-schema.yaml'));
+
+    const selections = defaultModuleSelections(schema);
+    selections['extras'] = 'excluded';
+
+    const validator = buildValuesValidator(schema);
+    const values = validator.parse(resolveComputedDefaults(schema, VALUES));
+
+    await runInstall({
+      vaultRoot: vault,
+      manifest,
+      schema,
+      tempDir: MINIMAL_SHARD,
+      resolved: RESOLVED,
+      values,
+      selections,
+    });
+
+    const state = (await readState(vault)) as ShardState;
+    expect(state.modules['extras']).toBe('excluded');
+
+    // extras command should not exist
+    await expect(
+      fsp.access(path.join(vault, '.claude/commands/example-command.md')),
+    ).rejects.toThrow();
+    // brain/ still exists (required)
+    await expect(fsp.access(path.join(vault, 'brain'))).resolves.toBeUndefined();
+  });
+
+  it('records sha256 hash per file in state', async () => {
+    const manifest = await parseManifest(path.join(MINIMAL_SHARD, 'shard.yaml'));
+    const schema = await parseSchema(path.join(MINIMAL_SHARD, 'shard-schema.yaml'));
+    const selections = defaultModuleSelections(schema);
+    const validator = buildValuesValidator(schema);
+    const values = validator.parse(resolveComputedDefaults(schema, VALUES));
+
+    await runInstall({
+      vaultRoot: vault,
+      manifest,
+      schema,
+      tempDir: MINIMAL_SHARD,
+      resolved: RESOLVED,
+      values,
+      selections,
+    });
+
+    const state = (await readState(vault)) as ShardState;
+    const home = state.files['Home.md'];
+    expect(home).toBeDefined();
+    expect(home?.ownership).toBe('managed');
+    expect(home?.rendered_hash).toMatch(/^[a-f0-9]{64}$/);
+
+    // Hash matches the file on disk
+    const diskContent = await fsp.readFile(path.join(vault, 'Home.md'));
+    const diskHash = crypto.createHash('sha256').update(diskContent).digest('hex');
+    expect(home?.rendered_hash).toBe(diskHash);
+  });
+
+  it('dry-run does not write any files', async () => {
+    const manifest = await parseManifest(path.join(MINIMAL_SHARD, 'shard.yaml'));
+    const schema = await parseSchema(path.join(MINIMAL_SHARD, 'shard-schema.yaml'));
+    const selections = defaultModuleSelections(schema);
+    const validator = buildValuesValidator(schema);
+    const values = validator.parse(resolveComputedDefaults(schema, VALUES));
+
+    await runInstall({
+      vaultRoot: vault,
+      manifest,
+      schema,
+      tempDir: MINIMAL_SHARD,
+      resolved: RESOLVED,
+      values,
+      selections,
+      dryRun: true,
+    });
+
+    await expect(fsp.access(path.join(vault, 'Home.md'))).rejects.toThrow();
+    await expect(fsp.access(path.join(vault, '.shardmind'))).rejects.toThrow();
+  });
+
+  it('planOutputs reports per-module file counts', async () => {
+    const schema = await parseSchema(path.join(MINIMAL_SHARD, 'shard-schema.yaml'));
+    const selections = defaultModuleSelections(schema);
+    const { moduleFileCounts, plan } = await planOutputs(schema, MINIMAL_SHARD, selections);
+
+    expect(plan.totalFiles).toBeGreaterThan(0);
+    expect(moduleFileCounts['brain']).toBeGreaterThan(0);
+    // extras contributes a command and a partial; the partial has no output file on its own
+    expect(moduleFileCounts['extras']).toBeGreaterThanOrEqual(1);
+  });
+
+  it('collision detection flags pre-existing files at planned output paths', async () => {
+    await fsp.writeFile(path.join(vault, 'Home.md'), 'user content', 'utf-8');
+
+    const schema = await parseSchema(path.join(MINIMAL_SHARD, 'shard-schema.yaml'));
+    const selections = defaultModuleSelections(schema);
+    const { outputs } = await planOutputs(schema, MINIMAL_SHARD, selections);
+    const collisions = await detectCollisions(vault, outputs.map((o) => o.outputPath));
+
+    expect(collisions.length).toBeGreaterThan(0);
+    expect(collisions.some((c) => c.outputPath === 'Home.md')).toBe(true);
+  });
+
+  it('backupCollisions renames existing files out of the way', async () => {
+    await fsp.writeFile(path.join(vault, 'Home.md'), 'user content', 'utf-8');
+
+    const schema = await parseSchema(path.join(MINIMAL_SHARD, 'shard-schema.yaml'));
+    const selections = defaultModuleSelections(schema);
+    const { outputs } = await planOutputs(schema, MINIMAL_SHARD, selections);
+    const collisions = await detectCollisions(vault, outputs.map((o) => o.outputPath));
+
+    const backups = await backupCollisions(collisions);
+    expect(backups.length).toBeGreaterThan(0);
+    await expect(fsp.access(path.join(vault, 'Home.md'))).rejects.toThrow();
+    await expect(fsp.access(backups[0]!.backupPath)).resolves.toBeUndefined();
+  });
+
+  it('rollback removes all written files and the .shardmind directory', async () => {
+    const manifest = await parseManifest(path.join(MINIMAL_SHARD, 'shard.yaml'));
+    const schema = await parseSchema(path.join(MINIMAL_SHARD, 'shard-schema.yaml'));
+    const selections = defaultModuleSelections(schema);
+    const validator = buildValuesValidator(schema);
+    const values = validator.parse(resolveComputedDefaults(schema, VALUES));
+
+    const result = await runInstall({
+      vaultRoot: vault,
+      manifest,
+      schema,
+      tempDir: MINIMAL_SHARD,
+      resolved: RESOLVED,
+      values,
+      selections,
+    });
+
+    await rollbackInstall(vault, result.writtenPaths);
+
+    // All originally-written files are gone
+    for (const p of result.writtenPaths) {
+      await expect(fsp.access(path.join(vault, p))).rejects.toThrow();
+    }
+    // .shardmind/ is gone
+    await expect(fsp.access(path.join(vault, '.shardmind'))).rejects.toThrow();
+  });
+});

--- a/tests/unit/install-plan.test.ts
+++ b/tests/unit/install-plan.test.ts
@@ -12,6 +12,7 @@ import {
   missingValueKeys,
   defaultModuleSelections,
 } from '../../source/core/install-plan.js';
+import { hashValues } from '../../source/core/install-runner.js';
 import type { ShardSchema } from '../../source/runtime/types.js';
 
 function schema(values: ShardSchema['values'], modules: ShardSchema['modules'] = {}): ShardSchema {
@@ -282,6 +283,35 @@ describe('missingValueKeys', () => {
 
     const missing = missingValueKeys(s, {});
     expect(missing).toEqual(['z', 'a', 'm']);
+  });
+});
+
+describe('hashValues', () => {
+  it('is stable regardless of top-level key order', () => {
+    const a = hashValues({ name: 'alice', org: 'acme' });
+    const b = hashValues({ org: 'acme', name: 'alice' });
+    expect(a).toBe(b);
+  });
+
+  it('is stable regardless of nested key order', () => {
+    const a = hashValues({ opts: { foo: 1, bar: 2 }, list: [{ k: 'x' }] });
+    const b = hashValues({ list: [{ k: 'x' }], opts: { bar: 2, foo: 1 } });
+    expect(a).toBe(b);
+  });
+
+  it('preserves nested object keys (does not whitelist by top-level keys)', () => {
+    // The previous `JSON.stringify(v, Object.keys(v).sort())` approach
+    // applied top-level keys as a whitelist to nested objects too, so
+    // different nested values hashed identically. Guard against regression.
+    const a = hashValues({ outer: { inner_a: 1 } });
+    const b = hashValues({ outer: { inner_b: 2 } });
+    expect(a).not.toBe(b);
+  });
+
+  it('distinguishes arrays of objects by their contents', () => {
+    const a = hashValues({ items: [{ x: 1 }, { x: 2 }] });
+    const b = hashValues({ items: [{ x: 1 }, { x: 3 }] });
+    expect(a).not.toBe(b);
   });
 });
 

--- a/tests/unit/install-plan.test.ts
+++ b/tests/unit/install-plan.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import {
+  resolveComputedDefaults,
+  detectCollisions,
+  backupCollisions,
+  mergePrefill,
+  missingValueKeys,
+  defaultModuleSelections,
+} from '../../source/core/install-plan.js';
+import type { ShardSchema } from '../../source/runtime/types.js';
+
+function schema(values: ShardSchema['values'], modules: ShardSchema['modules'] = {}): ShardSchema {
+  return {
+    schema_version: 1,
+    values,
+    groups: [{ id: 'setup', label: 'Setup' }],
+    modules,
+    signals: [],
+    frontmatter: {},
+    migrations: [],
+  };
+}
+
+describe('resolveComputedDefaults', () => {
+  it('evaluates a boolean expression using collected values', () => {
+    const s = schema({
+      vault_purpose: { type: 'select', required: true, message: '', group: 'setup', options: [{ value: 'engineering', label: 'Eng' }, { value: 'research', label: 'Res' }] },
+      qmd_enabled: { type: 'boolean', message: '', default: "{{ vault_purpose == 'engineering' }}", group: 'setup' },
+    });
+
+    const result = resolveComputedDefaults(s, { vault_purpose: 'engineering' });
+    expect(result['qmd_enabled']).toBe(true);
+
+    const result2 = resolveComputedDefaults(s, { vault_purpose: 'research' });
+    expect(result2['qmd_enabled']).toBe(false);
+  });
+
+  it('leaves already-answered values untouched', () => {
+    const s = schema({
+      x: { type: 'boolean', message: '', default: '{{ true }}', group: 'setup' },
+    });
+
+    const result = resolveComputedDefaults(s, { x: false });
+    expect(result['x']).toBe(false);
+  });
+
+  it('coerces numbers', () => {
+    const s = schema({
+      n: { type: 'number', message: '', default: '{{ 40 + 2 }}', group: 'setup' },
+    });
+
+    const result = resolveComputedDefaults(s, {});
+    expect(result['n']).toBe(42);
+  });
+
+  it('coerces JSON arrays for list type', () => {
+    const s = schema({
+      tags: { type: 'list', message: '', default: '{{ ["a", "b"] | dump }}', group: 'setup' },
+    });
+
+    const result = resolveComputedDefaults(s, {});
+    expect(result['tags']).toEqual(['a', 'b']);
+  });
+
+  it('throws with code when boolean coercion fails', () => {
+    const s = schema({
+      x: { type: 'boolean', message: '', default: '{{ "maybe" }}', group: 'setup' },
+    });
+
+    expect(() => resolveComputedDefaults(s, {})).toThrowError(
+      expect.objectContaining({ code: 'COMPUTED_DEFAULT_INVALID' }),
+    );
+  });
+
+  it('skips values without a computed default', () => {
+    const s = schema({
+      name: { type: 'string', required: true, message: '', group: 'setup' },
+    });
+
+    const result = resolveComputedDefaults(s, { name: 'alice' });
+    expect(result).toEqual({ name: 'alice' });
+  });
+});
+
+describe('detectCollisions', () => {
+  let vault: string;
+
+  beforeEach(async () => {
+    vault = path.join(os.tmpdir(), `shardmind-coll-${crypto.randomUUID()}`);
+    await fsp.mkdir(vault, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fsp.rm(vault, { recursive: true, force: true });
+  });
+
+  it('returns empty when no planned paths exist on disk', async () => {
+    const result = await detectCollisions(vault, ['Home.md', 'brain/North Star.md']);
+    expect(result).toEqual([]);
+  });
+
+  it('flags existing files with size and mtime', async () => {
+    await fsp.writeFile(path.join(vault, 'Home.md'), 'user content', 'utf-8');
+
+    const result = await detectCollisions(vault, ['Home.md', 'brain/New.md']);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.outputPath).toBe('Home.md');
+    expect(result[0]?.size).toBe('user content'.length);
+    expect(result[0]?.mtime).toBeInstanceOf(Date);
+  });
+
+  it('ignores directories that exist at planned paths', async () => {
+    await fsp.mkdir(path.join(vault, 'Home.md'), { recursive: true });
+
+    const result = await detectCollisions(vault, ['Home.md']);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('backupCollisions', () => {
+  let vault: string;
+
+  beforeEach(async () => {
+    vault = path.join(os.tmpdir(), `shardmind-bkup-${crypto.randomUUID()}`);
+    await fsp.mkdir(vault, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fsp.rm(vault, { recursive: true, force: true });
+  });
+
+  it('renames each colliding file with a timestamped backup suffix', async () => {
+    const original = path.join(vault, 'Home.md');
+    await fsp.writeFile(original, 'user content', 'utf-8');
+
+    const records = await backupCollisions(
+      [{ outputPath: 'Home.md', absolutePath: original, size: 12, mtime: new Date() }],
+      new Date('2026-04-18T10:30:00.123Z'),
+    );
+
+    expect(records).toHaveLength(1);
+    expect(records[0]?.backupPath).toBe(`${original}.shardmind-backup-2026-04-18T10-30-00`);
+
+    await expect(fsp.access(original)).rejects.toThrow();
+    const backup = await fsp.readFile(records[0]!.backupPath, 'utf-8');
+    expect(backup).toBe('user content');
+  });
+});
+
+describe('mergePrefill', () => {
+  it('prefers prefill values over schema defaults', () => {
+    const s = schema({
+      org: { type: 'string', message: '', default: 'Independent', group: 'setup' },
+      name: { type: 'string', required: true, message: '', group: 'setup' },
+    });
+
+    const merged = mergePrefill(s, { org: 'Acme', name: 'alice' });
+    expect(merged).toEqual({ org: 'Acme', name: 'alice' });
+  });
+
+  it('uses static defaults when prefill is absent', () => {
+    const s = schema({
+      org: { type: 'string', message: '', default: 'Independent', group: 'setup' },
+      name: { type: 'string', required: true, message: '', group: 'setup' },
+    });
+
+    const merged = mergePrefill(s, {});
+    expect(merged).toEqual({ org: 'Independent' });
+  });
+
+  it('does not fill computed defaults (deferred to resolveComputedDefaults)', () => {
+    const s = schema({
+      purpose: { type: 'select', required: true, message: '', group: 'setup', options: [{ value: 'x', label: 'x' }] },
+      qmd: { type: 'boolean', message: '', default: "{{ purpose == 'x' }}", group: 'setup' },
+    });
+
+    const merged = mergePrefill(s, { purpose: 'x' });
+    expect(merged).toEqual({ purpose: 'x' });
+    expect(merged['qmd']).toBeUndefined();
+  });
+});
+
+describe('missingValueKeys', () => {
+  it('returns keys that need prompting', () => {
+    const s = schema({
+      a: { type: 'string', required: true, message: '', group: 'setup' },
+      b: { type: 'string', message: '', default: 'x', group: 'setup' },
+      c: { type: 'string', required: true, message: '', group: 'setup' },
+    });
+
+    const missing = missingValueKeys(s, { a: 'hi', b: 'x' });
+    expect(missing).toEqual(['c']);
+  });
+
+  it('excludes values with computed defaults', () => {
+    const s = schema({
+      a: { type: 'string', required: true, message: '', group: 'setup' },
+      b: { type: 'boolean', message: '', default: '{{ true }}', group: 'setup' },
+    });
+
+    const missing = missingValueKeys(s, {});
+    expect(missing).toEqual(['a']);
+  });
+
+  it('preserves schema declaration order', () => {
+    const s = schema({
+      z: { type: 'string', required: true, message: '', group: 'setup' },
+      a: { type: 'string', required: true, message: '', group: 'setup' },
+      m: { type: 'string', required: true, message: '', group: 'setup' },
+    });
+
+    const missing = missingValueKeys(s, {});
+    expect(missing).toEqual(['z', 'a', 'm']);
+  });
+});
+
+describe('defaultModuleSelections', () => {
+  it('marks all modules as included by default', () => {
+    const s = schema({}, {
+      core: { label: 'Core', paths: ['core/'], removable: false },
+      extras: { label: 'Extras', paths: ['extras/'], removable: true },
+    });
+
+    const selections = defaultModuleSelections(s);
+    expect(selections).toEqual({ core: 'included', extras: 'included' });
+  });
+});

--- a/tests/unit/install-plan.test.ts
+++ b/tests/unit/install-plan.test.ts
@@ -7,6 +7,7 @@ import {
   resolveComputedDefaults,
   detectCollisions,
   backupCollisions,
+  restoreBackups,
   mergePrefill,
   missingValueKeys,
   defaultModuleSelections,
@@ -113,11 +114,12 @@ describe('detectCollisions', () => {
     expect(result[0]?.mtime).toBeInstanceOf(Date);
   });
 
-  it('ignores directories that exist at planned paths', async () => {
+  it('flags existing directories at planned paths (would cause EISDIR on write)', async () => {
     await fsp.mkdir(path.join(vault, 'Home.md'), { recursive: true });
 
     const result = await detectCollisions(vault, ['Home.md']);
-    expect(result).toEqual([]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.kind).toBe('directory');
   });
 });
 
@@ -138,7 +140,7 @@ describe('backupCollisions', () => {
     await fsp.writeFile(original, 'user content', 'utf-8');
 
     const records = await backupCollisions(
-      [{ outputPath: 'Home.md', absolutePath: original, size: 12, mtime: new Date() }],
+      [{ outputPath: 'Home.md', absolutePath: original, size: 12, mtime: new Date(), kind: 'file' }],
       new Date('2026-04-18T10:30:00.123Z'),
     );
 
@@ -148,6 +150,71 @@ describe('backupCollisions', () => {
     await expect(fsp.access(original)).rejects.toThrow();
     const backup = await fsp.readFile(records[0]!.backupPath, 'utf-8');
     expect(backup).toBe('user content');
+  });
+
+  it('appends a counter when a backup path already exists (same-second collisions)', async () => {
+    const original = path.join(vault, 'Home.md');
+    const stamp = '2026-04-18T10-30-00';
+    // Pre-seed a stale backup at the canonical name
+    await fsp.writeFile(`${original}.shardmind-backup-${stamp}`, 'stale', 'utf-8');
+    await fsp.writeFile(original, 'new user content', 'utf-8');
+
+    const records = await backupCollisions(
+      [{ outputPath: 'Home.md', absolutePath: original, size: 16, mtime: new Date(), kind: 'file' }],
+      new Date('2026-04-18T10:30:00.000Z'),
+    );
+
+    expect(records[0]?.backupPath).toBe(`${original}.shardmind-backup-${stamp}.1`);
+    const stale = await fsp.readFile(`${original}.shardmind-backup-${stamp}`, 'utf-8');
+    expect(stale).toBe('stale'); // untouched
+  });
+});
+
+describe('restoreBackups', () => {
+  let vault: string;
+
+  beforeEach(async () => {
+    vault = path.join(os.tmpdir(), `shardmind-restore-${crypto.randomUUID()}`);
+    await fsp.mkdir(vault, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fsp.rm(vault, { recursive: true, force: true });
+  });
+
+  it('moves backup files back to their original paths', async () => {
+    const original = path.join(vault, 'Home.md');
+    const backup = `${original}.shardmind-backup-2026-04-18T10-30-00`;
+    await fsp.writeFile(backup, 'original content', 'utf-8');
+    // Simulate a post-install artifact at the original path
+    await fsp.writeFile(original, 'new install content', 'utf-8');
+
+    const { restored, failed } = await restoreBackups([
+      { originalPath: original, backupPath: backup },
+    ]);
+
+    expect(restored).toHaveLength(1);
+    expect(failed).toHaveLength(0);
+    const restoredContent = await fsp.readFile(original, 'utf-8');
+    expect(restoredContent).toBe('original content');
+    await expect(fsp.access(backup)).rejects.toThrow();
+  });
+
+  it('continues past individual failures and reports them', async () => {
+    const goodOriginal = path.join(vault, 'good.md');
+    const goodBackup = `${goodOriginal}.shardmind-backup-stamp`;
+    await fsp.writeFile(goodBackup, 'good', 'utf-8');
+
+    const missingBackup = path.join(vault, 'missing.md.shardmind-backup-stamp');
+
+    const { restored, failed } = await restoreBackups([
+      { originalPath: goodOriginal, backupPath: goodBackup },
+      { originalPath: path.join(vault, 'missing.md'), backupPath: missingBackup },
+    ]);
+
+    expect(restored).toHaveLength(1);
+    expect(failed).toHaveLength(1);
+    expect(failed[0]?.originalPath).toContain('missing.md');
   });
 });
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -12,7 +12,10 @@ export default defineConfig([
   },
   // Pastel commands — file-system routing requires separate files in dist/commands/
   {
-    entry: { 'commands/index': 'source/commands/index.tsx' },
+    entry: {
+      'commands/index': 'source/commands/index.tsx',
+      'commands/install': 'source/commands/install.tsx',
+    },
     format: ['esm'],
     dts: true,
     target: 'node18',


### PR DESCRIPTION
## Summary

Closes #8. Milestone 2's main deliverable.

Orchestrates every core module built to date (manifest, schema, download, renderer, modules, state, registry) into the first user-facing command. Built against the \"best UX over shortcuts\" brief agreed in chat.

## What's in

### Core (testable without Ink)
- **\`source/core/install-plan.ts\`** — pure orchestration: \`resolveComputedDefaults\`, \`detectCollisions\`, \`backupCollisions\`, \`mergePrefill\`, \`missingValueKeys\`, \`defaultModuleSelections\`
- **\`source/core/install-runner.ts\`** — the actual install pipeline: \`planOutputs\`, \`runInstall\` (render + copy + write + cache + state), \`rollbackInstall\`
- **\`source/core/hook.ts\`** — detects \`hooks/post-install.ts\`, defers execution (tracked in #30)

### Ink components (\`source/components/\`)
- **\`Header\`** — shard banner (name, version, description, persona)
- **\`ValueInput\`** — per-value input supporting string/boolean/number/select/multiselect/list with inline zod validation
- **\`ModuleReview\`** — multiselect of removable modules with label + per-module file count + live install-total
- **\`CollisionReview\`** — list of existing files that would be overwritten; choose backup / overwrite / cancel
- **\`ExistingInstallGate\`** — state display when \`.shardmind/\` exists; choose run-update / reinstall / cancel. Reinstall requires typing \`REINSTALL\` verbatim.
- **\`InstallProgress\`** — spinner + progress bar + per-file line (verbose)
- **\`InstallWizard\`** — step state machine (header → values → computed-preview → modules → confirm), Esc for back-nav, keyboard legend footer
- **\`Summary\`** — green banner, file count + duration, backup list, hook status, platform-aware \"Next: open …\" hint

### Command
- **\`source/commands/install.tsx\`** — Pastel entry. Args: \`[shardRef]\`. Options: \`--values <file>\`, \`--yes\`, \`--verbose\`, \`--dry-run\`. State machine phases route users through the right components.

### UX decisions beyond IMPLEMENTATION.md §6.3
- Collision detection with three-way choice + backup-to-timestamped-file path
- Existing-install gate with typed-confirm reinstall (no blind \"reinstall?\" prompt)
- Back-navigation via Esc — answers persist on re-entry
- Inline validation via the zod validator \`schema.ts\` already generates
- Computed-default preview shows resolved value + the source expression
- Per-module file counts in the multiselect + live running total
- Progress during render, time-to-summary
- Next-step hint (\`open\` / \`start\` / \`xdg-open\` per platform)
- Rollback uses the recorded \`writtenPaths\` to unwind cleanly

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 127 passing (17 new install-plan unit + 8 new install integration)
- [x] Integration test covers: full install with all modules, module exclusion, hash correctness, dry-run, plan enumeration, collision detection, backup, rollback
- [x] \`npm run build\` — clean output, \`dist/commands/install.js\` is 82KB
- [x] \`node dist/cli.js install --help\` — all four flags + positional arg listed correctly
- [ ] Manual TUI smoke (cannot automate with current tooling):
  - [ ] Interactive install of minimal-shard into an empty dir
  - [ ] Collision flow in a dir with pre-existing files
  - [ ] Existing-install gate with all three options
  - [ ] Non-interactive \`--values values.yaml --yes\`
  - [ ] \`--dry-run\` preview
  - [ ] Deliberate render failure triggers rollback

Type checking and the test suite verify code correctness — the Ink TUI layers need manual verification before Milestone 5 (obsidian-mind) ships.

## Spec gaps flagged

- **#30** — post-install hook runtime. Placeholder is in place; install succeeds without running the hook. Real execution mechanism (tsx spawn vs jiti) decided before Milestone 5.

## Roadmap

- [x] \`commands/install.tsx\` bullet ticked in Milestone 2
- [x] Integration test bullet ticked — against \`examples/minimal-shard\` (real obsidian-mind verification deferred to Milestone 5 when the shard exists)
- Added a new bullet in Milestone 5 linking #30 as a gate on the obsidian-mind conversion

## Out of scope (intentional)

- Hook execution (see #30)
- DiffView.tsx (update command only — Milestone 4)
- \`shardmind update\` itself (Milestone 4)
- Dependency resolution / multi-shard installs (v0.2 per VISION.md §21)
- Resume after partial-install crash (v0.2)