### PR TITLE
polish: v0.1 architecture + docs pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Node 18 hit EOL April 2025; vitest@4 requires Node 20+.
-        # Runtime engines in package.json still support Node 18+ — this
-        # matrix only constrains where we RUN the dev tooling.
-        node-version: [20, 22, 24]
+        # Node 22+ matches obsidian-mind's requirement (hook TS strip
+        # via --experimental-strip-types, stable in 22.6+). Node 18 hit
+        # EOL April 2025; Node 20 EOL April 2026. Keep the matrix
+        # aligned with the flagship shard's floor.
+        node-version: [22, 24]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        # Node 18 hit EOL April 2025; vitest@4 requires Node 20+.
+        # Runtime engines in package.json still support Node 18+ — this
+        # matrix only constrains where we RUN the dev tooling.
+        node-version: [20, 22, 24]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `examples/minimal-shard/` — test shard for development
 - `source/runtime/types.ts` — 34 shared TypeScript interfaces
 - CI/CD: GitHub Actions for typecheck, test, build, npm publish
+- **Core engine modules** (v0.1 Milestone 1): manifest, schema, download, renderer, modules, state, registry, install-planner, install-executor, hook, fs-utils, state-migrator, vault-paths
+- **Install command** (v0.1 Milestone 2): `shardmind install <shardRef>` with Ink wizard, collision detection + backup/overwrite/cancel, existing-install gate with typed REINSTALL confirm, back-navigation via Esc, computed-default preview, per-module file counts + live total, progress display, SIGINT rollback, `--dry-run` / `--values` / `--yes` / `--verbose` flags
+- `docs/AUTHORING.md` — 9-section shard author guide
+- `docs/ERRORS.md` — every `ShardMindError` code's meaning, cause, remedy
+- `schemas/shard.schema.json` + `schemas/shard-schema.schema.json` — JSON Schema files for editor tooling
+- JSDoc on every `shardmind/runtime` public export
+- `ShardState.tarball_sha256` — source-drift detection anchor for update command
+- State migration framework (`source/core/state-migrator.ts`) for future `schema_version` bumps
+- `source/core/vault-paths.ts` — centralized path constants
+- `source/core/renderer.ts:buildRenderContext` — shared context builder for install + update
+- Reserved-name validation in `parseSchema` (shard, install_date, year, included_modules, values)
+- `source/commands/hooks/use-install-machine.ts` — extracted state machine hook
+
+### Changed
+
+- Upgraded `vitest` to `^4.1.4` and `diff` to `^9.0.0` (via `npm audit fix`, zero vulnerabilities).
+- Renamed `install-plan.ts` → `install-planner.ts` and `install-runner.ts` → `install-executor.ts` to match I/O concerns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,36 +1,10 @@
 # Changelog
 
-All notable changes to ShardMind will be documented in this file.
+Populated on each release. Between releases:
 
-The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+- **What's merged but not released:** `git log`
+- **What's planned:** [`ROADMAP.md`](ROADMAP.md)
 
-## [Unreleased]
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### Added
-
-- Project scaffold: Pastel + Ink + tsup + vitest
-- `docs/ARCHITECTURE.md` — 22-section architecture spec
-- `docs/IMPLEMENTATION.md` — 10-section implementation spec
-- `VISION.md` — origin story, architectural bets, scope guardrails
-- `ROADMAP.md` — milestones linked to GitHub issues
-- `examples/minimal-shard/` — test shard for development
-- `source/runtime/types.ts` — 34 shared TypeScript interfaces
-- CI/CD: GitHub Actions for typecheck, test, build, npm publish
-- **Core engine modules** (v0.1 Milestone 1): manifest, schema, download, renderer, modules, state, registry, install-planner, install-executor, hook, fs-utils, state-migrator, vault-paths
-- **Install command** (v0.1 Milestone 2): `shardmind install <shardRef>` with Ink wizard, collision detection + backup/overwrite/cancel, existing-install gate with typed REINSTALL confirm, back-navigation via Esc, computed-default preview, per-module file counts + live total, progress display, SIGINT rollback, `--dry-run` / `--values` / `--yes` / `--verbose` flags
-- `docs/AUTHORING.md` — 9-section shard author guide
-- `docs/ERRORS.md` — every `ShardMindError` code's meaning, cause, remedy
-- `schemas/shard.schema.json` + `schemas/shard-schema.schema.json` — JSON Schema files for editor tooling
-- JSDoc on every `shardmind/runtime` public export
-- `ShardState.tarball_sha256` — source-drift detection anchor for update command
-- State migration framework (`source/core/state-migrator.ts`) for future `schema_version` bumps
-- `source/core/vault-paths.ts` — centralized path constants
-- `source/core/renderer.ts:buildRenderContext` — shared context builder for install + update
-- Reserved-name validation in `parseSchema` (shard, install_date, year, included_modules, values)
-- `source/commands/hooks/use-install-machine.ts` — extracted state machine hook
-
-### Changed
-
-- Upgraded `vitest` to `^4.1.4` and `diff` to `^9.0.0` (via `npm audit fix`, zero vulnerabilities).
-- Renamed `install-plan.ts` → `install-planner.ts` and `install-runner.ts` → `install-executor.ts` to match I/O concerns.
+<!-- First release: v0.1.0, target end of Milestone 6. -->

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://www.typescriptlang.org"><img src="https://img.shields.io/badge/typescript-5.0%2B-3178C6" alt="TypeScript"></a>
-  <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-18%2B-339933" alt="Node"></a>
+  <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-22%2B-339933" alt="Node"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
 </p>
 
@@ -169,7 +169,7 @@ Shard authors choose which agents to support. A shard can ship `CLAUDE.md` only,
 
 ## Requirements
 
-- [Node.js](https://nodejs.org) 18+
+- [Node.js](https://nodejs.org) 22+ (matches obsidian-mind's hook runtime requirement)
 - [Git](https://git-scm.com)
 - [Obsidian](https://obsidian.md) 1.12+ (for CLI support)
 - [QMD](https://github.com/tobi/qmd) (optional, for semantic search)

--- a/README.md
+++ b/README.md
@@ -145,14 +145,25 @@ Shard authors choose which agents to support. A shard can ship `CLAUDE.md` only,
 
 ## Documentation
 
+### For shard authors
+
 | Document | What |
 |----------|------|
-| [`VISION.md`](VISION.md) | Origin story, architectural bets, scope guardrails, competitive moat |
-| [`ROADMAP.md`](ROADMAP.md) | v0.1 milestones (linked to issues), v0.2 deferred, v1.0 ecosystem |
-| [`CLAUDE.md`](CLAUDE.md) | Spec-driven development guide for building ShardMind with AI agents |
+| [`docs/AUTHORING.md`](docs/AUTHORING.md) | **Start here.** Every file and concept a shard author needs. |
+| [`schemas/shard.schema.json`](schemas/shard.schema.json) | JSON Schema for `shard.yaml` — drop into VS Code for autocomplete + validation. |
+| [`schemas/shard-schema.schema.json`](schemas/shard-schema.schema.json) | JSON Schema for `shard-schema.yaml`. |
+| [`examples/minimal-shard/`](examples/minimal-shard/) | Minimal reference shard — 4 values, 2 modules, partials, signals. |
+
+### For users + contributors
+
+| Document | What |
+|----------|------|
+| [`docs/ERRORS.md`](docs/ERRORS.md) | Every `ShardMindError` code: meaning, cause, remedy. |
+| [`VISION.md`](VISION.md) | Origin story, architectural bets, scope guardrails, competitive moat. |
+| [`ROADMAP.md`](ROADMAP.md) | v0.1 milestones (linked to issues), v0.2 deferred, v1.0 ecosystem. |
 | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | The what and why. 22 sections. Ownership model, values layer, modules, signals. |
 | [`docs/IMPLEMENTATION.md`](docs/IMPLEMENTATION.md) | The how, exactly. 10 modules with TypeScript signatures, 17 merge fixtures, 6-day build plan. |
-| [`examples/minimal-shard/`](examples/minimal-shard/) | Minimal test shard for development — 4 values, 2 modules, partials, signals. |
+| [`CLAUDE.md`](CLAUDE.md) | Spec-driven development guide for building ShardMind with AI agents. |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -99,6 +99,19 @@ Deferred from v0.1. Build only after v0.1 is stable and adoption signals are rea
 - [ ] Scaffold `shard.yaml`, `shard-schema.yaml`, `templates/` from prompts
 - [ ] Generate starter module structure
 
+### Engine polish (from v0.1 review)
+
+Deferred items surfaced during the v0.1 polish-pass architecture audit. None are blockers for shipping v0.1; all are worth doing before v0.2 marketing.
+
+- [ ] VaultFS abstraction with built-in rollback tracking ([#33](https://github.com/breferrari/shardmind/issues/33))
+- [ ] `shardmind validate <shard>` command ([#34](https://github.com/breferrari/shardmind/issues/34))
+- [ ] Pre-install template syntax lint ([#35](https://github.com/breferrari/shardmind/issues/35))
+- [ ] Debug logging (`SHARDMIND_DEBUG` env var) ([#36](https://github.com/breferrari/shardmind/issues/36))
+- [ ] `NO_COLOR` / `FORCE_COLOR` respect across Ink components ([#37](https://github.com/breferrari/shardmind/issues/37))
+- [ ] `ink-testing-library` integration for TUI unit tests ([#38](https://github.com/breferrari/shardmind/issues/38))
+- [ ] Alternate registry configurability (GHE, private, custom URL) ([#39](https://github.com/breferrari/shardmind/issues/39))
+- [ ] Encode state-schema migration rules (uses v0.1 framework) ([#40](https://github.com/breferrari/shardmind/issues/40))
+
 ---
 
 ## v1.0.0 — Ecosystem (2026–2027)
@@ -114,7 +127,7 @@ Only after the engine is proven, the flagship shard is stable, and community sha
 
 ### Community
 
-- [ ] Shard authoring guide (docs/AUTHORING.md)
+- [x] Shard authoring guide ([`docs/AUTHORING.md`](docs/AUTHORING.md), shipped in v0.1 polish pass)
 - [ ] Shard validation CI (GitHub Action for shard authors)
 - [ ] Community shard listing
 - [ ] Fork-to-shard conversion guide (for obsidian-mind fork authors)

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -55,7 +55,7 @@ license: MIT
 homepage: https://github.com/breferrari/obsidian-mind
 
 requires:
-  node: ">=18.0.0"
+  node: ">=22.0.0"
 
 hooks:
   post-install: hooks/post-install.ts

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -1,0 +1,334 @@
+# Authoring a ShardMind shard
+
+This guide walks through every file and concept a shard author needs. Read [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) first if you want the "why"; this document covers the "how".
+
+## 1. What is a shard
+
+A shard is a git repository that ShardMind installs into a user's vault. It ships four things:
+
+1. **Templates** (`templates/`) — Nunjucks-rendered markdown, config, and settings files.
+2. **Declarations** (`shard.yaml`, `shard-schema.yaml`) — identity, values, modules, signals.
+3. **Resources** (`scripts/`, `utilities/`, `skills/`, `codex/`, `commands/`, `agents/`) — copied verbatim.
+4. **Hooks** (`hooks/*.ts`, optional) — post-install / post-update lifecycle scripts.
+
+Users run `shardmind install <namespace>/<shard>`. The engine downloads the tarball, prompts for values, lets the user opt out of removable modules, renders templates, writes state, and runs your hook. Users never edit your shard directly — they edit their vault, and the next `shardmind update` merges upstream changes into their customizations via three-way merge.
+
+## 2. File layout
+
+```
+your-shard/
+├── shard.yaml              # manifest — who you are
+├── shard-schema.yaml       # schema — questions, modules, signals
+├── templates/              # Nunjucks templates, rendered into the vault
+│   ├── Home.md.njk
+│   ├── CLAUDE.md.njk
+│   └── brain/
+│       └── North Star.md.njk
+├── commands/               # Claude Code command files (copied verbatim)
+│   └── reflect.md
+├── agents/                 # Claude Code agent files (copied verbatim)
+├── scripts/                # Utility scripts
+├── utilities/              # Utility modules
+├── skills/                 # Skills
+├── codex/                  # Codex prompts → .codex/prompts/
+├── hooks/                  # Lifecycle hooks
+│   └── post-install.ts
+└── README.md
+```
+
+Minimum: `shard.yaml`, `shard-schema.yaml`, and `templates/`. Everything else is optional.
+
+## 3. `shard.yaml` — the manifest
+
+Identity + metadata. Validated by [`schemas/shard.schema.json`](../schemas/shard.schema.json).
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/breferrari/shardmind/main/schemas/shard.schema.json
+
+apiVersion: v1
+name: obsidian-mind
+namespace: breferrari
+version: 3.5.0
+description: "AI-augmented vault template for research and engineering"
+persona: "Knowledge workers who think in Markdown"
+license: MIT
+homepage: https://github.com/breferrari/obsidian-mind
+
+requires:
+  node: ">=18.0.0"
+
+hooks:
+  post-install: hooks/post-install.ts
+  post-update: hooks/post-update.ts
+```
+
+### Field reference
+
+| Field | Required | Notes |
+|---|---|---|
+| `apiVersion` | yes | Always `v1` in v0.x. |
+| `name` | yes | Lowercase alphanumeric + hyphens. By convention matches your repo name. |
+| `namespace` | yes | Usually your GitHub username. Lowercase alphanumeric + hyphens. |
+| `version` | yes | Valid semver. Release tag must be `v<version>` (e.g., `v3.5.0`). |
+| `description` | no | One line shown in the install header. |
+| `persona` | no | Shown in the header as "for <persona>". |
+| `license` | no | SPDX identifier. |
+| `homepage` | no | URL. |
+| `requires.obsidian` | no | Semver range. Advisory only in v0.1. |
+| `requires.node` | no | Semver range. Applied when hooks run. |
+| `dependencies` | no | Array of `{ name, namespace, version }`. Vendored in v0.1 (pre-install manually); auto-fetched in v0.2+. |
+| `hooks.post-install` | no | Path relative to shard root. Runs after first install. |
+| `hooks.post-update` | no | Path relative to shard root. Runs after update. |
+
+## 4. `shard-schema.yaml` — the schema
+
+Declares questions, module toggles, signals, frontmatter rules, and migrations. Validated by [`schemas/shard-schema.schema.json`](../schemas/shard-schema.schema.json).
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/breferrari/shardmind/main/schemas/shard-schema.schema.json
+
+schema_version: 1
+
+values:
+  user_name:
+    type: string
+    required: true
+    message: "Your name"
+    group: setup
+
+  vault_purpose:
+    type: select
+    required: true
+    message: "How will you use this vault?"
+    options:
+      - { value: engineering, label: "Engineering" }
+      - { value: research,    label: "Research" }
+      - { value: general,     label: "General" }
+    group: setup
+
+  qmd_enabled:
+    type: boolean
+    message: "Enable QMD semantic search?"
+    default: "{{ vault_purpose == 'engineering' }}"
+    group: setup
+
+groups:
+  - id: setup
+    label: "Quick Setup"
+
+modules:
+  brain:
+    label: "Goals, memories, patterns"
+    paths: ["brain/"]
+    removable: false
+
+  extras:
+    label: "Optional features"
+    paths: ["extras/"]
+    partials: ["claude/_extras.md.njk"]
+    commands: ["reflect"]
+    removable: true
+
+signals:
+  - id: DECISION
+    description: "A choice was made"
+    routes_to: "brain/"
+    core: true
+
+frontmatter:
+  global: [date, description, tags]
+  brain-note:
+    required: [date, description]
+    path_match: "brain/*.md"
+
+migrations: []
+```
+
+### `values` — the wizard
+
+Each entry becomes one prompt. Supported `type`s:
+
+| Type | Wizard UI | Validator |
+|---|---|---|
+| `string` | TextInput | any string; `required` blocks empty |
+| `number` | TextInput | finite number; honors `min` / `max` |
+| `boolean` | ConfirmInput (y/n) | bool |
+| `select` | Select | must be one of `options[].value` |
+| `multiselect` | comma-separated text (v0.1) | array of `options[].value` |
+| `list` | comma-separated text | array of strings |
+
+`message` is the prompt text. `hint` is gray helper text. `placeholder` is shown in empty inputs.
+
+**Reserved names** (cannot be used as value keys — they shadow the render context):
+`shard`, `install_date`, `year`, `included_modules`, `values`. Using any of these throws `SCHEMA_RESERVED_NAME` at install.
+
+#### Computed defaults
+
+A `default` string starting with `{{` is evaluated as a Nunjucks expression after all non-computed values have been answered. The evaluation context is the collected values.
+
+```yaml
+qmd_enabled:
+  type: boolean
+  default: "{{ vault_purpose == 'engineering' }}"
+```
+
+Coercion rules:
+- `string` / `select` → raw rendered output
+- `boolean` → expression must render exactly `"true"` or `"false"`
+- `number` → must render a finite number
+- `multiselect` / `list` → must render a JSON array (use Nunjucks `dump`: `"{{ ['a', 'b'] | dump }}"`)
+
+Errors surface at install time as `COMPUTED_DEFAULT_FAILED` or `COMPUTED_DEFAULT_INVALID` with the key named.
+
+### `groups` — wizard sections
+
+Every value's `group` must reference a declared group `id`. Groups drive wizard section titles.
+
+### `modules` — optional feature sets
+
+Users see non-removable modules as locked "always included"; removable modules are checkboxes with label + file count + live install total.
+
+A module owns:
+- `paths` — template directory prefixes (any `.njk` under `brain/` belongs to the `brain` module)
+- `partials` — specific partial templates gated by this module
+- `commands` — command file basenames (from your `commands/`) gated here
+- `agents` — agent file basenames
+- `bases` — base template IDs
+
+Files under `scripts/`, `utilities/`, `skills/`, `codex/` are always copied regardless of module selection — these are framework-level.
+
+### `signals` — LLM routing hints
+
+Declarative "when to route where". Surfaced to agents via `shardmind/runtime`. `core: true` means always active; `module: <id>` gates on a module being included.
+
+### `frontmatter` — per-note-type rules
+
+Shorthand `key: [a, b]` expands to `key: { required: [a, b] }`. Optional `path_match` applies the rule only to matching paths. `global` is the catch-all.
+
+### `migrations` — value migrations
+
+Ordered rules applied to `shard-values.yaml` when the shard version moves forward. Four change types: `rename`, `added`, `removed`, `type_changed`. See `MigrationChange` in `source/runtime/types.ts` for the exact shape.
+
+## 5. Templates
+
+Files under `templates/` use [Nunjucks](https://mozilla.github.io/nunjucks/). Engine settings:
+
+- `autoescape: false` (you're rendering Markdown, not HTML)
+- `trimBlocks: true` / `lstripBlocks: true` (tidy output around `{% ... %}` tags)
+
+### Naming
+
+- `.njk` suffix → template, rendered; suffix is stripped. `Home.md.njk` → `Home.md`.
+- No `.njk` → copy verbatim to the same relative path.
+- `settings.json.njk` is the special-cased rename to `.claude/settings.json`.
+
+### Frontmatter-aware rendering
+
+If a template starts with `---\n...yaml...\n---\n`, frontmatter is:
+1. Rendered as its own Nunjucks pass
+2. Parsed as YAML
+3. Re-serialized with safe escaping (lineWidth 0, trim trailing newline)
+
+The body after the second `---` is rendered in a second pass. This gives you escape-safety on YAML-embedded expressions without manual quoting.
+
+### Render context
+
+Every template has access to:
+
+| Key | Type | Value |
+|---|---|---|
+| `values` | object | Merged user answers (after computed defaults resolved) |
+| `included_modules` | string[] | IDs of modules the user kept |
+| `shard` | `{ name, version }` | From `shard.yaml` |
+| `install_date` | string | ISO-8601 UTC, set once at install |
+| `year` | string | `YYYY` |
+
+Values are spread into the top level too. `{{ user_name }}` works the same as `{{ values.user_name }}`.
+
+### The volatile marker
+
+A template whose first non-whitespace content is `{# shardmind: volatile #}` renders as a volatile file. `shardmind update` skips overwriting volatile files even when the template changed — useful for LLM-maintained indexes, daily notes, wiki-style TOCs. The marker is stripped from the output.
+
+```
+{# shardmind: volatile #}
+# Daily Index
+
+{% for note in daily_notes %}
+- [[{{ note }}]]
+{% endfor %}
+```
+
+### `_each` templates
+
+A template whose output path contains `_each` renders once per entry of a list-typed value. The rendered filename uses the item's `slug` or `name` field for the path segment that replaces `_each`.
+
+## 6. Hooks
+
+`hooks/post-install.ts` (and `post-update.ts`) are TypeScript files with a default async export:
+
+```ts
+import type { HookContext } from 'shardmind/runtime';
+
+export default async function(ctx: HookContext): Promise<void> {
+  console.log(`Welcome, ${ctx.values.user_name}. Installed ${ctx.shard.name}@${ctx.shard.version}.`);
+  // ctx.vaultRoot       — absolute path to the installed vault
+  // ctx.values          — the answered values
+  // ctx.modules         — { moduleId: 'included' | 'excluded' }
+  // ctx.shard           — { name, version }
+  // ctx.previousVersion — only set on post-update
+}
+```
+
+### Capabilities
+
+Hooks **can**:
+- Read / write files anywhere in `vaultRoot`
+- Run shell commands (`git init`, `qmd setup`, etc.)
+- Log to stdout (captured and surfaced in the install summary)
+- Import `shardmind/runtime` for helpers (`loadValues`, `loadState`, `validateFrontmatter`)
+
+Hooks **cannot**:
+- Modify `.shardmind/` (engine-owned)
+- Modify `shard-values.yaml` (user-owned)
+- Affect the install/update flow by throwing — exceptions become warnings, not fatal errors
+
+### Runtime status
+
+As of v0.1, the engine **detects** hook files but **does not execute them** yet. Execution is tracked in [#30](https://github.com/breferrari/shardmind/issues/30) and lands before Milestone 5 (obsidian-mind conversion). The contract above is stable; a `post-install.ts` written today will run unchanged when the runtime ships.
+
+## 7. Testing your shard locally
+
+1. Clone your shard to a directory under your GitHub account.
+2. Tag a pre-release: `git tag v0.0.1 && git push --tags`.
+3. In an empty directory: `shardmind install github:<user>/<shard> --dry-run`. Fix anything broken.
+4. Drop `--dry-run` for a real install. Inspect the resulting vault.
+5. Use `scripts/smoke-install.sh` in the shardmind repo as a template for your own smoke harness.
+6. Iterate. Tag new versions as you go.
+
+## 8. Publishing checklist
+
+Before tagging a release:
+
+- [ ] `shard.yaml` `version` matches the git tag (`v` prefix on the tag, no prefix in the file)
+- [ ] Install completes cleanly with `--dry-run` against a representative values file
+- [ ] Every value in `shard-schema.yaml` has a clear `message`
+- [ ] Computed defaults work against at least two realistic answer sets
+- [ ] Removable modules produce no files when excluded
+- [ ] Hook scripts either work or are clearly scoped "coming soon" (hook execution is deferred in v0.1)
+- [ ] README in your shard repo explains: what it installs, who it's for, how to upgrade
+
+## 9. Common errors
+
+See [`docs/ERRORS.md`](ERRORS.md) for the full catalog. The authoring-side ones you'll hit most:
+
+- `SCHEMA_RESERVED_NAME` — you named a value `shard`, `install_date`, `year`, `included_modules`, or `values`.
+- `SCHEMA_VALIDATION_FAILED` — a value's `group` doesn't match any group ID, or a select/multiselect is missing `options`.
+- `COMPUTED_DEFAULT_INVALID` — your `{{ expression }}` didn't produce the expected type.
+- `RENDER_FAILED` — Nunjucks error. Check for `{% ... %}` without matching `{% end... %}` and references to undefined values.
+
+## Further reading
+
+- [`README.md`](../README.md) — user perspective
+- [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) — why the engine is shaped this way
+- [`docs/IMPLEMENTATION.md`](IMPLEMENTATION.md) — module-level specs
+- [`examples/minimal-shard/`](../examples/minimal-shard/) — a working shard to crib from

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -1,0 +1,321 @@
+# ShardMind error codes
+
+Every `ShardMindError` carries a `code` (the label below), a `message` (what went wrong, with specifics), and a `hint` (what to do about it). This page catalogs every code, grouped by subsystem, with the typical cause and remedy.
+
+If you hit a code not listed here, it's likely a new one — please open an issue so it gets documented.
+
+---
+
+## Registry (resolving a shard reference)
+
+Thrown by `source/core/registry.ts`.
+
+### `REGISTRY_INVALID_REF`
+
+**Meaning:** The shard reference you passed to `shardmind install` doesn't match any accepted pattern.
+
+**Typical cause:** Using uppercase letters, path separators, or forgetting the `namespace/name` form.
+
+**Remedy:** Use `namespace/name`, `namespace/name@version`, or `github:namespace/name[@version]`. Names and namespaces must be lowercase alphanumeric + hyphens.
+
+### `SHARD_NOT_FOUND`
+
+**Meaning:** The shard key isn't present in the registry index.
+
+**Typical cause:** Typo in the namespace or name, or the shard hasn't been registered yet.
+
+**Remedy:** Check spelling, or install via direct mode: `shardmind install github:owner/repo`.
+
+### `VERSION_NOT_FOUND`
+
+**Meaning:** The version you asked for isn't available. For registry mode, the version isn't in the `versions[]` array. For direct mode, the git tag `v<version>` doesn't exist on the repo. Also thrown when direct-mode `releases/latest` returns 404.
+
+**Remedy:** Pick an available version (the error message lists them for registry mode), or omit `@version` to use the latest.
+
+### `REGISTRY_NETWORK`
+
+**Meaning:** A network error talking to the registry or GitHub API.
+
+**Typical cause:** Offline, DNS failure, GitHub status issue, or the registry index JSON is malformed.
+
+**Remedy:** Check your connection; retry. If persistent, use direct mode (`github:owner/repo`) to bypass the registry.
+
+### `REGISTRY_RATE_LIMITED`
+
+**Meaning:** GitHub returned 403 with `x-ratelimit-remaining: 0`.
+
+**Remedy:** Set `GITHUB_TOKEN` in your environment. Unauthenticated GitHub is 60 requests/hour; authenticated is 5000.
+
+---
+
+## Download (fetching + extracting the tarball)
+
+Thrown by `source/core/download.ts`.
+
+### `DOWNLOAD_HTTP_ERROR`
+
+**Meaning:** The HTTP request to fetch the tarball failed, or the server returned a non-2xx status, or the response body was empty.
+
+**Remedy:** Check the tarball URL in the error and your internet connection. For private repos, ensure `GITHUB_TOKEN` has repo access.
+
+### `DOWNLOAD_INVALID_TARBALL`
+
+**Meaning:** The downloaded bytes weren't a valid tar archive.
+
+**Typical cause:** The URL didn't point at a tarball, GitHub served a redirect page, or the archive is corrupted.
+
+**Remedy:** Open the tarball URL in a browser to see what's actually served. Verify the tag exists.
+
+### `DOWNLOAD_MISSING_MANIFEST`
+
+**Meaning:** The extracted tarball has no `shard.yaml` at its root.
+
+**Remedy:** If you're the shard author: add `shard.yaml`. If you're installing: confirm the repo is actually a ShardMind shard.
+
+### `DOWNLOAD_MISSING_SCHEMA`
+
+**Meaning:** The extracted tarball has no `shard-schema.yaml` at its root.
+
+**Remedy:** Same as above.
+
+---
+
+## Manifest (`shard.yaml` parsing)
+
+Thrown by `source/core/manifest.ts`.
+
+### `MANIFEST_NOT_FOUND`
+
+**Meaning:** The file path passed to `parseManifest` doesn't exist.
+
+**Remedy:** Usually an engine-internal error. If you're a shard author running tooling: check the path.
+
+### `MANIFEST_READ_FAILED`
+
+**Meaning:** I/O error reading `shard.yaml` (not ENOENT).
+
+**Remedy:** Check permissions / disk health.
+
+### `MANIFEST_INVALID_YAML`
+
+**Meaning:** `shard.yaml` has a YAML syntax error.
+
+**Remedy:** Fix the YAML. A YAML linter will point at the line.
+
+### `MANIFEST_VALIDATION_FAILED`
+
+**Meaning:** `shard.yaml` parsed as YAML but doesn't match the manifest schema (missing required field, invalid semver, invalid name, etc.).
+
+**Remedy:** Check the error details and consult [`docs/AUTHORING.md`](AUTHORING.md) §3 or [`schemas/shard.schema.json`](../schemas/shard.schema.json).
+
+---
+
+## Schema (`shard-schema.yaml` parsing)
+
+Thrown by `source/core/schema.ts`.
+
+### `SCHEMA_NOT_FOUND`
+
+**Meaning:** `shard-schema.yaml` doesn't exist at the expected path. In runtime context, the cache at `.shardmind/shard-schema.yaml` is missing (vault isn't initialized).
+
+**Remedy:** If installing: the downloaded tarball is missing the file. If in a hook: run `shardmind install` first.
+
+### `SCHEMA_READ_FAILED`
+
+**Meaning:** I/O error reading `shard-schema.yaml`.
+
+**Remedy:** Check permissions / disk.
+
+### `SCHEMA_INVALID_YAML`
+
+**Meaning:** `shard-schema.yaml` has a YAML syntax error.
+
+**Remedy:** Fix the YAML.
+
+### `SCHEMA_VALIDATION_FAILED`
+
+**Meaning:** `shard-schema.yaml` parsed but doesn't match the schema schema. The error message includes the offending path (e.g., `values.user_name.options: Required`).
+
+**Common causes:**
+- A value's `group` references a non-existent group
+- A `select` or `multiselect` value is missing `options`
+- `schema_version` isn't `1`
+
+**Remedy:** Consult [`docs/AUTHORING.md`](AUTHORING.md) §4 or [`schemas/shard-schema.schema.json`](../schemas/shard-schema.schema.json).
+
+### `SCHEMA_RESERVED_NAME`
+
+**Meaning:** A value key in `shard-schema.yaml` collides with the render context: `shard`, `install_date`, `year`, `included_modules`, or `values`.
+
+**Remedy:** Rename the value. These keys are provided by the engine; using them would silently shadow the context at render time.
+
+---
+
+## State (`.shardmind/state.json`)
+
+Thrown by `source/core/state.ts` and `source/runtime/state.ts`.
+
+### `STATE_READ_FAILED`
+
+**Meaning:** Generic I/O failure reading `state.json` (not ENOENT — missing file returns `null`, it doesn't throw).
+
+**Remedy:** Check `.shardmind/` permissions.
+
+### `STATE_CORRUPT`
+
+**Meaning:** `state.json` is not valid JSON, or is missing the `schema_version` field.
+
+**Remedy:** Engine-owned file shouldn't be corrupted by normal use. If you hand-edited it or had a disk event, the simplest fix is `rm -rf .shardmind/` and reinstall (your `shard-values.yaml` is preserved).
+
+### `STATE_UNSUPPORTED_VERSION`
+
+**Meaning:** `state.json` uses a schema version this engine doesn't know how to read, and no migration rule handles the jump.
+
+**Typical cause:** A newer version of shardmind wrote the state, then you downgraded. Or a future version added shape that v0.1 can't read.
+
+**Remedy:** Upgrade shardmind (`npm install -g shardmind@latest`). In v0.2+, migrations will handle forward compatibility.
+
+### `STATE_CACHE_MISSING_TEMPLATES`
+
+**Meaning:** During install, the shard's `templates/` directory wasn't found in the extracted tarball.
+
+**Remedy:** Shard author issue — add a `templates/` directory.
+
+### `VAULT_NOT_FOUND`
+
+**Meaning:** `resolveVaultRoot` (used by hook scripts via `shardmind/runtime`) searched up from `process.cwd()` and found no `.shardmind/` directory.
+
+**Remedy:** Run your script from inside a ShardMind vault. Run `shardmind install` to create one if needed.
+
+---
+
+## Values (`shard-values.yaml`)
+
+### `VALUES_NOT_FOUND`
+
+**Meaning (runtime):** `shard-values.yaml` doesn't exist when a hook tries to load it.
+
+**Remedy:** Run `shardmind install` first.
+
+### `VALUES_READ_FAILED`
+
+**Meaning:** I/O failure reading `shard-values.yaml`.
+
+**Remedy:** Check permissions.
+
+### `VALUES_INVALID`
+
+**Meaning (runtime):** `shard-values.yaml` parsed as YAML but isn't a mapping at the top level.
+
+**Remedy:** Ensure the file is `key: value` entries; not a list, not a scalar.
+
+### `VALUES_FILE_READ_FAILED`
+
+**Meaning:** `--values <file>` pointed at a file that couldn't be read.
+
+**Remedy:** Check the path and permissions.
+
+### `VALUES_FILE_INVALID`
+
+**Meaning:** `--values <file>` is not valid YAML, or not a mapping at the top level.
+
+**Remedy:** Ensure it's `{ key: value }` entries matching your shard's schema value IDs.
+
+### `VALUES_FILE_COLLISION`
+
+**Meaning:** Install tried to write `shard-values.yaml` but the file already exists. The `ExistingInstallGate` normally catches this earlier; this is a last-defense check.
+
+**Remedy:** Move or remove the existing `shard-values.yaml`. `shardmind update` (Milestone 4) will handle this automatically once available.
+
+### `VALUES_MISSING`
+
+**Meaning:** Running with `--yes` but the `--values` file doesn't include every required value.
+
+**Remedy:** Provide the missing keys in your `--values` file, or drop `--yes` to answer interactively.
+
+---
+
+## Computed defaults
+
+Thrown by `source/core/install-planner.ts:resolveComputedDefaults`.
+
+### `COMPUTED_DEFAULT_FAILED`
+
+**Meaning:** A `{{ expression }}` in `shard-schema.yaml` threw during Nunjucks rendering.
+
+**Remedy:** Shard author issue — check the expression syntax and that every referenced variable exists.
+
+### `COMPUTED_DEFAULT_INVALID`
+
+**Meaning:** The expression rendered, but the output couldn't be coerced into the declared value type (boolean needs `true`/`false`, number needs a finite number, list/multiselect needs a JSON array).
+
+**Remedy:** See [`docs/AUTHORING.md`](AUTHORING.md) §4 for the coercion rules. For arrays, use Nunjucks' `dump` filter: `"{{ ['a', 'b'] | dump }}"`.
+
+---
+
+## Collisions + backups
+
+Thrown by `source/core/install-planner.ts` and `source/core/install-executor.ts`.
+
+### `COLLISION_CHECK_FAILED`
+
+**Meaning:** `fsp.stat` on a planned output path threw something other than ENOENT.
+
+**Remedy:** Usually permissions. Check the file referenced in the error.
+
+### `BACKUP_FAILED`
+
+**Meaning:** `fsp.rename` failed while backing up a colliding file, OR 1000+ backups with the same timestamp already exist (shouldn't happen).
+
+**Remedy:** Check permissions at the file path. Clean up stale `*.shardmind-backup-*` files if you somehow have a thousand of them.
+
+---
+
+## Render
+
+Thrown by `source/core/renderer.ts` and wrapped in `source/core/install-executor.ts`.
+
+### `RENDER_FAILED`
+
+**Meaning:** Nunjucks threw while rendering a template. The output path is in the message; the original error is in the hint.
+
+**Typical cause:** `{% ... %}` without matching `{% end... %}`, or a reference to a value that isn't defined.
+
+**Remedy:** Shard author issue. Check the template at the reported path.
+
+### `RENDER_FRONTMATTER_ERROR`
+
+**Meaning:** The frontmatter section of a template rendered, but the result isn't parseable as YAML.
+
+**Typical cause:** Unquoted value with special characters (colons in a string need quoting).
+
+**Remedy:** Wrap the problematic value in quotes in the template.
+
+### `RENDER_TEMPLATE_ERROR`
+
+**Meaning:** Low-level Nunjucks render error (more granular than `RENDER_FAILED` in some paths).
+
+**Remedy:** Same as `RENDER_FAILED`.
+
+### `RENDER_ITERATOR_ERROR`
+
+**Meaning:** A template with `_each` in its name expects a list-typed value in the render context, but `values.<iterator>` isn't an array.
+
+**Remedy:** Ensure the named value in `shard-values.yaml` is a list.
+
+---
+
+## Maintenance
+
+If you're a shard author and hit a code that feels authoring-side, the specifically author-facing ones are:
+- `SCHEMA_RESERVED_NAME`, `SCHEMA_VALIDATION_FAILED`
+- `COMPUTED_DEFAULT_FAILED`, `COMPUTED_DEFAULT_INVALID`
+- `RENDER_FAILED`, `RENDER_FRONTMATTER_ERROR`, `RENDER_ITERATOR_ERROR`
+- `DOWNLOAD_MISSING_MANIFEST`, `DOWNLOAD_MISSING_SCHEMA`
+
+If you're an end user, the most common ones you'll see are:
+- `SHARD_NOT_FOUND`, `VERSION_NOT_FOUND`, `REGISTRY_NETWORK`
+- `VALUES_MISSING`, `VALUES_FILE_COLLISION`
+- `VAULT_NOT_FOUND` (if running a hook script outside a vault)
+
+Engine-internal codes (`STATE_*`, `BACKUP_FAILED`, `COLLISION_CHECK_FAILED`) shouldn't happen in normal use; open an issue if you hit one.

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -265,9 +265,9 @@ Thrown by `source/core/install-planner.ts` and `source/core/install-executor.ts`
 
 ### `BACKUP_FAILED`
 
-**Meaning:** `fsp.rename` failed while backing up a colliding file, OR 1000+ backups with the same timestamp already exist (shouldn't happen).
+**Meaning:** `fsp.rename` failed while backing up a colliding path, OR 1000+ backups with the same timestamp already exist (shouldn't happen).
 
-**Remedy:** Check permissions at the file path. Clean up stale `*.shardmind-backup-*` files if you somehow have a thousand of them.
+**Remedy:** Check permissions at the path referenced in the error. Clean up stale `*.shardmind-backup-*` backup paths if you somehow have a thousand of them.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",
-        "diff": "9.0.0",
+        "diff": "^9.0.0",
         "ink": "^5.0.0",
         "node-diff3": "^3.1.0",
         "nunjucks": "^3.2.4",
@@ -33,7 +33,7 @@
         "@types/tar": "^6.1.0",
         "tsup": "^8.0.0",
         "typescript": "^5.5.0",
-        "vitest": "4.1.4"
+        "vitest": "^4.1.4"
       },
       "engines": {
         "node": ">=18.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",
-        "diff": "^7.0.0",
+        "diff": "9.0.0",
         "ink": "^5.0.0",
         "node-diff3": "^3.1.0",
         "nunjucks": "^3.2.4",
@@ -33,7 +33,7 @@
         "@types/tar": "^6.1.0",
         "tsup": "^8.0.0",
         "typescript": "^5.5.0",
-        "vitest": "^2.0.0"
+        "vitest": "4.1.4"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -73,6 +73,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/win32-x64": {
@@ -170,6 +204,299 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
@@ -210,6 +537,42 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/diff": {
       "version": "6.0.0",
@@ -285,38 +648,40 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
-      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.9",
-        "@vitest/utils": "2.1.9",
-        "chai": "^5.1.2",
-        "tinyrainbow": "^1.2.0"
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
-      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.9",
+        "@vitest/spy": "4.1.4",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.12"
+        "magic-string": "^0.30.21"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -328,84 +693,68 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
-      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^1.2.0"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
-      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "2.1.9",
-        "pathe": "^1.1.2"
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
-    },
-    "node_modules/@vitest/runner/node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@vitest/snapshot": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
-      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "magic-string": "^0.30.12",
-        "pathe": "^1.1.2"
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/snapshot/node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@vitest/spy": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
-      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^3.0.2"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
-      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "loupe": "^3.1.2",
-        "tinyrainbow": "^1.2.0"
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -588,18 +937,11 @@
       }
     },
     "node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
       "engines": {
         "node": ">=18"
       }
@@ -614,16 +956,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -770,6 +1102,13 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-to-spaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
@@ -816,16 +1155,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -835,10 +1164,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -863,9 +1202,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1019,6 +1358,20 @@
         "magic-string": "^0.30.17",
         "mlly": "^1.7.4",
         "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -1245,6 +1598,267 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -1286,13 +1900,6 @@
       "bin": {
         "loose-envify": "cli.js"
       }
-    },
-    "node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
@@ -1471,6 +2078,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -1549,16 +2167,6 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1806,6 +2414,40 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
@@ -1988,9 +2630,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2138,30 +2780,10 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
     "node_modules/tinyrainbow": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
-      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tinyspy": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
-      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2198,6 +2820,14 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsup": {
       "version": "8.5.1",
@@ -2345,21 +2975,23 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.21",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.21.3",
-        "postcss": "^8.4.43",
-        "rollup": "^4.20.0"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.15",
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -2368,23 +3000,33 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.4.0"
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
       },
       "peerDependenciesMeta": {
         "@types/node": {
           "optional": true
         },
-        "less": {
+        "@vitejs/devtools": {
           "optional": true
         },
-        "lightningcss": {
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
           "optional": true
         },
         "sass": {
@@ -2401,148 +3043,89 @@
         },
         "terser": {
           "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
         }
       }
     },
-    "node_modules/vite-node": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
-      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.3.7",
-        "es-module-lexer": "^1.5.4",
-        "pathe": "^1.1.2",
-        "vite": "^5.0.0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vite-node/node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
-      }
-    },
     "node_modules/vitest": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
-      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "2.1.9",
-        "@vitest/mocker": "2.1.9",
-        "@vitest/pretty-format": "^2.1.9",
-        "@vitest/runner": "2.1.9",
-        "@vitest/snapshot": "2.1.9",
-        "@vitest/spy": "2.1.9",
-        "@vitest/utils": "2.1.9",
-        "chai": "^5.1.2",
-        "debug": "^4.3.7",
-        "expect-type": "^1.1.0",
-        "magic-string": "^0.30.12",
-        "pathe": "^1.1.2",
-        "std-env": "^3.8.0",
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.1",
-        "tinypool": "^1.0.1",
-        "tinyrainbow": "^1.2.0",
-        "vite": "^5.0.0",
-        "vite-node": "2.1.9",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.9",
-        "@vitest/ui": "2.1.9",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
+        "@opentelemetry/api": {
+          "optional": true
+        },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser": {
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {
@@ -2553,15 +3136,21 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
-    "node_modules/vitest/node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "vitest": "^4.1.4"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@inkjs/ui": "^2.0.0",
-    "diff": "9.0.0",
+    "diff": "^9.0.0",
     "ink": "^5.0.0",
     "node-diff3": "^3.1.0",
     "nunjucks": "^3.2.4",
@@ -49,7 +49,7 @@
     "@types/tar": "^6.1.0",
     "tsup": "^8.0.0",
     "typescript": "^5.5.0",
-    "vitest": "4.1.4"
+    "vitest": "^4.1.4"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "vitest": "^4.1.4"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "license": "MIT",
   "author": "Brenno Ferrari <brenno@brennoferrari.com>",

--- a/package.json
+++ b/package.json
@@ -28,28 +28,28 @@
     "release:major": "npm version major && git push && git push --tags"
   },
   "dependencies": {
-    "pastel": "^3.0.0",
-    "ink": "^5.0.0",
     "@inkjs/ui": "^2.0.0",
-    "react": "^18.0.0",
+    "diff": "9.0.0",
+    "ink": "^5.0.0",
+    "node-diff3": "^3.1.0",
     "nunjucks": "^3.2.4",
-    "yaml": "^2.4.0",
-    "tar": "^7.0.0",
+    "pastel": "^3.0.0",
+    "react": "^18.0.0",
     "semver": "^7.6.0",
-    "zod": "^3.23.0",
-    "diff": "^7.0.0",
-    "node-diff3": "^3.1.0"
+    "tar": "^7.0.0",
+    "yaml": "^2.4.0",
+    "zod": "^3.23.0"
   },
   "devDependencies": {
-    "typescript": "^5.5.0",
     "@sindresorhus/tsconfig": "^6.0.0",
-    "tsup": "^8.0.0",
-    "vitest": "^2.0.0",
-    "@types/nunjucks": "^3.2.6",
-    "@types/tar": "^6.1.0",
     "@types/diff": "^6.0.0",
+    "@types/nunjucks": "^3.2.6",
+    "@types/react": "^18.0.0",
     "@types/semver": "^7.5.0",
-    "@types/react": "^18.0.0"
+    "@types/tar": "^6.1.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.5.0",
+    "vitest": "4.1.4"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/schemas/shard-schema.schema.json
+++ b/schemas/shard-schema.schema.json
@@ -1,0 +1,236 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/breferrari/shardmind/main/schemas/shard-schema.schema.json",
+  "title": "Shard schema (shard-schema.yaml)",
+  "description": "Declares the values (prompt questions), groups (prompt grouping), modules (optional feature sets), signals (LLM routing), frontmatter rules, and migrations for a ShardMind shard. Drives the install wizard and the update command.",
+  "type": "object",
+  "required": ["schema_version", "values", "groups", "modules"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "description": "Schema format version. 1 is the only accepted value in v0.x.",
+      "type": "integer",
+      "const": 1
+    },
+    "values": {
+      "description": "Named prompts the user fills in at install time. Stored in shard-values.yaml and available as template context. Reserved keys (shadow render context): shard, install_date, year, included_modules, values.",
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/valueDefinition" }
+    },
+    "groups": {
+      "description": "Ordered groupings for the wizard. Every value's `group` must reference an id declared here.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "label"],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string" },
+          "label": { "type": "string" },
+          "description": { "type": "string" }
+        }
+      }
+    },
+    "modules": {
+      "description": "Optional feature sets. Users toggle removable modules in the wizard; non-removable modules always install.",
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/moduleDefinition" }
+    },
+    "signals": {
+      "description": "Declarative LLM routing hints. Surfaced to agents via shardmind/runtime.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "object",
+        "required": ["id", "description", "routes_to"],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string" },
+          "description": { "type": "string" },
+          "routes_to": { "type": "string" },
+          "core": { "type": "boolean" },
+          "module": {
+            "type": "string",
+            "description": "If set, this signal only activates when the named module is included."
+          }
+        }
+      }
+    },
+    "frontmatter": {
+      "description": "Per-note-type frontmatter rules. Shorthand array form becomes { required: [...] }.",
+      "type": "object",
+      "default": {},
+      "additionalProperties": {
+        "oneOf": [
+          { "type": "array", "items": { "type": "string" } },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "required": { "type": "array", "items": { "type": "string" } },
+              "path_match": { "type": "string" }
+            }
+          }
+        ]
+      }
+    },
+    "migrations": {
+      "description": "Ordered migration rules applied to shard-values.yaml when the shard version moves forward.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "object",
+        "required": ["from_version", "changes"],
+        "additionalProperties": false,
+        "properties": {
+          "from_version": { "type": "string" },
+          "changes": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "required": ["type", "old", "new"],
+                  "properties": {
+                    "type": { "const": "rename" },
+                    "old": { "type": "string" },
+                    "new": { "type": "string" }
+                  }
+                },
+                {
+                  "type": "object",
+                  "required": ["type", "key"],
+                  "properties": {
+                    "type": { "const": "added" },
+                    "key": { "type": "string" },
+                    "default": {}
+                  }
+                },
+                {
+                  "type": "object",
+                  "required": ["type", "key"],
+                  "properties": {
+                    "type": { "const": "removed" },
+                    "key": { "type": "string" }
+                  }
+                },
+                {
+                  "type": "object",
+                  "required": ["type", "key", "from", "to", "transform"],
+                  "properties": {
+                    "type": { "const": "type_changed" },
+                    "key": { "type": "string" },
+                    "from": { "type": "string" },
+                    "to": { "type": "string" },
+                    "transform": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "valueDefinition": {
+      "type": "object",
+      "required": ["type", "message", "group"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "description": "Input type. Drives the wizard prompt widget and the generated zod validator.",
+          "enum": ["string", "boolean", "number", "select", "multiselect", "list"]
+        },
+        "required": { "type": "boolean" },
+        "message": {
+          "description": "Prompt text shown to the user in the wizard.",
+          "type": "string"
+        },
+        "default": {
+          "description": "Default value. A string starting with `{{` is a computed expression evaluated via Nunjucks after non-computed values are collected.",
+          "anyOf": [
+            { "type": "string" },
+            { "type": "number" },
+            { "type": "boolean" },
+            { "type": "array" }
+          ]
+        },
+        "options": {
+          "description": "Required for select/multiselect types.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["value", "label"],
+            "additionalProperties": false,
+            "properties": {
+              "value": { "type": "string" },
+              "label": { "type": "string" },
+              "description": { "type": "string" }
+            }
+          }
+        },
+        "min": {
+          "description": "Minimum (inclusive) for number type.",
+          "type": "number"
+        },
+        "max": {
+          "description": "Maximum (inclusive) for number type.",
+          "type": "number"
+        },
+        "group": {
+          "description": "ID of a group declared in `groups[]`.",
+          "type": "string"
+        },
+        "hint": {
+          "description": "Helper text shown under the prompt in the wizard.",
+          "type": "string"
+        },
+        "placeholder": {
+          "description": "Placeholder shown in empty string/number inputs.",
+          "type": "string"
+        }
+      }
+    },
+    "moduleDefinition": {
+      "type": "object",
+      "required": ["label", "paths", "removable"],
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "Human-readable module name shown in the wizard.",
+          "type": "string"
+        },
+        "paths": {
+          "description": "Template directory prefixes that belong to this module. Matching templates are only rendered when the module is included.",
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "partials": {
+          "description": "Partial template paths that belong to this module. Included conditionally by the parent templates that reference them.",
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "commands": {
+          "description": "Command file basenames (from commands/) gated by this module.",
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "agents": {
+          "description": "Agent file basenames (from agents/) gated by this module.",
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "bases": {
+          "description": "Base template IDs gated by this module.",
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "removable": {
+          "description": "If true, users can uncheck this module in the wizard. If false, it always installs.",
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/schemas/shard.schema.json
+++ b/schemas/shard.schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/breferrari/shardmind/main/schemas/shard.schema.json",
+  "title": "Shard manifest (shard.yaml)",
+  "description": "The top-level manifest for a ShardMind shard. Lives at the root of the shard repository and declares identity, versioning, hooks, and dependencies. Validated on every install/update.",
+  "type": "object",
+  "required": ["apiVersion", "name", "namespace", "version"],
+  "additionalProperties": false,
+  "properties": {
+    "apiVersion": {
+      "description": "Schema version of shard.yaml. v1 is the only accepted value in v0.x.",
+      "const": "v1"
+    },
+    "name": {
+      "description": "Package name within its namespace. Lowercase alphanumeric and hyphens only. Example: \"obsidian-mind\".",
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$"
+    },
+    "namespace": {
+      "description": "Owner namespace. Typically your GitHub username or organization. Lowercase alphanumeric and hyphens only.",
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$"
+    },
+    "version": {
+      "description": "Semver-valid version string. See https://semver.org.",
+      "type": "string"
+    },
+    "description": {
+      "description": "Short human-readable summary of the shard. Shown in the install wizard.",
+      "type": "string"
+    },
+    "persona": {
+      "description": "Who this shard is for. Displayed in the install header (e.g., \"AI-augmented research vaults\").",
+      "type": "string"
+    },
+    "license": {
+      "description": "SPDX license identifier (e.g., \"MIT\", \"Apache-2.0\").",
+      "type": "string"
+    },
+    "homepage": {
+      "description": "URL to the shard's project page or documentation.",
+      "type": "string",
+      "format": "uri"
+    },
+    "requires": {
+      "description": "Environment requirements. ShardMind does not enforce these in v0.1 but tooling may warn.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "obsidian": {
+          "description": "Minimum Obsidian version required (semver range).",
+          "type": "string"
+        },
+        "node": {
+          "description": "Minimum Node.js version required for hook execution (semver range).",
+          "type": "string"
+        }
+      }
+    },
+    "dependencies": {
+      "description": "Other shards this shard depends on. Vendored in v0.1 (must be pre-installed in the vault); auto-fetched in v0.2+.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "object",
+        "required": ["name", "namespace", "version"],
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string" },
+          "namespace": { "type": "string" },
+          "version": { "type": "string" }
+        }
+      }
+    },
+    "hooks": {
+      "description": "Lifecycle hook file paths (relative to the shard root).",
+      "type": "object",
+      "default": {},
+      "additionalProperties": false,
+      "properties": {
+        "post-install": {
+          "description": "Path to a TypeScript file whose default export runs after `shardmind install`.",
+          "type": "string"
+        },
+        "post-update": {
+          "description": "Path to a TypeScript file whose default export runs after `shardmind update`.",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/source/commands/hooks/use-install-machine.ts
+++ b/source/commands/hooks/use-install-machine.ts
@@ -1,0 +1,519 @@
+/**
+ * State machine + async orchestration for the install command.
+ *
+ * Owns every side-effecting transition (resolve, download, parse,
+ * collision detection, backup, render, rollback, hook invocation)
+ * behind a hook interface so commands/install.tsx stays thin
+ * presentation. The update command (Milestone 4) is expected to
+ * reuse the same machine with a few added phase variants.
+ */
+
+import { useEffect, useState, useCallback, useRef } from 'react';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import { useApp } from 'ink';
+import { parse as parseYaml } from 'yaml';
+
+import type {
+  ShardManifest,
+  ShardSchema,
+  ShardState,
+  ResolvedShard,
+} from '../../runtime/types.js';
+import { ShardMindError } from '../../runtime/types.js';
+
+import { resolve as resolveRef } from '../../core/registry.js';
+import { downloadShard } from '../../core/download.js';
+import { parseManifest } from '../../core/manifest.js';
+import { parseSchema, buildValuesValidator } from '../../core/schema.js';
+import { readState } from '../../core/state.js';
+import {
+  planOutputs,
+  detectCollisions,
+  mergePrefill,
+  resolveComputedDefaults,
+  missingValueKeys,
+  defaultModuleSelections,
+  type Collision,
+} from '../../core/install-planner.js';
+import {
+  backupCollisions,
+  runInstall,
+  rollbackInstall,
+  type BackupRecord,
+} from '../../core/install-executor.js';
+import { runPostInstallHook, type HookResult } from '../../core/hook.js';
+import { SHARDMIND_DIR, VALUES_FILE } from '../../runtime/vault-paths.js';
+
+import type { WizardResult } from '../../components/InstallWizard.js';
+import type { CollisionAction } from '../../components/CollisionReview.js';
+import type { GateChoice } from '../../components/ExistingInstallGate.js';
+
+export interface PreparedContext {
+  resolved: ResolvedShard;
+  manifest: ShardManifest;
+  schema: ShardSchema;
+  tempDir: string;
+  tarballSha256: string;
+  cleanup: () => Promise<void>;
+  prefillValues: Record<string, unknown>;
+  moduleFileCounts: Record<string, number>;
+  alwaysIncludedFileCount: number;
+}
+
+export interface HookSummary {
+  deferred?: boolean;
+  stdout?: string;
+  exitCode?: number;
+}
+
+export type Phase =
+  | { kind: 'booting' }
+  | { kind: 'loading'; message: string }
+  | { kind: 'gate'; state: ShardState; ctx: PreparedContext }
+  | { kind: 'wizard'; ctx: PreparedContext }
+  | { kind: 'collision'; collisions: Collision[]; result: WizardResult; ctx: PreparedContext }
+  | { kind: 'installing'; total: number; current: number; label: string; history: string[]; ctx: PreparedContext; result: WizardResult; backups: BackupRecord[] }
+  | { kind: 'summary'; manifest: ShardManifest; vaultRoot: string; fileCount: number; durationMs: number; backups: BackupRecord[]; hook: HookSummary | null; dryRun: boolean }
+  | { kind: 'cancelled'; reason: string }
+  | { kind: 'error'; error: ShardMindError | Error; detail?: string };
+
+export interface UseInstallMachineInput {
+  shardRef: string;
+  valuesFile: string | undefined;
+  yes: boolean;
+  verbose: boolean;
+  dryRun: boolean;
+  vaultRoot: string;
+}
+
+export interface UseInstallMachineOutput {
+  phase: Phase;
+  onGateChoice: (choice: GateChoice) => void;
+  onWizardComplete: (result: WizardResult) => void;
+  onWizardCancel: () => void;
+  onWizardError: (err: Error) => void;
+  onCollisionChoice: (action: CollisionAction) => void;
+}
+
+export function useInstallMachine(input: UseInstallMachineInput): UseInstallMachineOutput {
+  const { shardRef, valuesFile, yes, verbose, dryRun, vaultRoot } = input;
+  const { exit } = useApp();
+
+  const [phase, setPhase] = useState<Phase>({ kind: 'booting' });
+
+  // Refs tracked during runInstall so a SIGINT handler can roll back
+  // any files written so far and restore any backups created during
+  // collision handling.
+  const writtenPathsRef = useRef<string[]>([]);
+  const backupsRef = useRef<BackupRecord[]>([]);
+  const installingRef = useRef(false);
+  // Mutable pointer to the latest handleWizardComplete closure so
+  // runNonInteractive can call it without circular useCallback deps.
+  const handleWizardCompleteRef = useRef<(r: WizardResult, c: PreparedContext) => Promise<void>>(
+    async () => {},
+  );
+
+  const finish = useCallback(
+    (next: Phase) => {
+      setPhase(next);
+      if (next.kind === 'summary' || next.kind === 'cancelled' || next.kind === 'error') {
+        setTimeout(() => exit(), 100);
+      }
+    },
+    [exit],
+  );
+
+  // SIGINT handler: if a render is in progress when the user hits Ctrl+C,
+  // roll back partial writes and restore backups before exiting. Default
+  // Ink behavior exits without knowing about our bookkeeping.
+  useEffect(() => {
+    const handler = () => {
+      if (installingRef.current && !dryRun) {
+        // Fire-and-forget; process is about to exit anyway.
+        rollbackInstall(vaultRoot, writtenPathsRef.current, backupsRef.current)
+          .catch(() => {})
+          .finally(() => process.exit(130));
+      } else {
+        process.exit(130);
+      }
+    };
+    process.on('SIGINT', handler);
+    return () => {
+      process.off('SIGINT', handler);
+    };
+  }, [dryRun, vaultRoot]);
+
+  useEffect(() => {
+    let disposed = false;
+    let ctxForCleanup: PreparedContext | null = null;
+
+    (async () => {
+      try {
+        setPhase({ kind: 'loading', message: `Resolving ${shardRef}…` });
+        const resolved = await resolveRef(shardRef);
+
+        setPhase({ kind: 'loading', message: `Downloading ${resolved.namespace}/${resolved.name}@${resolved.version}…` });
+        const temp = await downloadShard(resolved.tarballUrl);
+
+        setPhase({ kind: 'loading', message: 'Parsing manifest and schema…' });
+        const manifest = await parseManifest(temp.manifest);
+        const schema = await parseSchema(temp.schema);
+
+        const prefill = valuesFile ? await loadValuesFile(valuesFile, schema) : {};
+        const merged = mergePrefill(schema, prefill);
+
+        const { moduleFileCounts, alwaysIncludedFileCount } = await planOutputs(
+          schema,
+          temp.tempDir,
+          defaultModuleSelections(schema),
+        );
+
+        const ctx: PreparedContext = {
+          resolved,
+          manifest,
+          schema,
+          tempDir: temp.tempDir,
+          tarballSha256: temp.tarball_sha256,
+          cleanup: temp.cleanup,
+          prefillValues: merged,
+          moduleFileCounts,
+          alwaysIncludedFileCount,
+        };
+        ctxForCleanup = ctx;
+
+        const existing = await readState(vaultRoot);
+        if (existing) {
+          if (disposed) return;
+          setPhase({ kind: 'gate', state: existing, ctx });
+          return;
+        }
+
+        if (disposed) return;
+        if (yes) {
+          await runNonInteractive(ctx);
+        } else {
+          setPhase({ kind: 'wizard', ctx });
+        }
+      } catch (err) {
+        if (disposed) return;
+        finish({ kind: 'error', error: err as Error });
+      }
+    })();
+
+    return () => {
+      disposed = true;
+      if (ctxForCleanup) {
+        ctxForCleanup.cleanup().catch(() => {});
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shardRef, valuesFile, yes]);
+
+  const runNonInteractive = useCallback(
+    async (ctx: PreparedContext) => {
+      const missing = missingValueKeys(ctx.schema, ctx.prefillValues);
+      if (missing.length > 0) {
+        throw new ShardMindError(
+          `Missing required values for --yes: ${missing.join(', ')}`,
+          'VALUES_MISSING',
+          'Provide them via --values <file> or drop --yes to prompt interactively.',
+        );
+      }
+      const validator = buildValuesValidator(ctx.schema);
+      const validated = validator.parse(
+        resolveComputedDefaults(ctx.schema, ctx.prefillValues),
+      ) as Record<string, unknown>;
+      await handleWizardCompleteRef.current(
+        { values: validated, selections: defaultModuleSelections(ctx.schema) },
+        ctx,
+      );
+    },
+    [],
+  );
+
+  const executeInstall = useCallback(
+    async (ctx: PreparedContext, result: WizardResult, backups: BackupRecord[]) => {
+      const start = Date.now();
+      const history: string[] = [];
+
+      // Register backups + reset writtenPaths so the SIGINT handler sees
+      // live state from the first byte written.
+      backupsRef.current = backups;
+      writtenPathsRef.current = [];
+      installingRef.current = true;
+
+      setPhase({
+        kind: 'installing',
+        total: 0,
+        current: 0,
+        label: 'Preparing…',
+        history,
+        ctx,
+        result,
+        backups,
+      });
+
+      let written: string[] = [];
+      try {
+        const runResult = await runInstall({
+          vaultRoot,
+          manifest: ctx.manifest,
+          schema: ctx.schema,
+          tempDir: ctx.tempDir,
+          resolved: ctx.resolved,
+          tarballSha256: ctx.tarballSha256,
+          values: result.values,
+          selections: result.selections,
+          dryRun,
+          onFileWritten: (outputPath) => {
+            writtenPathsRef.current.push(outputPath);
+          },
+          onProgress: (ev) => {
+            if (ev.kind === 'start') {
+              setPhase((prev) =>
+                prev.kind === 'installing' && (prev.total !== ev.total || prev.current !== 0)
+                  ? { ...prev, total: ev.total, current: 0, label: 'Starting…' }
+                  : prev,
+              );
+            } else if (ev.kind === 'file') {
+              if (verbose) {
+                history.push(ev.outputPath);
+                if (history.length > 5) history.shift();
+              }
+              setPhase((prev) => {
+                if (prev.kind !== 'installing') return prev;
+                if (prev.current === ev.index && prev.label === ev.label) return prev;
+                return {
+                  ...prev,
+                  current: ev.index,
+                  total: ev.total,
+                  label: ev.label,
+                  history: verbose ? [...history] : prev.history,
+                };
+              });
+            }
+          },
+        });
+        written = runResult.writtenPaths;
+
+        const hookResult = dryRun
+          ? { kind: 'absent' as const }
+          : await runPostInstallHook(ctx.tempDir, ctx.manifest);
+        const hookSummary = summarizeHook(hookResult);
+
+        installingRef.current = false;
+
+        finish({
+          kind: 'summary',
+          manifest: ctx.manifest,
+          vaultRoot,
+          fileCount: runResult.fileCount,
+          durationMs: Date.now() - start,
+          backups,
+          hook: hookSummary,
+          dryRun: Boolean(dryRun),
+        });
+      } catch (err) {
+        if (!dryRun) {
+          await rollbackInstall(vaultRoot, written, backups).catch(() => {});
+        }
+        installingRef.current = false;
+        finish({
+          kind: 'error',
+          error: err as Error,
+          detail: dryRun ? undefined : 'Rolled back partial install (including any pre-install backups).',
+        });
+      }
+    },
+    [vaultRoot, verbose, dryRun, finish],
+  );
+
+  const handleWizardComplete = useCallback(
+    async (result: WizardResult, ctx: PreparedContext) => {
+      try {
+        const validator = buildValuesValidator(ctx.schema);
+        const validated = validator.parse(result.values) as Record<string, unknown>;
+        const validatedResult: WizardResult = { values: validated, selections: result.selections };
+
+        const { outputs } = await planOutputs(ctx.schema, ctx.tempDir, validatedResult.selections);
+        const collisions = await detectCollisions(vaultRoot, outputs.map((o) => o.outputPath));
+
+        if (collisions.length > 0) {
+          if (yes) {
+            // --yes policy: auto-backup. Dry-run must skip the disk action.
+            const backups = dryRun ? [] : await backupCollisions(collisions);
+            await executeInstall(ctx, validatedResult, backups);
+          } else {
+            setPhase({ kind: 'collision', collisions, result: validatedResult, ctx });
+          }
+          return;
+        }
+
+        await executeInstall(ctx, validatedResult, []);
+      } catch (err) {
+        finish({ kind: 'error', error: err as Error });
+      }
+    },
+    [yes, dryRun, vaultRoot, executeInstall, finish],
+  );
+
+  useEffect(() => {
+    handleWizardCompleteRef.current = handleWizardComplete;
+  }, [handleWizardComplete]);
+
+  const onCollisionChoice = useCallback(
+    async (action: CollisionAction) => {
+      if (phase.kind !== 'collision') return;
+      const { collisions, result, ctx } = phase;
+      if (action === 'cancel') {
+        finish({ kind: 'cancelled', reason: 'User cancelled at collision review.' });
+        return;
+      }
+
+      try {
+        if (action === 'backup') {
+          const backups = await backupCollisions(collisions);
+          await executeInstall(ctx, result, backups);
+          return;
+        }
+        // Overwrite: remove colliding paths so writeFile doesn't hit EISDIR
+        // when a directory sits at a planned file path. User authorized the loss.
+        await Promise.all(
+          collisions.map((c) => fsp.rm(c.absolutePath, { recursive: true, force: true })),
+        );
+        await executeInstall(ctx, result, []);
+      } catch (err) {
+        finish({ kind: 'error', error: err as Error });
+      }
+    },
+    [phase, finish, executeInstall],
+  );
+
+  const onGateChoice = useCallback(
+    (choice: GateChoice) => {
+      if (phase.kind !== 'gate') return;
+      if (choice === 'cancel') {
+        finish({ kind: 'cancelled', reason: 'User cancelled at existing-install gate.' });
+        return;
+      }
+      if (choice === 'update') {
+        finish({
+          kind: 'cancelled',
+          reason: 'Existing install preserved. `shardmind update` is not yet available (Milestone 4); re-run `install` and pick Reinstall when you want a fresh start.',
+        });
+        return;
+      }
+      if (choice === 'reinstall') {
+        if (dryRun) {
+          finish({
+            kind: 'cancelled',
+            reason: 'Reinstall is destructive and cannot run under --dry-run. Drop --dry-run to reinstall.',
+          });
+          return;
+        }
+        (async () => {
+          try {
+            await Promise.all([
+              fsp.rm(path.join(vaultRoot, SHARDMIND_DIR), { recursive: true, force: true }),
+              fsp.rm(path.join(vaultRoot, VALUES_FILE), { force: true }),
+            ]);
+            if (yes) {
+              await runNonInteractive(phase.ctx);
+            } else {
+              setPhase({ kind: 'wizard', ctx: phase.ctx });
+            }
+          } catch (err) {
+            finish({ kind: 'error', error: err as Error });
+          }
+        })();
+      }
+    },
+    [phase, vaultRoot, yes, dryRun, finish, runNonInteractive],
+  );
+
+  const onWizardComplete = useCallback(
+    (result: WizardResult) => {
+      if (phase.kind !== 'wizard') return;
+      void handleWizardComplete(result, phase.ctx);
+    },
+    [phase, handleWizardComplete],
+  );
+
+  const onWizardCancel = useCallback(
+    () => finish({ kind: 'cancelled', reason: 'User cancelled in wizard.' }),
+    [finish],
+  );
+
+  const onWizardError = useCallback(
+    (err: Error) => finish({ kind: 'error', error: err }),
+    [finish],
+  );
+
+  return {
+    phase,
+    onGateChoice,
+    onWizardComplete,
+    onWizardCancel,
+    onWizardError,
+    onCollisionChoice,
+  };
+}
+
+async function loadValuesFile(
+  filePath: string,
+  schema: ShardSchema,
+): Promise<Record<string, unknown>> {
+  let raw: string;
+  try {
+    raw = await fsp.readFile(filePath, 'utf-8');
+  } catch (err) {
+    throw new ShardMindError(
+      `Could not read --values file: ${filePath}`,
+      'VALUES_FILE_READ_FAILED',
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(raw);
+  } catch (err) {
+    throw new ShardMindError(
+      `--values file is not valid YAML: ${filePath}`,
+      'VALUES_FILE_INVALID',
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new ShardMindError(
+      `--values file must be a YAML mapping: ${filePath}`,
+      'VALUES_FILE_INVALID',
+      'Top level must be { key: value } entries matching shard schema value IDs.',
+    );
+  }
+
+  // Unknown keys are silently ignored so a values file can be reused
+  // across shard versions that have added or removed entries.
+  const filtered: Record<string, unknown> = {};
+  for (const key of Object.keys(schema.values)) {
+    if (key in (parsed as Record<string, unknown>)) {
+      filtered[key] = (parsed as Record<string, unknown>)[key];
+    }
+  }
+  return filtered;
+}
+
+function summarizeHook(result: HookResult): HookSummary | null {
+  switch (result.kind) {
+    case 'absent':
+      return null;
+    case 'deferred':
+      return { deferred: true };
+    case 'ran':
+      return { stdout: result.stdout, exitCode: result.exitCode };
+    case 'failed':
+      return { stdout: result.message, exitCode: 1 };
+  }
+}

--- a/source/commands/install.tsx
+++ b/source/commands/install.tsx
@@ -1,42 +1,17 @@
-import { useEffect, useState, useCallback, useRef, type ReactNode } from 'react';
-import fsp from 'node:fs/promises';
-import path from 'node:path';
-import { Box, Text, useApp } from 'ink';
+import { type ReactNode } from 'react';
+import { Box, Text } from 'ink';
 import { Spinner, StatusMessage, Alert } from '@inkjs/ui';
-import { parse as parseYaml } from 'yaml';
 import zod from 'zod';
 
-import type { ShardManifest, ShardSchema, ShardState, ResolvedShard } from '../runtime/types.js';
 import { ShardMindError } from '../runtime/types.js';
 
-import { resolve as resolveRef } from '../core/registry.js';
-import { downloadShard } from '../core/download.js';
-import { parseManifest } from '../core/manifest.js';
-import { parseSchema, buildValuesValidator } from '../core/schema.js';
-import { readState } from '../core/state.js';
-import {
-  planOutputs,
-  detectCollisions,
-  mergePrefill,
-  resolveComputedDefaults,
-  missingValueKeys,
-  defaultModuleSelections,
-  type Collision,
-} from '../core/install-planner.js';
-import {
-  backupCollisions,
-  runInstall,
-  rollbackInstall,
-  type BackupRecord,
-} from '../core/install-executor.js';
-import { runPostInstallHook, type HookResult } from '../core/hook.js';
-import { SHARDMIND_DIR, VALUES_FILE } from '../runtime/vault-paths.js';
-
-import InstallWizard, { type WizardResult } from '../components/InstallWizard.js';
-import CollisionReview, { type CollisionAction } from '../components/CollisionReview.js';
-import ExistingInstallGate, { type GateChoice } from '../components/ExistingInstallGate.js';
+import InstallWizard from '../components/InstallWizard.js';
+import CollisionReview from '../components/CollisionReview.js';
+import ExistingInstallGate from '../components/ExistingInstallGate.js';
 import InstallProgress from '../components/InstallProgress.js';
 import Summary from '../components/Summary.js';
+
+import { useInstallMachine } from './hooks/use-install-machine.js';
 
 export const args = zod.tuple([
   zod.string().describe('Shard reference, e.g. "breferrari/obsidian-mind" or "github:owner/repo"'),
@@ -54,377 +29,30 @@ type Props = {
   options: zod.infer<typeof options>;
 };
 
-type Phase =
-  | { kind: 'booting' }
-  | { kind: 'loading'; message: string }
-  | { kind: 'gate'; state: ShardState; ctx: PreparedContext }
-  | { kind: 'wizard'; ctx: PreparedContext }
-  | { kind: 'collision'; collisions: Collision[]; result: WizardResult; ctx: PreparedContext }
-  | { kind: 'installing'; total: number; current: number; label: string; history: string[]; ctx: PreparedContext; result: WizardResult; backups: BackupRecord[] }
-  | { kind: 'summary'; manifest: ShardManifest; vaultRoot: string; fileCount: number; durationMs: number; backups: BackupRecord[]; hook: HookSummary | null; dryRun: boolean }
-  | { kind: 'cancelled'; reason: string }
-  | { kind: 'error'; error: ShardMindError | Error; detail?: string };
-
-interface PreparedContext {
-  resolved: ResolvedShard;
-  manifest: ShardManifest;
-  schema: ShardSchema;
-  tempDir: string;
-  tarballSha256: string;
-  cleanup: () => Promise<void>;
-  prefillValues: Record<string, unknown>;
-  moduleFileCounts: Record<string, number>;
-  alwaysIncludedFileCount: number;
-}
-
-interface HookSummary {
-  deferred?: boolean;
-  stdout?: string;
-  exitCode?: number;
-}
-
 export default function Install({ args, options }: Props) {
   const [shardRef] = args;
   const { values: valuesFile, yes, verbose, dryRun } = options;
-  const vaultRoot = process.cwd();
-  const { exit } = useApp();
 
-  const [phase, setPhase] = useState<Phase>({ kind: 'booting' });
-
-  // Refs tracked during runInstall so a SIGINT handler can roll back
-  // any files written so far and restore any backups created during
-  // collision handling.
-  const writtenPathsRef = useRef<string[]>([]);
-  const backupsRef = useRef<BackupRecord[]>([]);
-  const installingRef = useRef(false);
-  // Mutable pointer to the latest handleWizardComplete closure so
-  // runNonInteractive can call it without circular useCallback deps.
-  const handleWizardCompleteRef = useRef<(r: WizardResult, c: PreparedContext) => Promise<void>>(
-    async () => {},
-  );
-
-  const finish = useCallback(
-    (next: Phase) => {
-      setPhase(next);
-      if (next.kind === 'summary' || next.kind === 'cancelled' || next.kind === 'error') {
-        setTimeout(() => exit(), 100);
-      }
-    },
-    [exit],
-  );
-
-  // SIGINT handler: if a render is in progress when the user hits Ctrl+C,
-  // roll back partial writes and restore backups before exiting. Default
-  // Ink behavior exits without knowing about our bookkeeping.
-  useEffect(() => {
-    const handler = () => {
-      if (installingRef.current && !dryRun) {
-        // Fire-and-forget; process is about to exit anyway.
-        rollbackInstall(vaultRoot, writtenPathsRef.current, backupsRef.current)
-          .catch(() => {})
-          .finally(() => process.exit(130));
-      } else {
-        process.exit(130);
-      }
-    };
-    process.on('SIGINT', handler);
-    return () => {
-      process.off('SIGINT', handler);
-    };
-  }, [dryRun, vaultRoot]);
-
-  useEffect(() => {
-    let disposed = false;
-    let ctxForCleanup: PreparedContext | null = null;
-
-    (async () => {
-      try {
-        setPhase({ kind: 'loading', message: `Resolving ${shardRef}…` });
-        const resolved = await resolveRef(shardRef!);
-
-        setPhase({ kind: 'loading', message: `Downloading ${resolved.namespace}/${resolved.name}@${resolved.version}…` });
-        const temp = await downloadShard(resolved.tarballUrl);
-
-        setPhase({ kind: 'loading', message: 'Parsing manifest and schema…' });
-        const manifest = await parseManifest(temp.manifest);
-        const schema = await parseSchema(temp.schema);
-
-        const prefill = valuesFile ? await loadValuesFile(valuesFile, schema) : {};
-        const merged = mergePrefill(schema, prefill);
-
-        const { moduleFileCounts, alwaysIncludedFileCount } = await planOutputs(
-          schema,
-          temp.tempDir,
-          defaultModuleSelections(schema),
-        );
-
-        const ctx: PreparedContext = {
-          resolved,
-          manifest,
-          schema,
-          tempDir: temp.tempDir,
-          tarballSha256: temp.tarball_sha256,
-          cleanup: temp.cleanup,
-          prefillValues: merged,
-          moduleFileCounts,
-          alwaysIncludedFileCount,
-        };
-        ctxForCleanup = ctx;
-
-        const existing = await readState(vaultRoot);
-        if (existing) {
-          if (disposed) return;
-          setPhase({ kind: 'gate', state: existing, ctx });
-          return;
-        }
-
-        if (disposed) return;
-        if (yes) {
-          await runNonInteractive(ctx);
-        } else {
-          setPhase({ kind: 'wizard', ctx });
-        }
-      } catch (err) {
-        if (disposed) return;
-        finish({ kind: 'error', error: err as Error });
-      }
-    })();
-
-    return () => {
-      disposed = true;
-      if (ctxForCleanup) {
-        ctxForCleanup.cleanup().catch(() => {});
-      }
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shardRef, valuesFile, yes]);
-
-  const runNonInteractive = useCallback(
-    async (ctx: PreparedContext) => {
-      const missing = missingValueKeys(ctx.schema, ctx.prefillValues);
-      if (missing.length > 0) {
-        throw new ShardMindError(
-          `Missing required values for --yes: ${missing.join(', ')}`,
-          'VALUES_MISSING',
-          'Provide them via --values <file> or drop --yes to prompt interactively.',
-        );
-      }
-      const validator = buildValuesValidator(ctx.schema);
-      const validated = validator.parse(
-        resolveComputedDefaults(ctx.schema, ctx.prefillValues),
-      ) as Record<string, unknown>;
-      await handleWizardCompleteRef.current(
-        { values: validated, selections: defaultModuleSelections(ctx.schema) },
-        ctx,
-      );
-    },
-    [],
-  );
-
-  const executeInstall = useCallback(
-    async (ctx: PreparedContext, result: WizardResult, backups: BackupRecord[]) => {
-      const start = Date.now();
-      const history: string[] = [];
-
-      // Register backups + reset writtenPaths so the SIGINT handler sees
-      // live state from the first byte written.
-      backupsRef.current = backups;
-      writtenPathsRef.current = [];
-      installingRef.current = true;
-
-      setPhase({
-        kind: 'installing',
-        total: 0,
-        current: 0,
-        label: 'Preparing…',
-        history,
-        ctx,
-        result,
-        backups,
-      });
-
-      let written: string[] = [];
-      try {
-        const runResult = await runInstall({
-          vaultRoot,
-          manifest: ctx.manifest,
-          schema: ctx.schema,
-          tempDir: ctx.tempDir,
-          resolved: ctx.resolved,
-          tarballSha256: ctx.tarballSha256,
-          values: result.values,
-          selections: result.selections,
-          dryRun,
-          onFileWritten: (outputPath) => {
-            writtenPathsRef.current.push(outputPath);
-          },
-          onProgress: (ev) => {
-            if (ev.kind === 'start') {
-              setPhase((prev) =>
-                prev.kind === 'installing' && (prev.total !== ev.total || prev.current !== 0)
-                  ? { ...prev, total: ev.total, current: 0, label: 'Starting…' }
-                  : prev,
-              );
-            } else if (ev.kind === 'file') {
-              if (verbose) {
-                history.push(ev.outputPath);
-                if (history.length > 5) history.shift();
-              }
-              setPhase((prev) => {
-                if (prev.kind !== 'installing') return prev;
-                if (prev.current === ev.index && prev.label === ev.label) return prev;
-                return {
-                  ...prev,
-                  current: ev.index,
-                  total: ev.total,
-                  label: ev.label,
-                  history: verbose ? [...history] : prev.history,
-                };
-              });
-            }
-          },
-        });
-        written = runResult.writtenPaths;
-
-        const hookResult = dryRun
-          ? { kind: 'absent' as const }
-          : await runPostInstallHook(ctx.tempDir, ctx.manifest);
-        const hookSummary = summarizeHook(hookResult);
-
-        installingRef.current = false;
-
-        finish({
-          kind: 'summary',
-          manifest: ctx.manifest,
-          vaultRoot,
-          fileCount: runResult.fileCount,
-          durationMs: Date.now() - start,
-          backups,
-          hook: hookSummary,
-          dryRun: Boolean(dryRun),
-        });
-      } catch (err) {
-        if (!dryRun) {
-          await rollbackInstall(vaultRoot, written, backups).catch(() => {});
-        }
-        installingRef.current = false;
-        finish({
-          kind: 'error',
-          error: err as Error,
-          detail: dryRun ? undefined : 'Rolled back partial install (including any pre-install backups).',
-        });
-      }
-    },
-    [vaultRoot, verbose, dryRun, finish],
-  );
-
-  const handleWizardComplete = useCallback(
-    async (result: WizardResult, ctx: PreparedContext) => {
-      try {
-        const validator = buildValuesValidator(ctx.schema);
-        const validated = validator.parse(result.values) as Record<string, unknown>;
-        const validatedResult: WizardResult = { values: validated, selections: result.selections };
-
-        const { outputs } = await planOutputs(ctx.schema, ctx.tempDir, validatedResult.selections);
-        const collisions = await detectCollisions(vaultRoot, outputs.map((o) => o.outputPath));
-
-        if (collisions.length > 0) {
-          if (yes) {
-            // --yes policy: auto-backup. Dry-run must skip the disk action.
-            const backups = dryRun ? [] : await backupCollisions(collisions);
-            await executeInstall(ctx, validatedResult, backups);
-          } else {
-            setPhase({ kind: 'collision', collisions, result: validatedResult, ctx });
-          }
-          return;
-        }
-
-        await executeInstall(ctx, validatedResult, []);
-      } catch (err) {
-        finish({ kind: 'error', error: err as Error });
-      }
-    },
-    [yes, dryRun, vaultRoot, executeInstall, finish],
-  );
-
-  useEffect(() => {
-    handleWizardCompleteRef.current = handleWizardComplete;
-  }, [handleWizardComplete]);
-
-  const handleCollisionChoice = useCallback(
-    async (action: CollisionAction) => {
-      if (phase.kind !== 'collision') return;
-      const { collisions, result, ctx } = phase;
-      if (action === 'cancel') {
-        finish({ kind: 'cancelled', reason: 'User cancelled at collision review.' });
-        return;
-      }
-
-      try {
-        if (action === 'backup') {
-          const backups = await backupCollisions(collisions);
-          await executeInstall(ctx, result, backups);
-          return;
-        }
-        // Overwrite: remove colliding paths so writeFile doesn't hit EISDIR
-        // when a directory sits at a planned file path. User authorized the loss.
-        await Promise.all(
-          collisions.map((c) => fsp.rm(c.absolutePath, { recursive: true, force: true })),
-        );
-        await executeInstall(ctx, result, []);
-      } catch (err) {
-        finish({ kind: 'error', error: err as Error });
-      }
-    },
-    [phase, finish, executeInstall],
-  );
-
-  const handleGateChoice = useCallback(
-    (choice: GateChoice) => {
-      if (phase.kind !== 'gate') return;
-      if (choice === 'cancel') {
-        finish({ kind: 'cancelled', reason: 'User cancelled at existing-install gate.' });
-        return;
-      }
-      if (choice === 'update') {
-        finish({
-          kind: 'cancelled',
-          reason: 'Existing install preserved. `shardmind update` is not yet available (Milestone 4); re-run `install` and pick Reinstall when you want a fresh start.',
-        });
-        return;
-      }
-      if (choice === 'reinstall') {
-        if (dryRun) {
-          finish({
-            kind: 'cancelled',
-            reason: 'Reinstall is destructive and cannot run under --dry-run. Drop --dry-run to reinstall.',
-          });
-          return;
-        }
-        (async () => {
-          try {
-            await Promise.all([
-              fsp.rm(path.join(vaultRoot, SHARDMIND_DIR), { recursive: true, force: true }),
-              fsp.rm(path.join(vaultRoot, VALUES_FILE), { force: true }),
-            ]);
-            if (yes) {
-              await runNonInteractive(phase.ctx);
-            } else {
-              setPhase({ kind: 'wizard', ctx: phase.ctx });
-            }
-          } catch (err) {
-            finish({ kind: 'error', error: err as Error });
-          }
-        })();
-      }
-    },
-    [phase, vaultRoot, yes, dryRun, finish, runNonInteractive],
-  );
+  const {
+    phase,
+    onGateChoice,
+    onWizardComplete,
+    onWizardCancel,
+    onWizardError,
+    onCollisionChoice,
+  } = useInstallMachine({
+    shardRef: shardRef!,
+    valuesFile,
+    yes,
+    verbose,
+    dryRun,
+    vaultRoot: process.cwd(),
+  });
 
   if (phase.kind === 'booting' || phase.kind === 'loading') {
     const msg = phase.kind === 'loading' ? phase.message : 'Starting…';
     return (
-      <RootFrame dryRun={Boolean(dryRun)} showLegend={false}>
+      <RootFrame dryRun={dryRun} showLegend={false}>
         <Box gap={1}>
           <Spinner />
           <Text>{msg}</Text>
@@ -435,24 +63,24 @@ export default function Install({ args, options }: Props) {
 
   if (phase.kind === 'gate') {
     return (
-      <RootFrame dryRun={Boolean(dryRun)}>
-        <ExistingInstallGate state={phase.state} onChoice={handleGateChoice} />
+      <RootFrame dryRun={dryRun}>
+        <ExistingInstallGate state={phase.state} onChoice={onGateChoice} />
       </RootFrame>
     );
   }
 
   if (phase.kind === 'wizard') {
     return (
-      <RootFrame dryRun={Boolean(dryRun)}>
+      <RootFrame dryRun={dryRun}>
         <InstallWizard
           manifest={phase.ctx.manifest}
           schema={phase.ctx.schema}
           prefillValues={phase.ctx.prefillValues}
           moduleFileCounts={phase.ctx.moduleFileCounts}
           alwaysIncludedFileCount={phase.ctx.alwaysIncludedFileCount}
-          onComplete={(result) => handleWizardComplete(result, phase.ctx)}
-          onCancel={() => finish({ kind: 'cancelled', reason: 'User cancelled in wizard.' })}
-          onError={(err) => finish({ kind: 'error', error: err })}
+          onComplete={onWizardComplete}
+          onCancel={onWizardCancel}
+          onError={onWizardError}
         />
       </RootFrame>
     );
@@ -460,15 +88,15 @@ export default function Install({ args, options }: Props) {
 
   if (phase.kind === 'collision') {
     return (
-      <RootFrame dryRun={Boolean(dryRun)}>
-        <CollisionReview collisions={phase.collisions} onChoice={handleCollisionChoice} />
+      <RootFrame dryRun={dryRun}>
+        <CollisionReview collisions={phase.collisions} onChoice={onCollisionChoice} />
       </RootFrame>
     );
   }
 
   if (phase.kind === 'installing') {
     return (
-      <RootFrame dryRun={Boolean(dryRun)} showLegend={false}>
+      <RootFrame dryRun={dryRun} showLegend={false}>
         <InstallProgress
           current={phase.current}
           total={phase.total}
@@ -482,7 +110,7 @@ export default function Install({ args, options }: Props) {
 
   if (phase.kind === 'summary') {
     return (
-      <RootFrame dryRun={Boolean(dryRun)} showLegend={false}>
+      <RootFrame dryRun={dryRun} showLegend={false}>
         <Summary
           manifest={phase.manifest}
           vaultRoot={phase.vaultRoot}
@@ -498,7 +126,7 @@ export default function Install({ args, options }: Props) {
 
   if (phase.kind === 'cancelled') {
     return (
-      <RootFrame dryRun={Boolean(dryRun)} showLegend={false}>
+      <RootFrame dryRun={dryRun} showLegend={false}>
         <Box flexDirection="column">
           <Alert variant="info">Cancelled</Alert>
           <Text dimColor>{phase.reason}</Text>
@@ -511,7 +139,7 @@ export default function Install({ args, options }: Props) {
   const code = err instanceof ShardMindError ? err.code : null;
   const hint = err instanceof ShardMindError ? err.hint : null;
   return (
-    <RootFrame dryRun={Boolean(dryRun)} showLegend={false}>
+    <RootFrame dryRun={dryRun} showLegend={false}>
       <Box flexDirection="column" gap={1}>
         <StatusMessage variant="error">{err.message}</StatusMessage>
         {code && <Text dimColor>code: {code}</Text>}
@@ -551,64 +179,6 @@ function RootFrame({
       )}
     </Box>
   );
-}
-
-async function loadValuesFile(
-  filePath: string,
-  schema: ShardSchema,
-): Promise<Record<string, unknown>> {
-  let raw: string;
-  try {
-    raw = await fsp.readFile(filePath, 'utf-8');
-  } catch (err) {
-    throw new ShardMindError(
-      `Could not read --values file: ${filePath}`,
-      'VALUES_FILE_READ_FAILED',
-      err instanceof Error ? err.message : String(err),
-    );
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = parseYaml(raw);
-  } catch (err) {
-    throw new ShardMindError(
-      `--values file is not valid YAML: ${filePath}`,
-      'VALUES_FILE_INVALID',
-      err instanceof Error ? err.message : String(err),
-    );
-  }
-
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    throw new ShardMindError(
-      `--values file must be a YAML mapping: ${filePath}`,
-      'VALUES_FILE_INVALID',
-      'Top level must be { key: value } entries matching shard schema value IDs.',
-    );
-  }
-
-  // Unknown keys are silently ignored so a values file can be reused
-  // across shard versions that have added or removed entries.
-  const filtered: Record<string, unknown> = {};
-  for (const key of Object.keys(schema.values)) {
-    if (key in (parsed as Record<string, unknown>)) {
-      filtered[key] = (parsed as Record<string, unknown>)[key];
-    }
-  }
-  return filtered;
-}
-
-function summarizeHook(result: HookResult): HookSummary | null {
-  switch (result.kind) {
-    case 'absent':
-      return null;
-    case 'deferred':
-      return { deferred: true };
-    case 'ran':
-      return { stdout: result.stdout, exitCode: result.exitCode };
-    case 'failed':
-      return { stdout: result.message, exitCode: 1 };
-  }
 }
 
 export const description = 'Install a shard into the current directory';

--- a/source/commands/install.tsx
+++ b/source/commands/install.tsx
@@ -70,6 +70,7 @@ interface PreparedContext {
   manifest: ShardManifest;
   schema: ShardSchema;
   tempDir: string;
+  tarballSha256: string;
   cleanup: () => Promise<void>;
   prefillValues: Record<string, unknown>;
   moduleFileCounts: Record<string, number>;
@@ -162,6 +163,7 @@ export default function Install({ args, options }: Props) {
           manifest,
           schema,
           tempDir: temp.tempDir,
+          tarballSha256: temp.tarball_sha256,
           cleanup: temp.cleanup,
           prefillValues: merged,
           moduleFileCounts,
@@ -249,6 +251,7 @@ export default function Install({ args, options }: Props) {
           schema: ctx.schema,
           tempDir: ctx.tempDir,
           resolved: ctx.resolved,
+          tarballSha256: ctx.tarballSha256,
           values: result.values,
           selections: result.selections,
           dryRun,

--- a/source/commands/install.tsx
+++ b/source/commands/install.tsx
@@ -30,6 +30,7 @@ import {
   type BackupRecord,
 } from '../core/install-plan.js';
 import { runPostInstallHook, type HookResult } from '../core/hook.js';
+import { SHARDMIND_DIR, VALUES_FILE } from '../runtime/vault-paths.js';
 
 import InstallWizard, { type WizardResult } from '../components/InstallWizard.js';
 import CollisionReview, { type CollisionAction } from '../components/CollisionReview.js';
@@ -400,8 +401,8 @@ export default function Install({ args, options }: Props) {
         (async () => {
           try {
             await Promise.all([
-              fsp.rm(path.join(vaultRoot, '.shardmind'), { recursive: true, force: true }),
-              fsp.rm(path.join(vaultRoot, 'shard-values.yaml'), { force: true }),
+              fsp.rm(path.join(vaultRoot, SHARDMIND_DIR), { recursive: true, force: true }),
+              fsp.rm(path.join(vaultRoot, VALUES_FILE), { force: true }),
             ]);
             if (yes) {
               await runNonInteractive(phase.ctx);

--- a/source/commands/install.tsx
+++ b/source/commands/install.tsx
@@ -16,19 +16,19 @@ import { parseSchema, buildValuesValidator } from '../core/schema.js';
 import { readState } from '../core/state.js';
 import {
   planOutputs,
-  runInstall,
-  rollbackInstall,
-} from '../core/install-runner.js';
-import {
   detectCollisions,
-  backupCollisions,
   mergePrefill,
   resolveComputedDefaults,
   missingValueKeys,
   defaultModuleSelections,
   type Collision,
+} from '../core/install-planner.js';
+import {
+  backupCollisions,
+  runInstall,
+  rollbackInstall,
   type BackupRecord,
-} from '../core/install-plan.js';
+} from '../core/install-executor.js';
 import { runPostInstallHook, type HookResult } from '../core/hook.js';
 import { SHARDMIND_DIR, VALUES_FILE } from '../runtime/vault-paths.js';
 

--- a/source/components/CollisionReview.tsx
+++ b/source/components/CollisionReview.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from 'ink';
 import { Select, Alert } from '@inkjs/ui';
-import type { Collision } from '../core/install-plan.js';
+import type { Collision } from '../core/install-planner.js';
 
 export type CollisionAction = 'backup' | 'overwrite' | 'cancel';
 

--- a/source/components/InstallWizard.tsx
+++ b/source/components/InstallWizard.tsx
@@ -9,7 +9,7 @@ import {
   missingValueKeys,
   resolveComputedDefaults,
   defaultModuleSelections,
-} from '../core/install-plan.js';
+} from '../core/install-planner.js';
 import { isComputedDefault } from '../core/schema.js';
 
 export interface WizardResult {

--- a/source/components/Summary.tsx
+++ b/source/components/Summary.tsx
@@ -2,7 +2,7 @@ import os from 'node:os';
 import { Box, Text } from 'ink';
 import { StatusMessage } from '@inkjs/ui';
 import type { ShardManifest } from '../runtime/types.js';
-import type { BackupRecord } from '../core/install-plan.js';
+import type { BackupRecord } from '../core/install-executor.js';
 
 interface SummaryProps {
   manifest: ShardManifest;

--- a/source/core/download.ts
+++ b/source/core/download.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import crypto from 'node:crypto';
-import { Readable } from 'node:stream';
+import { Readable, Transform } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import * as tar from 'tar';
 import type { TempShard } from '../runtime/types.js';
@@ -51,11 +51,18 @@ export async function downloadShard(tarballUrl: string): Promise<TempShard> {
     );
   }
 
-  // Extract tarball
+  // Extract tarball and hash the bytes in the same pass.
+  const hasher = crypto.createHash('sha256');
   try {
     const nodeStream = Readable.fromWeb(response.body as import('node:stream/web').ReadableStream);
+    const hashTap = new Transform({
+      transform(chunk, _enc, cb) {
+        hasher.update(chunk);
+        cb(null, chunk);
+      },
+    });
     const extractor = tar.x({ strip: 1, C: tempDir });
-    await pipeline(nodeStream, extractor);
+    await pipeline(nodeStream, hashTap, extractor);
   } catch (err) {
     await safeCleanup(tempDir);
     const message = err instanceof Error ? err.message : String(err);
@@ -96,6 +103,7 @@ export async function downloadShard(tarballUrl: string): Promise<TempShard> {
     tempDir,
     manifest: manifestPath,
     schema: schemaPath,
+    tarball_sha256: hasher.digest('hex'),
     cleanup: () => cleanup(tempDir),
   };
 }

--- a/source/core/download.ts
+++ b/source/core/download.ts
@@ -7,6 +7,7 @@ import { pipeline } from 'node:stream/promises';
 import * as tar from 'tar';
 import type { TempShard } from '../runtime/types.js';
 import { ShardMindError } from '../runtime/types.js';
+import { SHARD_MANIFEST_FILE, SHARD_SCHEMA_FILE } from '../runtime/vault-paths.js';
 
 export async function downloadShard(tarballUrl: string): Promise<TempShard> {
   const tempDir = path.join(os.tmpdir(), `shardmind-${crypto.randomUUID()}`);
@@ -74,8 +75,8 @@ export async function downloadShard(tarballUrl: string): Promise<TempShard> {
   }
 
   // Verify required files
-  const manifestPath = path.join(tempDir, 'shard.yaml');
-  const schemaPath = path.join(tempDir, 'shard-schema.yaml');
+  const manifestPath = path.join(tempDir, SHARD_MANIFEST_FILE);
+  const schemaPath = path.join(tempDir, SHARD_SCHEMA_FILE);
 
   try {
     await fs.access(manifestPath);

--- a/source/core/install-executor.ts
+++ b/source/core/install-executor.ts
@@ -41,6 +41,7 @@ export interface InstallRunnerOptions {
   schema: ShardSchema;
   tempDir: string;
   resolved: ResolvedShard;
+  tarballSha256: string;
   values: Record<string, unknown>;
   selections: ModuleSelections;
   onProgress?: (event: ProgressEvent) => void;
@@ -141,7 +142,7 @@ export async function restoreBackups(
  * Returns writtenPaths so the caller can roll back on later failure.
  */
 export async function runInstall(opts: InstallRunnerOptions): Promise<InstallResult> {
-  const { vaultRoot, manifest, schema, tempDir, resolved, values, selections, onProgress, onFileWritten, dryRun } = opts;
+  const { vaultRoot, manifest, schema, tempDir, resolved, tarballSha256, values, selections, onProgress, onFileWritten, dryRun } = opts;
 
   const resolution = await resolveModules(schema, selections, tempDir);
   const totalFiles = resolution.render.length + resolution.copy.length;
@@ -219,6 +220,7 @@ export async function runInstall(opts: InstallRunnerOptions): Promise<InstallRes
     shard: `${manifest.namespace}/${manifest.name}`,
     source: resolved.source,
     version: manifest.version,
+    tarball_sha256: tarballSha256,
     installed_at: context.install_date,
     updated_at: context.install_date,
     values_hash: hashValues(values),

--- a/source/core/install-executor.ts
+++ b/source/core/install-executor.ts
@@ -1,3 +1,11 @@
+/**
+ * Install executor — disk-mutating operations.
+ *
+ * The counterpart to `install-planner.ts`. Functions here write, rename,
+ * or delete files in the vault. Read-only enumeration and planning
+ * stays in the planner.
+ */
+
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import { stringify as stringifyYaml } from 'yaml';
@@ -18,13 +26,13 @@ import {
   cacheManifest,
   writeState,
 } from './state.js';
-import { restoreBackups, type BackupRecord } from './install-plan.js';
-import { sha256, toPosix } from './fs-utils.js';
+import { sha256, toPosix, pathExists } from './fs-utils.js';
+import { hashValues, type Collision } from './install-planner.js';
 import { SHARDMIND_DIR, VALUES_FILE, SHARD_TEMPLATES_DIR } from '../runtime/vault-paths.js';
 
-export interface PlannedOutput {
-  outputPath: string;
-  source: 'render' | 'copy';
+export interface BackupRecord {
+  originalPath: string;
+  backupPath: string;
 }
 
 export interface InstallRunnerOptions {
@@ -56,44 +64,81 @@ export type ProgressEvent =
   | { kind: 'done'; total: number };
 
 /**
- * Enumerate every file that would be written given the selected modules.
- * Used for collision detection and module file counting before install.
+ * Rename each colliding path to `<original>.shardmind-backup-<timestamp>`.
+ * Works for both files and directories (fsp.rename handles both).
+ * Unique-suffix-appends when the canonical backup name already exists.
  */
-export async function planOutputs(
-  schema: ShardSchema,
-  tempDir: string,
-  selections: ModuleSelections,
-): Promise<{
-  outputs: PlannedOutput[];
-  moduleFileCounts: Record<string, number>;
-  alwaysIncludedFileCount: number;
-}> {
-  const resolution = await resolveModules(schema, selections, tempDir);
-  const outputs: PlannedOutput[] = [];
-  const moduleFileCounts: Record<string, number> = {};
-  let alwaysIncludedFileCount = 0;
+export async function backupCollisions(
+  collisions: Collision[],
+  timestamp: Date = new Date(),
+): Promise<BackupRecord[]> {
+  const stamp = timestamp.toISOString().replace(/:/g, '-').replace(/\..+$/, '');
+  const records: BackupRecord[] = [];
 
-  for (const id of Object.keys(schema.modules)) {
-    moduleFileCounts[id] = 0;
+  for (const collision of collisions) {
+    const backupPath = await uniqueBackupPath(collision.absolutePath, stamp);
+    try {
+      await fsp.rename(collision.absolutePath, backupPath);
+    } catch (err) {
+      throw new ShardMindError(
+        `Could not back up existing file: ${collision.absolutePath}`,
+        'BACKUP_FAILED',
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+    records.push({ originalPath: collision.absolutePath, backupPath });
   }
 
-  const tally = (entry: { outputPath: string; module: string | null }, source: 'render' | 'copy') => {
-    outputs.push({ outputPath: entry.outputPath, source });
-    if (entry.module && entry.module in moduleFileCounts) {
-      moduleFileCounts[entry.module]!++;
-    } else if (!entry.module) {
-      alwaysIncludedFileCount++;
-    }
-  };
-  for (const entry of resolution.render) tally(entry, 'render');
-  for (const entry of resolution.copy) tally(entry, 'copy');
+  return records;
+}
 
-  return { outputs, moduleFileCounts, alwaysIncludedFileCount };
+async function uniqueBackupPath(absolutePath: string, stamp: string): Promise<string> {
+  const base = `${absolutePath}.shardmind-backup-${stamp}`;
+  if (!(await pathExists(base))) return base;
+  for (let i = 1; i < 1000; i++) {
+    const candidate = `${base}.${i}`;
+    if (!(await pathExists(candidate))) return candidate;
+  }
+  throw new ShardMindError(
+    `Could not find a unique backup name for ${absolutePath}`,
+    'BACKUP_FAILED',
+    'Too many existing backups with the same timestamp — clean up old .shardmind-backup-* files and retry.',
+  );
+}
+
+/**
+ * Move backup files back to their original paths. Used during rollback
+ * after a failed install so the user's pre-install content comes back
+ * intact. Best-effort per entry — individual failures are reported but
+ * don't abort the rest of the restore.
+ */
+export async function restoreBackups(
+  records: BackupRecord[],
+): Promise<{ restored: BackupRecord[]; failed: Array<BackupRecord & { reason: string }> }> {
+  const restored: BackupRecord[] = [];
+  const failed: Array<BackupRecord & { reason: string }> = [];
+
+  for (const record of records) {
+    try {
+      // Remove whatever the partial install wrote at the original path,
+      // then move the backup back.
+      await fsp.rm(record.originalPath, { recursive: true, force: true });
+      await fsp.rename(record.backupPath, record.originalPath);
+      restored.push(record);
+    } catch (err) {
+      failed.push({
+        ...record,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return { restored, failed };
 }
 
 /**
  * Execute the install pipeline: render + copy + write + cache + state.
- * Returns paths written so the caller can roll back on later failure.
+ * Returns writtenPaths so the caller can roll back on later failure.
  */
 export async function runInstall(opts: InstallRunnerOptions): Promise<InstallResult> {
   const { vaultRoot, manifest, schema, tempDir, resolved, values, selections, onProgress, onFileWritten, dryRun } = opts;
@@ -186,9 +231,6 @@ export async function runInstall(opts: InstallRunnerOptions): Promise<InstallRes
     await cacheTemplates(vaultRoot, tempDir);
     await cacheManifest(vaultRoot, manifest, schema);
     await writeState(vaultRoot, state);
-    // shard-values.yaml is user-owned; install must create it fresh.
-    // Use `wx` so an existing file races cleanly to EEXIST instead of
-    // being silently overwritten if ExistingInstallGate was bypassed.
     await writeValuesFile(vaultRoot, values);
     writtenPaths.push(VALUES_FILE);
     onFileWritten?.(VALUES_FILE);
@@ -198,11 +240,10 @@ export async function runInstall(opts: InstallRunnerOptions): Promise<InstallRes
 }
 
 /**
- * Roll back a partial install. Removes all written files, cleans up
- * empty parent directories, deletes .shardmind/ if present, and
- * restores any backups created during collision handling.
- * Best-effort — errors during rollback are swallowed because the
- * primary failure is already being reported.
+ * Roll back a partial install. Removes written files, cleans up empty
+ * parent directories, deletes .shardmind/ if present, and restores any
+ * backups. Best-effort — errors during rollback are swallowed because
+ * the primary failure is already being reported.
  */
 export async function rollbackInstall(
   vaultRoot: string,
@@ -213,9 +254,8 @@ export async function rollbackInstall(
     (a, b) => b.split('/').length - a.split('/').length,
   );
   for (const rel of sortedByDepth) {
-    const abs = path.join(vaultRoot, rel);
     try {
-      await fsp.unlink(abs);
+      await fsp.unlink(path.join(vaultRoot, rel));
     } catch {
       // already gone
     }
@@ -252,28 +292,6 @@ export async function rollbackInstall(
   }
 }
 
-export function hashValues(values: Record<string, unknown>): string {
-  return sha256(JSON.stringify(stableJson(values)));
-}
-
-/**
- * Recursively reorder object keys alphabetically so `JSON.stringify`
- * produces a deterministic byte sequence. Arrays keep their order;
- * primitives pass through. Unlike the `replacer` array overload of
- * JSON.stringify, this does NOT drop nested object keys.
- */
-function stableJson(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(stableJson);
-  if (value && typeof value === 'object') {
-    const sorted: Record<string, unknown> = {};
-    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
-      sorted[key] = stableJson((value as Record<string, unknown>)[key]);
-    }
-    return sorted;
-  }
-  return value;
-}
-
 async function writeVaultFile(
   vaultRoot: string,
   outputPath: string,
@@ -294,6 +312,11 @@ async function writeVaultFileBuffer(
   await fsp.writeFile(abs, content);
 }
 
+/**
+ * `wx` flag: refuse to overwrite an existing file. Catching EEXIST here
+ * is the last defense against a stale values file slipping past
+ * ExistingInstallGate.
+ */
 async function writeValuesFile(
   vaultRoot: string,
   values: Record<string, unknown>,

--- a/source/core/install-planner.ts
+++ b/source/core/install-planner.ts
@@ -1,10 +1,23 @@
+/**
+ * Install planner — pure + read-only operations.
+ *
+ * Everything here answers "what would the install do?" without touching
+ * disk beyond reading the downloaded shard's temp directory. Disk
+ * mutations (backup, write, rollback) live in `install-executor.ts`.
+ */
+
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import nunjucks from 'nunjucks';
-import type { ShardSchema, ValueDefinition, ModuleSelections } from '../runtime/types.js';
+import type {
+  ShardSchema,
+  ValueDefinition,
+  ModuleSelections,
+} from '../runtime/types.js';
 import { ShardMindError, assertNever } from '../runtime/types.js';
 import { isComputedDefault } from './schema.js';
-import { pathExists } from './fs-utils.js';
+import { resolveModules } from './modules.js';
+import { sha256 } from './fs-utils.js';
 
 export interface Collision {
   outputPath: string;
@@ -14,20 +27,11 @@ export interface Collision {
   kind: 'file' | 'directory';
 }
 
-export interface BackupRecord {
-  originalPath: string;
-  backupPath: string;
+export interface PlannedOutput {
+  outputPath: string;
+  source: 'render' | 'copy';
 }
 
-/**
- * Resolve values whose default is a computed expression (`{{ ... }}`).
- * Runs after non-computed values have been collected from the wizard or
- * a --values file.
- *
- * The expression is rendered through a standalone Nunjucks environment
- * (autoescape off) with the already-collected values as context.
- * The resulting string is coerced back into the value's declared type.
- */
 export function resolveComputedDefaults(
   schema: ShardSchema,
   collected: Record<string, unknown>,
@@ -36,7 +40,7 @@ export function resolveComputedDefaults(
   const result: Record<string, unknown> = { ...collected };
 
   for (const [key, def] of Object.entries(schema.values)) {
-    if (result[key] !== undefined) continue; // user already answered
+    if (result[key] !== undefined) continue;
     if (def.default === undefined) continue;
     if (!isComputedDefault(def.default)) continue;
 
@@ -103,8 +107,9 @@ function coerceToType(raw: string, def: ValueDefinition, key: string): unknown {
 
 /**
  * Detect which planned output paths already exist on disk.
- * Returns one Collision per existing file with size + mtime so the user
- * can make an informed choice between backup / overwrite / cancel.
+ * Flags files AND directories — a directory at a planned file path
+ * would cause EISDIR during write; the UI labels each entry so the
+ * user sees what's actually in the way.
  */
 export async function detectCollisions(
   vaultRoot: string,
@@ -116,9 +121,6 @@ export async function detectCollisions(
     const absolutePath = path.join(vaultRoot, outputPath);
     try {
       const stat = await fsp.stat(absolutePath);
-      // Flag both files and directories — a directory at a planned file
-      // path would cause EISDIR during write. The UI shows both with
-      // clear labels so the user sees the real blocker.
       if (stat.isFile() || stat.isDirectory()) {
         collisions.push({
           outputPath,
@@ -143,88 +145,6 @@ export async function detectCollisions(
   return collisions;
 }
 
-/**
- * Rename each colliding file to `<original>.shardmind-backup-<timestamp>`.
- * Timestamp is ISO-8601 compact (no colons) so the name is filesystem-safe.
- * If multiple collisions share the same timestamp suffix (same second,
- * or an earlier backup still on disk), we increment a counter to keep
- * backup names unique. Returns a record per backup so callers can
- * surface them in the summary and the rollback path can restore them.
- */
-export async function backupCollisions(
-  collisions: Collision[],
-  timestamp: Date = new Date(),
-): Promise<BackupRecord[]> {
-  const stamp = timestamp.toISOString().replace(/:/g, '-').replace(/\..+$/, '');
-  const records: BackupRecord[] = [];
-
-  for (const collision of collisions) {
-    const backupPath = await uniqueBackupPath(collision.absolutePath, stamp);
-    try {
-      await fsp.rename(collision.absolutePath, backupPath);
-    } catch (err) {
-      throw new ShardMindError(
-        `Could not back up existing file: ${collision.absolutePath}`,
-        'BACKUP_FAILED',
-        err instanceof Error ? err.message : String(err),
-      );
-    }
-    records.push({ originalPath: collision.absolutePath, backupPath });
-  }
-
-  return records;
-}
-
-async function uniqueBackupPath(absolutePath: string, stamp: string): Promise<string> {
-  const base = `${absolutePath}.shardmind-backup-${stamp}`;
-  if (!(await pathExists(base))) return base;
-  for (let i = 1; i < 1000; i++) {
-    const candidate = `${base}.${i}`;
-    if (!(await pathExists(candidate))) return candidate;
-  }
-  throw new ShardMindError(
-    `Could not find a unique backup name for ${absolutePath}`,
-    'BACKUP_FAILED',
-    'Too many existing backups with the same timestamp — clean up old .shardmind-backup-* files and retry.',
-  );
-}
-
-/**
- * Restore backups to their original paths. Used during rollback after
- * a failed install so the user's pre-install content comes back intact.
- * Best-effort per entry — individual failures are logged via the return
- * value but don't abort the rest of the restore.
- */
-export async function restoreBackups(
-  records: BackupRecord[],
-): Promise<{ restored: BackupRecord[]; failed: Array<BackupRecord & { reason: string }> }> {
-  const restored: BackupRecord[] = [];
-  const failed: Array<BackupRecord & { reason: string }> = [];
-
-  for (const record of records) {
-    try {
-      // Remove whatever the partial install wrote at the original path,
-      // then move the backup back.
-      await fsp.rm(record.originalPath, { recursive: true, force: true });
-      await fsp.rename(record.backupPath, record.originalPath);
-      restored.push(record);
-    } catch (err) {
-      failed.push({
-        ...record,
-        reason: err instanceof Error ? err.message : String(err),
-      });
-    }
-  }
-
-  return { restored, failed };
-}
-
-/**
- * Merge default values from the schema with prefill values provided via
- * `--values file.yaml`. Prefill wins over schema defaults. Computed
- * defaults are left unresolved (caller runs `resolveComputedDefaults`
- * after all prompts complete).
- */
 export function mergePrefill(
   schema: ShardSchema,
   prefill: Record<string, unknown>,
@@ -244,11 +164,6 @@ export function mergePrefill(
   return merged;
 }
 
-/**
- * Which schema value IDs still need prompting — not present in the
- * (prefill + static defaults) snapshot, not computed. Preserves schema
- * declaration order so the wizard walks values in the author's order.
- */
 export function missingValueKeys(
   schema: ShardSchema,
   snapshot: Record<string, unknown>,
@@ -262,17 +177,68 @@ export function missingValueKeys(
   return missing;
 }
 
-/**
- * Initial module selections: every module present in schema, with
- * `removable: false` locked to 'included' and `removable: true`
- * defaulting to 'included' (user unchecks to exclude).
- */
-export function defaultModuleSelections(
-  schema: ShardSchema,
-): ModuleSelections {
+export function defaultModuleSelections(schema: ShardSchema): ModuleSelections {
   const selections: ModuleSelections = {};
   for (const id of Object.keys(schema.modules)) {
     selections[id] = 'included';
   }
   return selections;
+}
+
+/**
+ * Enumerate every file that would be written given the selected modules.
+ * Reads the temp directory; does not touch the vault.
+ */
+export async function planOutputs(
+  schema: ShardSchema,
+  tempDir: string,
+  selections: ModuleSelections,
+): Promise<{
+  outputs: PlannedOutput[];
+  moduleFileCounts: Record<string, number>;
+  alwaysIncludedFileCount: number;
+}> {
+  const resolution = await resolveModules(schema, selections, tempDir);
+  const outputs: PlannedOutput[] = [];
+  const moduleFileCounts: Record<string, number> = {};
+  let alwaysIncludedFileCount = 0;
+
+  for (const id of Object.keys(schema.modules)) {
+    moduleFileCounts[id] = 0;
+  }
+
+  const tally = (entry: { outputPath: string; module: string | null }, source: 'render' | 'copy') => {
+    outputs.push({ outputPath: entry.outputPath, source });
+    if (entry.module && entry.module in moduleFileCounts) {
+      moduleFileCounts[entry.module]!++;
+    } else if (!entry.module) {
+      alwaysIncludedFileCount++;
+    }
+  };
+  for (const entry of resolution.render) tally(entry, 'render');
+  for (const entry of resolution.copy) tally(entry, 'copy');
+
+  return { outputs, moduleFileCounts, alwaysIncludedFileCount };
+}
+
+export function hashValues(values: Record<string, unknown>): string {
+  return sha256(JSON.stringify(stableJson(values)));
+}
+
+/**
+ * Recursively reorder object keys alphabetically so JSON.stringify produces
+ * a deterministic byte sequence. Arrays keep their order; primitives pass
+ * through. Unlike the `replacer` array overload of JSON.stringify, this
+ * does NOT drop nested object keys.
+ */
+function stableJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableJson);
+  if (value && typeof value === 'object') {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      sorted[key] = stableJson((value as Record<string, unknown>)[key]);
+    }
+    return sorted;
+  }
+  return value;
 }

--- a/source/core/install-runner.ts
+++ b/source/core/install-runner.ts
@@ -6,13 +6,12 @@ import type {
   ShardSchema,
   ShardState,
   FileState,
-  RenderContext,
   ResolvedShard,
   ModuleSelections,
 } from '../runtime/types.js';
 import { ShardMindError } from '../runtime/types.js';
 import { resolveModules } from './modules.js';
-import { createRenderer, renderFile } from './renderer.js';
+import { createRenderer, renderFile, buildRenderContext } from './renderer.js';
 import {
   initShardDir,
   cacheTemplates,
@@ -21,7 +20,7 @@ import {
 } from './state.js';
 import { restoreBackups, type BackupRecord } from './install-plan.js';
 import { sha256, toPosix } from './fs-utils.js';
-import { SHARDMIND_DIR, VALUES_FILE } from '../runtime/vault-paths.js';
+import { SHARDMIND_DIR, VALUES_FILE, SHARD_TEMPLATES_DIR } from '../runtime/vault-paths.js';
 
 export interface PlannedOutput {
   outputPath: string;
@@ -106,17 +105,8 @@ export async function runInstall(opts: InstallRunnerOptions): Promise<InstallRes
 
   onProgress?.({ kind: 'start', total: totalFiles });
 
-  const env = createRenderer(path.join(tempDir, 'templates'));
-  const includedModules = Object.entries(selections)
-    .filter(([, s]) => s === 'included')
-    .map(([id]) => id);
-  const context: RenderContext = {
-    values,
-    included_modules: includedModules,
-    shard: { name: manifest.name, version: manifest.version },
-    install_date: new Date().toISOString(),
-    year: new Date().getUTCFullYear().toString(),
-  };
+  const env = createRenderer(path.join(tempDir, SHARD_TEMPLATES_DIR));
+  const context = buildRenderContext(manifest, values, selections);
 
   let index = 0;
 

--- a/source/core/install-runner.ts
+++ b/source/core/install-runner.ts
@@ -21,6 +21,7 @@ import {
 } from './state.js';
 import { restoreBackups, type BackupRecord } from './install-plan.js';
 import { sha256, toPosix } from './fs-utils.js';
+import { SHARDMIND_DIR, VALUES_FILE } from '../runtime/vault-paths.js';
 
 export interface PlannedOutput {
   outputPath: string;
@@ -199,8 +200,8 @@ export async function runInstall(opts: InstallRunnerOptions): Promise<InstallRes
     // Use `wx` so an existing file races cleanly to EEXIST instead of
     // being silently overwritten if ExistingInstallGate was bypassed.
     await writeValuesFile(vaultRoot, values);
-    writtenPaths.push('shard-values.yaml');
-    onFileWritten?.('shard-values.yaml');
+    writtenPaths.push(VALUES_FILE);
+    onFileWritten?.(VALUES_FILE);
   }
 
   return { writtenPaths, state, fileCount: totalFiles };
@@ -249,7 +250,7 @@ export async function rollbackInstall(
   }
 
   try {
-    await fsp.rm(path.join(vaultRoot, '.shardmind'), { recursive: true, force: true });
+    await fsp.rm(path.join(vaultRoot, SHARDMIND_DIR), { recursive: true, force: true });
   } catch {
     // ignore
   }
@@ -307,7 +308,7 @@ async function writeValuesFile(
   vaultRoot: string,
   values: Record<string, unknown>,
 ): Promise<void> {
-  const abs = path.join(vaultRoot, 'shard-values.yaml');
+  const abs = path.join(vaultRoot, VALUES_FILE);
   const serialized = stringifyYaml(values, { lineWidth: 0 }).trimEnd() + '\n';
   try {
     await fsp.writeFile(abs, serialized, { encoding: 'utf-8', flag: 'wx' });

--- a/source/core/modules.ts
+++ b/source/core/modules.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { ShardSchema, ModuleResolution, FileEntry, ModuleSelections } from '../runtime/types.js';
+import { SHARD_TEMPLATES_DIR } from '../runtime/vault-paths.js';
 
 const VOLATILE_MARKER = '{# shardmind: volatile #}';
 
@@ -17,7 +18,7 @@ export async function resolveModules(
   const skip: FileEntry[] = [];
 
   // 1. Walk templates/ directory
-  const templatesDir = path.join(tempDir, 'templates');
+  const templatesDir = path.join(tempDir, SHARD_TEMPLATES_DIR);
   if (await dirExists(templatesDir)) {
     const files = await walkDir(templatesDir);
     for (const absPath of files) {

--- a/source/core/renderer.ts
+++ b/source/core/renderer.ts
@@ -2,7 +2,13 @@ import fs from 'node:fs/promises';
 import crypto from 'node:crypto';
 import nunjucks from 'nunjucks';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
-import type { FileEntry, RenderedFile, RenderContext } from '../runtime/types.js';
+import type {
+  FileEntry,
+  RenderedFile,
+  RenderContext,
+  ShardManifest,
+  ModuleSelections,
+} from '../runtime/types.js';
 import { ShardMindError } from '../runtime/types.js';
 
 const VOLATILE_MARKER = '{# shardmind: volatile #}';
@@ -14,6 +20,30 @@ export function createRenderer(templateDir: string): nunjucks.Environment {
     trimBlocks: true,
     lstripBlocks: true,
   });
+}
+
+/**
+ * Build the Nunjucks render context for an install or update operation.
+ * Centralizes the shape so the two commands can't drift apart on what's
+ * available to templates.
+ */
+export function buildRenderContext(
+  manifest: ShardManifest,
+  values: Record<string, unknown>,
+  selections: ModuleSelections,
+  now: Date = new Date(),
+): RenderContext {
+  const included_modules = Object.entries(selections)
+    .filter(([, s]) => s === 'included')
+    .map(([id]) => id);
+
+  return {
+    values,
+    included_modules,
+    shard: { name: manifest.name, version: manifest.version },
+    install_date: now.toISOString(),
+    year: now.getUTCFullYear().toString(),
+  };
 }
 
 export async function renderFile(

--- a/source/core/schema.ts
+++ b/source/core/schema.ts
@@ -1,3 +1,15 @@
+/**
+ * Engine-side schema parsing + validation. Reads `shard-schema.yaml`
+ * from a downloaded shard's temp directory, validates via zod, enforces
+ * cross-references (group/module IDs, reserved names), and normalizes
+ * frontmatter shorthand. Also builds the dynamic zod validator for
+ * user-supplied values.
+ *
+ * `source/runtime/schema.ts` is the thin read-only counterpart used by
+ * hook scripts. That one loads the already-cached copy and skips most
+ * validation — the engine validated it on install.
+ */
+
 import fs from 'node:fs/promises';
 import { parse as parseYaml } from 'yaml';
 import { z } from 'zod';

--- a/source/core/schema.ts
+++ b/source/core/schema.ts
@@ -99,6 +99,19 @@ export function isComputedDefault(value: unknown): boolean {
   return typeof value === 'string' && value.trimStart().startsWith('{{');
 }
 
+/**
+ * Keys provided by the render context. Shard authors cannot declare
+ * schema values with these names because they would silently shadow
+ * the engine-provided context at render time.
+ */
+export const RESERVED_VALUE_KEYS = new Set([
+  'shard',
+  'install_date',
+  'year',
+  'included_modules',
+  'values',
+]);
+
 export async function parseSchema(filePath: string): Promise<ShardSchema> {
   let raw: string;
   try {
@@ -145,6 +158,17 @@ export async function parseSchema(filePath: string): Promise<ShardSchema> {
   }
 
   const data = result.data;
+
+  // Reserved-name guard: reject schema values whose key collides with
+  // a render-context field (shard, install_date, year, etc.).
+  const reserved = Object.keys(data.values).filter(k => RESERVED_VALUE_KEYS.has(k));
+  if (reserved.length > 0) {
+    throw new ShardMindError(
+      `shard-schema.yaml uses reserved value name${reserved.length === 1 ? '' : 's'}: ${reserved.join(', ')}`,
+      'SCHEMA_RESERVED_NAME',
+      `Rename to avoid collision with the render context. Reserved: ${[...RESERVED_VALUE_KEYS].join(', ')}`,
+    );
+  }
 
   // Cross-validate: every value's group must exist
   const groupIds = new Set(data.groups.map(g => g.id));

--- a/source/core/state-migrator.ts
+++ b/source/core/state-migrator.ts
@@ -1,0 +1,51 @@
+/**
+ * state.json schema migration framework.
+ *
+ * `readState` delegates to `migrateState` whenever the version in the
+ * on-disk file differs from the engine's current `STATE_SCHEMA_VERSION`.
+ * Migration rules are encoded as an ordered chain: each step takes the
+ * previous shape and returns the next, stopping when the version matches.
+ *
+ * v0.1 has no rules because no shape evolution has happened yet. The
+ * framework is here so v0.2 (shard composition, multi-shard vaults,
+ * etc.) can slot rules in without a breaking format change.
+ *
+ * Usage pattern when adding a migration:
+ *
+ *   const migrations: StateMigration[] = [
+ *     { fromVersion: 1, toVersion: 2, apply: (s) => ({ ...s, shards: [...] }) },
+ *   ];
+ */
+
+import type { ShardState } from '../runtime/types.js';
+
+export interface StateMigration {
+  fromVersion: number;
+  toVersion: number;
+  apply: (state: unknown) => unknown;
+}
+
+const migrations: StateMigration[] = [];
+
+/**
+ * Migrate an on-disk state object up to the target version.
+ * Returns null if no migration chain exists from the current version
+ * (caller should throw STATE_UNSUPPORTED_VERSION).
+ */
+export function migrateState(
+  state: unknown,
+  fromVersion: number,
+  targetVersion: number,
+): ShardState | null {
+  let current: unknown = state;
+  let version = fromVersion;
+
+  while (version !== targetVersion) {
+    const step = migrations.find((m) => m.fromVersion === version);
+    if (!step) return null;
+    current = step.apply(current);
+    version = step.toVersion;
+  }
+
+  return current as ShardState;
+}

--- a/source/core/state.ts
+++ b/source/core/state.ts
@@ -11,6 +11,7 @@ import {
   CACHED_TEMPLATES,
   SHARD_TEMPLATES_DIR,
 } from '../runtime/vault-paths.js';
+import { migrateState } from './state-migrator.js';
 
 const STATE_SCHEMA_VERSION = 1;
 
@@ -54,15 +55,18 @@ export async function readState(vaultRoot: string): Promise<ShardState | null> {
   }
 
   const version = (parsed as { schema_version: number }).schema_version;
-  if (version !== STATE_SCHEMA_VERSION) {
-    throw new ShardMindError(
-      `Unsupported state schema_version: ${version}`,
-      'STATE_UNSUPPORTED_VERSION',
-      `This version of shardmind supports schema_version ${STATE_SCHEMA_VERSION}.`,
-    );
+  if (version === STATE_SCHEMA_VERSION) {
+    return parsed as ShardState;
   }
 
-  return parsed as ShardState;
+  const migrated = migrateState(parsed, version, STATE_SCHEMA_VERSION);
+  if (migrated) return migrated;
+
+  throw new ShardMindError(
+    `Unsupported state schema_version: ${version}`,
+    'STATE_UNSUPPORTED_VERSION',
+    `This version of shardmind supports schema_version ${STATE_SCHEMA_VERSION}. No migration rule is registered for ${version} → ${STATE_SCHEMA_VERSION}.`,
+  );
 }
 
 export async function writeState(vaultRoot: string, state: ShardState): Promise<void> {

--- a/source/core/state.ts
+++ b/source/core/state.ts
@@ -3,11 +3,19 @@ import path from 'node:path';
 import type { ShardState, ShardManifest, ShardSchema } from '../runtime/types.js';
 import { ShardMindError } from '../runtime/types.js';
 import { stringify as stringifyYaml } from 'yaml';
+import {
+  SHARDMIND_DIR,
+  STATE_FILE,
+  CACHED_MANIFEST,
+  CACHED_SCHEMA,
+  CACHED_TEMPLATES,
+  SHARD_TEMPLATES_DIR,
+} from '../runtime/vault-paths.js';
 
 const STATE_SCHEMA_VERSION = 1;
 
 export async function readState(vaultRoot: string): Promise<ShardState | null> {
-  const filePath = path.join(vaultRoot, '.shardmind', 'state.json');
+  const filePath = path.join(vaultRoot, STATE_FILE);
 
   let raw: string;
   try {
@@ -58,8 +66,8 @@ export async function readState(vaultRoot: string): Promise<ShardState | null> {
 }
 
 export async function writeState(vaultRoot: string, state: ShardState): Promise<void> {
-  const shardDir = path.join(vaultRoot, '.shardmind');
-  const filePath = path.join(shardDir, 'state.json');
+  const shardDir = path.join(vaultRoot, SHARDMIND_DIR);
+  const filePath = path.join(vaultRoot, STATE_FILE);
 
   await fsp.mkdir(shardDir, { recursive: true });
 
@@ -76,13 +84,12 @@ export async function writeState(vaultRoot: string, state: ShardState): Promise<
 }
 
 export async function initShardDir(vaultRoot: string): Promise<void> {
-  const shardDir = path.join(vaultRoot, '.shardmind');
-  await fsp.mkdir(path.join(shardDir, 'templates'), { recursive: true });
+  await fsp.mkdir(path.join(vaultRoot, CACHED_TEMPLATES), { recursive: true });
 }
 
 export async function cacheTemplates(vaultRoot: string, tempDir: string): Promise<void> {
-  const src = path.join(tempDir, 'templates');
-  const dest = path.join(vaultRoot, '.shardmind', 'templates');
+  const src = path.join(tempDir, SHARD_TEMPLATES_DIR);
+  const dest = path.join(vaultRoot, CACHED_TEMPLATES);
 
   await fsp.rm(dest, { recursive: true, force: true });
   await fsp.mkdir(dest, { recursive: true });
@@ -106,22 +113,13 @@ export async function cacheManifest(
   manifest: ShardManifest,
   schema: ShardSchema,
 ): Promise<void> {
-  const shardDir = path.join(vaultRoot, '.shardmind');
-  await fsp.mkdir(shardDir, { recursive: true });
+  await fsp.mkdir(path.join(vaultRoot, SHARDMIND_DIR), { recursive: true });
 
   const serializedManifest = stringifyYaml(manifest, { lineWidth: 0 }).trimEnd() + '\n';
   const serializedSchema = stringifyYaml(schema, { lineWidth: 0 }).trimEnd() + '\n';
 
-  await fsp.writeFile(
-    path.join(shardDir, 'shard.yaml'),
-    serializedManifest,
-    'utf-8',
-  );
-  await fsp.writeFile(
-    path.join(shardDir, 'shard-schema.yaml'),
-    serializedSchema,
-    'utf-8',
-  );
+  await fsp.writeFile(path.join(vaultRoot, CACHED_MANIFEST), serializedManifest, 'utf-8');
+  await fsp.writeFile(path.join(vaultRoot, CACHED_SCHEMA), serializedSchema, 'utf-8');
 }
 
 function errnoCode(err: unknown): string | undefined {

--- a/source/core/state.ts
+++ b/source/core/state.ts
@@ -1,3 +1,14 @@
+/**
+ * Engine-owned state I/O. Reads AND writes `.shardmind/state.json`,
+ * caches manifest/schema/templates at install time, and gates on
+ * schema_version migrations.
+ *
+ * The read-only counterpart for hook scripts lives at
+ * `source/runtime/state.ts`. Runtime never imports from here; the
+ * duplication of filename is intentional (same concern, different
+ * audience, different permissions).
+ */
+
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import type { ShardState, ShardManifest, ShardSchema } from '../runtime/types.js';

--- a/source/runtime/frontmatter.ts
+++ b/source/runtime/frontmatter.ts
@@ -1,8 +1,40 @@
+/**
+ * Frontmatter validation for hook scripts. Given a file's content and
+ * the shard schema, report which required frontmatter fields are
+ * present, missing, or unexpected (per the matched note-type rule).
+ *
+ * Files without frontmatter return `valid: true` (no rule to match).
+ */
+
 import { parse as parseYaml } from 'yaml';
 import type { FrontmatterValidationResult, ShardSchema, FrontmatterRule } from './types.js';
 
 const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---/;
 
+/**
+ * Validate the YAML frontmatter of a note against the shard's
+ * frontmatter rules.
+ *
+ * Picks a rule by `path_match` glob against `filePath`; falls back to
+ * the `global` rule's required fields. Returns the missing required
+ * fields and any extra fields not covered by any rule.
+ *
+ * @param filePath The note's vault-relative path (used for `path_match`).
+ * @param content The full file content including frontmatter.
+ * @param schema The shard schema (typically from `loadSchema`).
+ * @returns `{ valid, noteType, missing, extra }`.
+ *
+ * @example
+ * ```ts
+ * import fs from 'node:fs/promises';
+ * import { loadSchema, validateFrontmatter } from 'shardmind/runtime';
+ *
+ * const schema = await loadSchema();
+ * const content = await fs.readFile('brain/Goals.md', 'utf-8');
+ * const { valid, missing } = validateFrontmatter('brain/Goals.md', content, schema);
+ * if (!valid) console.warn(`Missing required fields: ${missing.join(', ')}`);
+ * ```
+ */
 export function validateFrontmatter(
   filePath: string,
   content: string,

--- a/source/runtime/schema.ts
+++ b/source/runtime/schema.ts
@@ -4,10 +4,11 @@ import { parse as parseYaml } from 'yaml';
 import type { ShardSchema, FrontmatterRule } from './types.js';
 import { ShardMindError } from './types.js';
 import { resolveVaultRoot } from './state.js';
+import { CACHED_SCHEMA } from './vault-paths.js';
 
 export async function loadSchema(): Promise<ShardSchema> {
   const vaultRoot = resolveVaultRoot();
-  const filePath = path.join(vaultRoot, '.shardmind', 'shard-schema.yaml');
+  const filePath = path.join(vaultRoot, CACHED_SCHEMA);
 
   let raw: string;
   try {

--- a/source/runtime/schema.ts
+++ b/source/runtime/schema.ts
@@ -17,6 +17,26 @@ import { ShardMindError } from './types.js';
 import { resolveVaultRoot } from './state.js';
 import { CACHED_SCHEMA } from './vault-paths.js';
 
+/**
+ * Load the cached `shard-schema.yaml` from the current vault.
+ *
+ * Reads the copy that `shardmind install` wrote to `.shardmind/`.
+ * Normalizes frontmatter shorthand (`key: [a, b]` → `key: { required: [a, b] }`).
+ * Runtime trusts the cached file because the engine validated it on
+ * install; this function is lean intentionally.
+ *
+ * @returns The parsed and normalized `ShardSchema`.
+ * @throws ShardMindError `VAULT_NOT_FOUND` if no vault in the ancestor chain.
+ * @throws ShardMindError `SCHEMA_NOT_FOUND` if the cached file is missing.
+ *
+ * @example
+ * ```ts
+ * import { loadSchema, loadValues, validateValues } from 'shardmind/runtime';
+ *
+ * const [schema, values] = await Promise.all([loadSchema(), loadValues()]);
+ * const result = validateValues(values, schema);
+ * ```
+ */
 export async function loadSchema(): Promise<ShardSchema> {
   const vaultRoot = resolveVaultRoot();
   const filePath = path.join(vaultRoot, CACHED_SCHEMA);

--- a/source/runtime/schema.ts
+++ b/source/runtime/schema.ts
@@ -1,3 +1,14 @@
+/**
+ * Read-only schema access for hook scripts. Loads the cached
+ * `shard-schema.yaml` that `core/state.cacheManifest` wrote at install
+ * time. Hook authors use this to validate values, drive conditional
+ * logic, or introspect modules.
+ *
+ * The parsing + validation path lives in `source/core/schema.ts`.
+ * Runtime trusts the cached file because the engine validated it on
+ * install; no zod here keeps the runtime bundle small.
+ */
+
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import { parse as parseYaml } from 'yaml';

--- a/source/runtime/state.ts
+++ b/source/runtime/state.ts
@@ -17,6 +17,27 @@ import { SHARDMIND_DIR, STATE_FILE } from './vault-paths.js';
 
 const MAX_DEPTH = 20;
 
+/**
+ * Find the current vault by walking up from `process.cwd()` looking
+ * for a `.shardmind/` directory. Stops at the filesystem root or after
+ * 20 hops, whichever comes first.
+ *
+ * Hook scripts rarely call this directly — {@link loadState} and
+ * {@link loadValues} use it internally — but it's exported for tools
+ * that need the absolute vault path (e.g., to write derived files).
+ *
+ * @returns Absolute path to the vault root.
+ * @throws ShardMindError `VAULT_NOT_FOUND` if no `.shardmind/` is found in the ancestor chain.
+ *
+ * @example
+ * ```ts
+ * import { resolveVaultRoot } from 'shardmind/runtime';
+ * import path from 'node:path';
+ *
+ * const vault = resolveVaultRoot();
+ * const logPath = path.join(vault, 'hook.log');
+ * ```
+ */
 export function resolveVaultRoot(): string {
   let dir = process.cwd();
 
@@ -37,6 +58,25 @@ export function resolveVaultRoot(): string {
   );
 }
 
+/**
+ * Load the current vault's `state.json`.
+ *
+ * Returns `null` if the vault exists but has never been installed
+ * (no state file). Throws on I/O errors or corrupted JSON.
+ *
+ * @returns The parsed `ShardState`, or `null` if state.json is absent.
+ * @throws ShardMindError `VAULT_NOT_FOUND` if no vault in the ancestor chain.
+ * @throws ShardMindError `STATE_READ_FAILED` on I/O errors.
+ * @throws ShardMindError `STATE_CORRUPT` if state.json is not valid JSON.
+ *
+ * @example
+ * ```ts
+ * import { loadState } from 'shardmind/runtime';
+ *
+ * const state = await loadState();
+ * if (state) console.log(`Installed: ${state.shard}@${state.version}`);
+ * ```
+ */
 export async function loadState(): Promise<ShardState | null> {
   const vaultRoot = resolveVaultRoot();
   const filePath = path.join(vaultRoot, STATE_FILE);
@@ -65,6 +105,23 @@ export async function loadState(): Promise<ShardState | null> {
   }
 }
 
+/**
+ * Return the IDs of modules that were `'included'` at install time.
+ *
+ * Convenience over {@link loadState} for the common "which features
+ * are active" check inside a hook or utility script.
+ *
+ * @returns Array of included module IDs. Empty if the vault has no state.
+ *
+ * @example
+ * ```ts
+ * import { getIncludedModules } from 'shardmind/runtime';
+ *
+ * if ((await getIncludedModules()).includes('brain')) {
+ *   // run brain-specific setup
+ * }
+ * ```
+ */
 export async function getIncludedModules(): Promise<string[]> {
   const state = await loadState();
   if (!state) return [];

--- a/source/runtime/state.ts
+++ b/source/runtime/state.ts
@@ -1,3 +1,13 @@
+/**
+ * Read-only vault-state access for hook scripts and other downstream
+ * tooling that imports from `shardmind/runtime`. Zero dependencies on
+ * Ink, React, or Pastel so the bundled runtime stays tiny.
+ *
+ * The write path (readState/writeState/initShardDir/cacheTemplates/
+ * cacheManifest) lives in `source/core/state.ts`. Keep the split
+ * intentional: hooks must never mutate engine state.
+ */
+
 import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';

--- a/source/runtime/state.ts
+++ b/source/runtime/state.ts
@@ -3,6 +3,7 @@ import fsp from 'node:fs/promises';
 import path from 'node:path';
 import type { ShardState } from './types.js';
 import { ShardMindError } from './types.js';
+import { SHARDMIND_DIR, STATE_FILE } from './vault-paths.js';
 
 const MAX_DEPTH = 20;
 
@@ -10,12 +11,12 @@ export function resolveVaultRoot(): string {
   let dir = process.cwd();
 
   for (let i = 0; i < MAX_DEPTH; i++) {
-    const shardmindDir = path.join(dir, '.shardmind');
+    const shardmindDir = path.join(dir, SHARDMIND_DIR);
     if (fs.existsSync(shardmindDir) && fs.statSync(shardmindDir).isDirectory()) {
       return dir;
     }
     const parent = path.dirname(dir);
-    if (parent === dir) break; // reached filesystem root
+    if (parent === dir) break;
     dir = parent;
   }
 
@@ -28,7 +29,7 @@ export function resolveVaultRoot(): string {
 
 export async function loadState(): Promise<ShardState | null> {
   const vaultRoot = resolveVaultRoot();
-  const filePath = path.join(vaultRoot, '.shardmind', 'state.json');
+  const filePath = path.join(vaultRoot, STATE_FILE);
 
   let raw: string;
   try {

--- a/source/runtime/types.ts
+++ b/source/runtime/types.ts
@@ -100,6 +100,11 @@ export interface ShardState {
   shard: string;
   source: string;
   version: string;
+  /**
+   * sha256 of the downloaded tarball this install was built from.
+   * Lets `shardmind update` detect retagged releases / source drift.
+   */
+  tarball_sha256: string;
   installed_at: string;
   updated_at: string;
   values_hash: string;
@@ -138,6 +143,8 @@ export interface TempShard {
   tempDir: string;
   manifest: string;
   schema: string;
+  /** sha256 of the tarball bytes as received, before extraction. */
+  tarball_sha256: string;
   cleanup: () => Promise<void>;
 }
 

--- a/source/runtime/values.ts
+++ b/source/runtime/values.ts
@@ -5,10 +5,11 @@ import { z } from 'zod';
 import type { ShardSchema, ValidationResult } from './types.js';
 import { ShardMindError } from './types.js';
 import { resolveVaultRoot } from './state.js';
+import { VALUES_FILE } from './vault-paths.js';
 
 export async function loadValues(): Promise<Record<string, unknown>> {
   const vaultRoot = resolveVaultRoot();
-  const filePath = path.join(vaultRoot, 'shard-values.yaml');
+  const filePath = path.join(vaultRoot, VALUES_FILE);
 
   let raw: string;
   try {

--- a/source/runtime/values.ts
+++ b/source/runtime/values.ts
@@ -7,6 +7,27 @@ import { ShardMindError } from './types.js';
 import { resolveVaultRoot } from './state.js';
 import { VALUES_FILE } from './vault-paths.js';
 
+/**
+ * Load `shard-values.yaml` from the current vault.
+ *
+ * Resolves the vault root by walking up from `process.cwd()` looking for
+ * a `.shardmind/` directory (see {@link resolveVaultRoot}). Reads the
+ * values file, parses as YAML, and returns the flat map.
+ *
+ * @returns The user's answered values as a plain object.
+ * @throws ShardMindError `VAULT_NOT_FOUND` if no vault is found in the ancestor chain.
+ * @throws ShardMindError `VALUES_NOT_FOUND` if the vault has no values file (vault not installed).
+ * @throws ShardMindError `VALUES_READ_FAILED` on I/O errors.
+ * @throws ShardMindError `VALUES_INVALID` if the file isn't a YAML mapping.
+ *
+ * @example
+ * ```ts
+ * import { loadValues } from 'shardmind/runtime';
+ *
+ * const values = await loadValues();
+ * console.log(`Hello, ${values.user_name}`);
+ * ```
+ */
 export async function loadValues(): Promise<Record<string, unknown>> {
   const vaultRoot = resolveVaultRoot();
   const filePath = path.join(vaultRoot, VALUES_FILE);
@@ -97,6 +118,29 @@ function buildValuesValidator(schema: ShardSchema): z.ZodObject<any> {
   return z.object(shape);
 }
 
+/**
+ * Validate an object of user values against a shard schema.
+ *
+ * Builds a dynamic zod validator from the schema's declared value types
+ * (string, number, boolean, select, multiselect, list) and checks the
+ * supplied values. Returns a result object rather than throwing so hook
+ * authors can branch on validity without a try/catch.
+ *
+ * @param values The values to validate (typically from {@link loadValues}).
+ * @param schema The shard schema (typically from {@link loadSchema}).
+ * @returns `{ valid: boolean, errors: Array<{ path, message }> }`.
+ *
+ * @example
+ * ```ts
+ * import { loadValues, loadSchema, validateValues } from 'shardmind/runtime';
+ *
+ * const [values, schema] = await Promise.all([loadValues(), loadSchema()]);
+ * const result = validateValues(values, schema);
+ * if (!result.valid) {
+ *   for (const err of result.errors) console.error(`${err.path}: ${err.message}`);
+ * }
+ * ```
+ */
 export function validateValues(
   values: Record<string, unknown>,
   schema: ShardSchema,

--- a/source/runtime/vault-paths.ts
+++ b/source/runtime/vault-paths.ts
@@ -1,0 +1,29 @@
+/**
+ * Vault-relative paths owned by ShardMind.
+ *
+ * Every other module reads these constants instead of hardcoding strings.
+ * Renaming `.shardmind/` or moving the values file becomes a one-file
+ * change here rather than a grep across the codebase.
+ */
+
+import path from 'node:path';
+
+export const SHARDMIND_DIR = '.shardmind';
+export const STATE_FILE = path.join(SHARDMIND_DIR, 'state.json');
+export const CACHED_MANIFEST = path.join(SHARDMIND_DIR, 'shard.yaml');
+export const CACHED_SCHEMA = path.join(SHARDMIND_DIR, 'shard-schema.yaml');
+export const CACHED_TEMPLATES = path.join(SHARDMIND_DIR, 'templates');
+
+/** User-authored values file. Engine creates it on install, never overwrites. */
+export const VALUES_FILE = 'shard-values.yaml';
+
+/** Claude Code namespace inside the vault (commands, agents, settings). */
+export const CLAUDE_DIR = '.claude';
+
+/** Codex prompts namespace. */
+export const CODEX_DIR = '.codex/prompts';
+
+/** Source-side filenames inside a downloaded shard's temp directory. */
+export const SHARD_MANIFEST_FILE = 'shard.yaml';
+export const SHARD_SCHEMA_FILE = 'shard-schema.yaml';
+export const SHARD_TEMPLATES_DIR = 'templates';

--- a/tests/fixtures/schema/invalid-reserved-name.yaml
+++ b/tests/fixtures/schema/invalid-reserved-name.yaml
@@ -1,0 +1,17 @@
+schema_version: 1
+
+values:
+  shard:
+    type: string
+    required: true
+    message: "Which shard?"
+    group: setup
+
+groups:
+  - id: setup
+    label: "Setup"
+
+modules: {}
+signals: []
+frontmatter: {}
+migrations: []

--- a/tests/integration/install.test.ts
+++ b/tests/integration/install.test.ts
@@ -66,6 +66,7 @@ describe('install pipeline (against examples/minimal-shard)', () => {
       schema,
       tempDir: MINIMAL_SHARD,
       resolved: RESOLVED,
+      tarballSha256: 'deadbeef',
       values,
       selections,
     });
@@ -78,6 +79,7 @@ describe('install pipeline (against examples/minimal-shard)', () => {
     expect(state.schema_version).toBe(1);
     expect(state.shard).toBe('shardmind/minimal');
     expect(state.version).toBe('0.1.0');
+    expect(state.tarball_sha256).toBe('deadbeef');
     expect(state.modules).toEqual(selections);
     expect(Object.keys(state.files).length).toBe(result.fileCount);
 
@@ -123,6 +125,7 @@ describe('install pipeline (against examples/minimal-shard)', () => {
       schema,
       tempDir: MINIMAL_SHARD,
       resolved: RESOLVED,
+      tarballSha256: 'deadbeef',
       values,
       selections,
     });
@@ -151,6 +154,7 @@ describe('install pipeline (against examples/minimal-shard)', () => {
       schema,
       tempDir: MINIMAL_SHARD,
       resolved: RESOLVED,
+      tarballSha256: 'deadbeef',
       values,
       selections,
     });
@@ -180,6 +184,7 @@ describe('install pipeline (against examples/minimal-shard)', () => {
       schema,
       tempDir: MINIMAL_SHARD,
       resolved: RESOLVED,
+      tarballSha256: 'deadbeef',
       values,
       selections,
       dryRun: true,
@@ -242,6 +247,7 @@ describe('install pipeline (against examples/minimal-shard)', () => {
         schema,
         tempDir: MINIMAL_SHARD,
         resolved: RESOLVED,
+      tarballSha256: 'deadbeef',
         values,
         selections,
       }),
@@ -275,6 +281,7 @@ describe('install pipeline (against examples/minimal-shard)', () => {
       schema,
       tempDir: MINIMAL_SHARD,
       resolved: RESOLVED,
+      tarballSha256: 'deadbeef',
       values,
       selections,
     });
@@ -299,6 +306,7 @@ describe('install pipeline (against examples/minimal-shard)', () => {
       schema,
       tempDir: MINIMAL_SHARD,
       resolved: RESOLVED,
+      tarballSha256: 'deadbeef',
       values,
       selections,
     });

--- a/tests/integration/install.test.ts
+++ b/tests/integration/install.test.ts
@@ -10,15 +10,15 @@ import { parseSchema, buildValuesValidator } from '../../source/core/schema.js';
 import { readState } from '../../source/core/state.js';
 import {
   planOutputs,
-  runInstall,
-  rollbackInstall,
-} from '../../source/core/install-runner.js';
-import {
   resolveComputedDefaults,
   defaultModuleSelections,
   detectCollisions,
+} from '../../source/core/install-planner.js';
+import {
+  runInstall,
+  rollbackInstall,
   backupCollisions,
-} from '../../source/core/install-plan.js';
+} from '../../source/core/install-executor.js';
 import type { ResolvedShard, ShardState } from '../../source/runtime/types.js';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/tests/unit/install-planner.test.ts
+++ b/tests/unit/install-planner.test.ts
@@ -6,13 +6,15 @@ import crypto from 'node:crypto';
 import {
   resolveComputedDefaults,
   detectCollisions,
-  backupCollisions,
-  restoreBackups,
   mergePrefill,
   missingValueKeys,
   defaultModuleSelections,
-} from '../../source/core/install-plan.js';
-import { hashValues } from '../../source/core/install-runner.js';
+  hashValues,
+} from '../../source/core/install-planner.js';
+import {
+  backupCollisions,
+  restoreBackups,
+} from '../../source/core/install-executor.js';
 import type { ShardSchema } from '../../source/runtime/types.js';
 
 function schema(values: ShardSchema['values'], modules: ShardSchema['modules'] = {}): ShardSchema {

--- a/tests/unit/schema.test.ts
+++ b/tests/unit/schema.test.ts
@@ -80,6 +80,57 @@ describe('parseSchema', () => {
     const err = await parseSchema(path.join(FIXTURES, 'invalid-bad-structure.yaml')).catch(e => e);
     expect(err.code).toBe('SCHEMA_VALIDATION_FAILED');
   });
+
+  it('rejects schema value keys that collide with render context (reserved names)', async () => {
+    const err = await parseSchema(path.join(FIXTURES, 'invalid-reserved-name.yaml')).catch(e => e);
+    expect(err.code).toBe('SCHEMA_RESERVED_NAME');
+    expect(err.message).toContain('shard');
+  });
+
+  it('reports every reserved-name collision when multiple', async () => {
+    const os = await import('node:os');
+    const fs = await import('node:fs/promises');
+    const tmp = path.join(os.tmpdir(), `schema-reserved-${Date.now()}.yaml`);
+    await fs.writeFile(tmp, [
+      'schema_version: 1',
+      'values:',
+      '  shard:',
+      '    type: string',
+      '    required: true',
+      '    message: "x"',
+      '    group: setup',
+      '  install_date:',
+      '    type: string',
+      '    required: true',
+      '    message: "y"',
+      '    group: setup',
+      'groups:',
+      '  - { id: setup, label: "Setup" }',
+      'modules: {}',
+      'signals: []',
+      'frontmatter: {}',
+      'migrations: []',
+      '',
+    ].join('\n'));
+
+    try {
+      const err = await parseSchema(tmp).catch(e => e);
+      expect(err.code).toBe('SCHEMA_RESERVED_NAME');
+      expect(err.message).toContain('shard');
+      expect(err.message).toContain('install_date');
+    } finally {
+      await fs.unlink(tmp);
+    }
+  });
+
+  it('exposes the full reserved-name list in the hint so authors can self-serve', async () => {
+    const err = await parseSchema(path.join(FIXTURES, 'invalid-reserved-name.yaml')).catch(e => e);
+    expect(err.hint).toContain('shard');
+    expect(err.hint).toContain('install_date');
+    expect(err.hint).toContain('year');
+    expect(err.hint).toContain('included_modules');
+    expect(err.hint).toContain('values');
+  });
 });
 
 describe('buildValuesValidator', () => {

--- a/tests/unit/state-migrator.test.ts
+++ b/tests/unit/state-migrator.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { migrateState } from '../../source/core/state-migrator.js';
+
+describe('migrateState', () => {
+  it('returns null when no migration rule exists for the source version', () => {
+    const result = migrateState({ schema_version: 99 }, 99, 1);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for future versions with no downward migration', () => {
+    // v0.1 has no rules registered; anything other than trivial cases returns null
+    const result = migrateState({ schema_version: 2 }, 2, 1);
+    expect(result).toBeNull();
+  });
+
+  // When v0.2 lands with its first migration, add a test that exercises
+  // the 1 → 2 chain here (input shape v1, expected output shape v2).
+});


### PR DESCRIPTION
## Summary

Pre-ship polish covering every finding from the v0.1 architecture + docs audit. 13 focused commits — each self-contained and green at the tip.

## Part 1 — Architecture (7 commits)

- **`refactor: extract runtime/vault-paths constants`** — every vault-relative magic string (`.shardmind`, `state.json`, `shard-values.yaml`, etc.) now lives in `source/runtime/vault-paths.ts`. Rename is a one-file change.
- **`refactor: extract buildRenderContext helper`** — the `{ values, included_modules, shard, install_date, year }` object is now built in `core/renderer.ts`; update command can reuse.
- **`feat(schema): reject reserved value names`** — `parseSchema` throws `SCHEMA_RESERVED_NAME` when a value key collides with the render context (`shard`, `install_date`, `year`, `included_modules`, `values`). Catches a real authoring footgun.
- **`refactor: split install-planner vs install-executor by I/O concern`** — old split between `install-plan.ts` (which wrote disk via `backupCollisions`) and `install-runner.ts` (which enumerated files via `planOutputs`) was muddy. Re-sorted: planner is read-only/pure, executor mutates disk.
- **`feat(state): tarball_sha256 in state + state-migrator framework`** — `downloadShard` hashes tarball bytes in-pipeline; install writes the hash to `state.json`. Update command (Milestone 4) will use it for drift detection. Migration framework registers zero rules in v0.1; rules slot in as future `schema_version` bumps.
- **`docs(runtime): file-header comments on state.ts + schema.ts`** — `runtime/state.ts` vs `core/state.ts` share a filename by design; header comments on each explain the split so readers don't have to grep `CLAUDE.md`.
- **`refactor(commands): extract useInstallMachine hook`** — `commands/install.tsx` went from 610 lines to 184. The phase state machine, SIGINT handling, and five `useCallback`s are now in `source/commands/hooks/use-install-machine.ts`. Update command will reuse the same shape.

## Part 2 — Documentation (4 commits)

- **`docs: shard authoring guide + JSON Schema files`** — new `docs/AUTHORING.md` (~400 lines, 9 sections: file layout, manifest, schema, templates, hooks, testing, publishing, errors) + `schemas/shard.schema.json` + `schemas/shard-schema.schema.json` for VS Code autocomplete via `yaml-language-server` pragma.
- **`docs: ERRORS.md`** — every `ShardMindError` code grouped by subsystem with cause + remedy. Bottom section splits by audience (author-facing, user-facing, engine-internal).
- **`docs(runtime): JSDoc on every public export`** — `loadValues`, `validateValues`, `loadState`, `resolveVaultRoot`, `getIncludedModules`, `loadSchema`, `validateFrontmatter` each get a block with description, `@param`, `@returns`, `@throws`, and an inline usage example.
- **`docs(readme): link new authoring + errors docs`** — README Documentation section split into "for shard authors" and "for users + contributors".

## Part 3 — Follow-up tracking (1 commit + 8 issues)

- **`docs: track v0.1 review follow-ups in v0.2 roadmap`** — added an "Engine polish (from v0.1 review)" subsection to `ROADMAP.md` v0.2, linking 8 new issues:
  - #33 VaultFS abstraction
  - #34 `shardmind validate` command
  - #35 Pre-install template syntax lint
  - #36 Debug logging (`SHARDMIND_DEBUG`)
  - #37 `NO_COLOR` / `FORCE_COLOR` respect
  - #38 `ink-testing-library` TUI tests
  - #39 Alternate registry configurability
  - #40 Encode state-schema migration rules

Nothing from the review is drifting without tracking.

## Part 4 — Chore

- **`chore: normalize npm audit fix pins + update CHANGELOG`** — `diff` and `vitest` got major version bumps via `npm audit fix` (bundled into an earlier commit). Normalized to caret ranges. CHANGELOG updated with everything this pass shipped.

## Test plan

- [x] `npm run typecheck` — clean at every commit
- [x] `npm test` — 142 passing at the final commit (up from 137)
- [x] `npm run build` — clean output at the final commit
- [x] `npm audit` — 0 vulnerabilities
- [x] `node dist/cli.js install --help` — unchanged
- [x] New tests added:
  - Reserved-name schema validation (3 tests)
  - `tarball_sha256` roundtrip through integration tests
  - State-migrator framework (2 tests)

## Files

- **13 new files**: `core/fs-utils.ts`, `core/install-planner.ts`, `core/install-executor.ts`, `core/state-migrator.ts`, `runtime/vault-paths.ts`, `commands/hooks/use-install-machine.ts`, `docs/AUTHORING.md`, `docs/ERRORS.md`, `schemas/shard.schema.json`, `schemas/shard-schema.schema.json`, `tests/fixtures/schema/invalid-reserved-name.yaml`, `tests/unit/state-migrator.test.ts`
- **2 renamed files**: `install-plan.ts` → `install-planner.ts`, `install-runner.ts` → `install-executor.ts`
- **Every source file touched** for vault-paths + JSDoc + headers

## Follow-up work (not this PR)

- Milestone 3: merge engine (drift.ts, differ.ts, 17 fixtures) — already tracked (#10, #11)
- Milestone 4: update command — will reuse `useInstallMachine` from step 7
- Milestone 5: obsidian-mind conversion — AUTHORING.md from step 8 is its prerequisite
