### PR TITLE
test: ink-testing-library TUI component tests (#38)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,6 +28,7 @@ Ship the core: install, update, status. Prove that vault template upgrades work 
 - [x] `source/core/state.ts` + `source/core/registry.ts` ([#9](https://github.com/breferrari/shardmind/issues/9))
 - [x] `commands/install.tsx` — full install flow with Ink wizard ([#8](https://github.com/breferrari/shardmind/issues/8))
 - [x] Integration test: install pipeline against `examples/minimal-shard` (real obsidian-mind shard verified at Milestone 5)
+- [x] `ink-testing-library` component tests for ValueInput, ModuleReview, ExistingInstallGate, InstallWizard ([#38](https://github.com/breferrari/shardmind/issues/38) — pulled forward from v0.2)
 - [ ] Verify: `shardmind install breferrari/obsidian-mind` works end to end
 
 ### Milestone 3: Merge Engine (Day 3)
@@ -108,7 +109,6 @@ Deferred items surfaced during the v0.1 polish-pass architecture audit. None are
 - [ ] Pre-install template syntax lint ([#35](https://github.com/breferrari/shardmind/issues/35))
 - [ ] Debug logging (`SHARDMIND_DEBUG` env var) ([#36](https://github.com/breferrari/shardmind/issues/36))
 - [ ] `NO_COLOR` / `FORCE_COLOR` respect across Ink components ([#37](https://github.com/breferrari/shardmind/issues/37))
-- [ ] `ink-testing-library` integration for TUI unit tests ([#38](https://github.com/breferrari/shardmind/issues/38))
 - [ ] Alternate registry configurability (GHE, private, custom URL) ([#39](https://github.com/breferrari/shardmind/issues/39))
 - [ ] Encode state-schema migration rules (uses v0.1 framework) ([#40](https://github.com/breferrari/shardmind/issues/40))
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -111,6 +111,7 @@ Deferred items surfaced during the v0.1 polish-pass architecture audit. None are
 - [ ] `NO_COLOR` / `FORCE_COLOR` respect across Ink components ([#37](https://github.com/breferrari/shardmind/issues/37))
 - [ ] Alternate registry configurability (GHE, private, custom URL) ([#39](https://github.com/breferrari/shardmind/issues/39))
 - [ ] Encode state-schema migration rules (uses v0.1 framework) ([#40](https://github.com/breferrari/shardmind/issues/40))
+- [ ] Re-evaluate `@inkjs/ui` dependency (upstream frozen; shim at `source/components/ui.ts` keeps swap cheap) ([#43](https://github.com/breferrari/shardmind/issues/43))
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -778,6 +778,23 @@ For pinning: `shardmind update --version 3.6.0`.
 | **@sindresorhus/tsconfig** | Pastel's recommended TS config |
 | **vitest** | Test runner |
 
+### 11.4 Dependency Risk: `@inkjs/ui`
+
+**Status (as of April 2026):** frozen upstream. Last release `2.0.0` on 2024-05-22. Last maintainer commit on 2024-05-22. Last maintainer comment on issues: June 2023. Meanwhile the same maintainer actively ships `ink` itself (7.0.0 / 7.0.1 in April 2026). Not archived, but behaviorally abandoned.
+
+**Why we still depend on it.** It covers the full wizard surface in one package: `TextInput`, `Select`, `MultiSelect`, `ConfirmInput`, `Spinner`, `ProgressBar`, `StatusMessage`, `Alert`, `Badge`. No maintained alternative at equivalent breadth exists. The standalone `ink-*` packages (`ink-text-input`, `ink-select-input`) are similarly frozen, and `ink-multi-select` / `ink-progress-bar` are years-dead. `OpenTUI` is a different renderer entirely, not a drop-in swap.
+
+**Hedge: `source/components/ui.ts` shim.** Every TUI file imports components from `./ui.js` rather than `@inkjs/ui` directly. The shim is a one-file re-export. To swap the backend (vendor a component, fork the library, migrate wholesale), only `ui.ts` changes. Callsites are untouched.
+
+**Swap triggers** — any one of:
+1. A second real bug we need to patch locally (the first was the `ExistingInstallGate` `onChange` quirk — see upstream issue [vadimdemedes/ink-ui#26](https://github.com/vadimdemedes/ink-ui/issues/26) and PR [#27](https://github.com/vadimdemedes/ink-ui/pull/27)).
+2. Ink 7 or later breaks compatibility and nobody upstream fixes it.
+3. We need a component `@inkjs/ui` doesn't provide.
+
+**When a trigger fires, vendor the 2–3 components that bit us into `source/components/vendor/*` and route `ui.ts` through the vendored copies. Don't fork the whole package unless the count grows past ~5 components.**
+
+**Revisit cadence.** Re-evaluate at v0.2 scope freeze. Do not pre-emptively migrate.
+
 ---
 
 ## 12. Project Structure

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@types/react": "^19.2.14",
         "@types/semver": "^7.5.0",
         "@types/tar": "^6.1.0",
+        "ink-testing-library": "^4.0.0",
         "tsup": "^8.5.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.4"
@@ -42,8 +43,6 @@
     },
     "node_modules/@alcalzone/ansi-tokenize": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.3.0.tgz",
-      "integrity": "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.1",
@@ -55,8 +54,6 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -69,476 +66,13 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -554,8 +88,6 @@
     },
     "node_modules/@inkjs/ui": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@inkjs/ui/-/ui-2.0.0.tgz",
-      "integrity": "sha512-5+8fJmwtF9UvikzLfph9sA+LS+l37Ij/szQltkuXLOAXwNkBX9innfzh4pLGXIB59vKEQUtc6D4qGvhD7h3pAg==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
@@ -572,8 +104,6 @@
     },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
       "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.4"
@@ -584,8 +114,6 @@
     },
     "node_modules/@isaacs/fs-minipass/node_modules/minipass": {
       "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -593,8 +121,6 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -604,8 +130,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -614,15 +138,11 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -630,279 +150,16 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@oxc-project/types": {
       "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
       "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
     },
-    "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
       "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
       "cpu": [
         "x64"
       ],
@@ -918,337 +175,11 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
-      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
-      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
-      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
-      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
-      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
-      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
-      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
-      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
-      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
-      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
-      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
-      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
-      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
-      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
-      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
-      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
-      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
-      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
-      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
-      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
-      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
-      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
       "cpu": [
         "x64"
       ],
@@ -1261,8 +192,6 @@
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
-      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
       "cpu": [
         "x64"
       ],
@@ -1275,8 +204,6 @@
     },
     "node_modules/@sindresorhus/tsconfig": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/tsconfig/-/tsconfig-8.1.0.tgz",
-      "integrity": "sha512-MggpguA4jNdtyoUy2Hs54nb4lP4rbhH34CsOiFId1q6fmFPnipqeo70ZRkjp5p4Z7wdyspALtSAcKaxL2/3waQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1288,26 +215,11 @@
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
-      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1317,29 +229,21 @@
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
-      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/diff": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-6.0.0.tgz",
-      "integrity": "sha512-dhVCYGv3ZSbzmQaBSagrv1WJ6rXCdkyTcDyoNu1MD8JohI7pR7k8wdZEm+mvdxRKXyHVwckFzWU1vJc+Z29MlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1348,21 +252,15 @@
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
-      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "license": "MIT"
     },
     "node_modules/@types/nunjucks": {
       "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.2.6.tgz",
-      "integrity": "sha512-pHiGtf83na1nCzliuAdq8GowYiXvH5l931xZ0YEHaLMNFgynpEqx+IPStlu7UaDkehfvl01e4x/9Tpwhy7Ue3w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -1371,15 +269,11 @@
     },
     "node_modules/@types/semver": {
       "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/tar": {
       "version": "6.1.13",
-      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-6.1.13.tgz",
-      "integrity": "sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1389,8 +283,6 @@
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1407,8 +299,6 @@
     },
     "node_modules/@vitest/mocker": {
       "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1434,8 +324,6 @@
     },
     "node_modules/@vitest/pretty-format": {
       "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1447,8 +335,6 @@
     },
     "node_modules/@vitest/runner": {
       "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1461,8 +347,6 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1477,8 +361,6 @@
     },
     "node_modules/@vitest/spy": {
       "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1487,8 +369,6 @@
     },
     "node_modules/@vitest/utils": {
       "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1502,14 +382,10 @@
     },
     "node_modules/a-sync-waterfall": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
-      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
       "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1521,8 +397,6 @@
     },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
-      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
       "license": "MIT",
       "dependencies": {
         "environment": "^1.0.0"
@@ -1536,8 +410,6 @@
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1548,8 +420,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1560,15 +430,11 @@
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -1582,8 +448,6 @@
     },
     "node_modules/anymatch/node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -1596,14 +460,10 @@
     },
     "node_modules/asap": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1612,8 +472,6 @@
     },
     "node_modules/auto-bind": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
-      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -1624,8 +482,6 @@
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -1638,8 +494,6 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -1652,8 +506,6 @@
     },
     "node_modules/bundle-require": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
-      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1668,8 +520,6 @@
     },
     "node_modules/cac": {
       "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1678,8 +528,6 @@
     },
     "node_modules/chai": {
       "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
-      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1688,8 +536,6 @@
     },
     "node_modules/chalk": {
       "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -1700,8 +546,6 @@
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -1726,8 +570,6 @@
     },
     "node_modules/chownr": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -1735,8 +577,6 @@
     },
     "node_modules/cli-boxes": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-4.0.1.tgz",
-      "integrity": "sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.20 <19 || >=20.10"
@@ -1747,8 +587,6 @@
     },
     "node_modules/cli-cursor": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^4.0.0"
@@ -1762,8 +600,6 @@
     },
     "node_modules/cli-spinners": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
-      "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.20"
@@ -1774,8 +610,6 @@
     },
     "node_modules/cli-truncate": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-6.0.0.tgz",
-      "integrity": "sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA==",
       "license": "MIT",
       "dependencies": {
         "slice-ansi": "^9.0.0",
@@ -1790,8 +624,6 @@
     },
     "node_modules/code-excerpt": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
-      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
       "license": "MIT",
       "dependencies": {
         "convert-to-spaces": "^2.0.1"
@@ -1802,8 +634,6 @@
     },
     "node_modules/commander": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -1811,15 +641,11 @@
     },
     "node_modules/confbox": {
       "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/consola": {
       "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
-      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1828,15 +654,11 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/convert-to-spaces": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
-      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -1844,15 +666,11 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1869,8 +687,6 @@
     },
     "node_modules/decamelize": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
-      "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -1881,8 +697,6 @@
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1890,8 +704,6 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1900,8 +712,6 @@
     },
     "node_modules/diff": {
       "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
-      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -1909,8 +719,6 @@
     },
     "node_modules/environment": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
-      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1921,15 +729,11 @@
     },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/es-toolkit": {
       "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
-      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
       "license": "MIT",
       "workspaces": [
         "docs",
@@ -1938,8 +742,6 @@
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1980,8 +782,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1989,8 +789,6 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1999,8 +797,6 @@
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2009,8 +805,6 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2027,8 +821,6 @@
     },
     "node_modules/figures": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
       "license": "MIT",
       "dependencies": {
         "is-unicode-supported": "^2.0.0"
@@ -2042,8 +834,6 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -2056,8 +846,6 @@
     },
     "node_modules/find-up-simple": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
-      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2068,8 +856,6 @@
     },
     "node_modules/fix-dts-default-cjs-exports": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
-      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2078,24 +864,8 @@
         "rollup": "^4.34.8"
       }
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/get-east-asian-width": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2106,8 +876,6 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -2120,8 +888,6 @@
     },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^10.0.1"
@@ -2132,8 +898,6 @@
     },
     "node_modules/indent-string": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2144,8 +908,6 @@
     },
     "node_modules/index-to-position": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
-      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2156,8 +918,6 @@
     },
     "node_modules/ink": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/ink/-/ink-7.0.1.tgz",
-      "integrity": "sha512-o6LAC268PLawlGVYrXTyaTfke4VtJftEheuwbgkQf7yvSXyWp1nRwBbAyKEkWXFZZsW/la5wrMuNbuBvZK2C1w==",
       "license": "MIT",
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.3.0",
@@ -2203,10 +963,26 @@
         }
       }
     },
+    "node_modules/ink-testing-library": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ink-testing-library/-/ink-testing-library-4.0.0.tgz",
+      "integrity": "sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/irregular-plurals": {
       "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.5.0.tgz",
-      "integrity": "sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2214,8 +990,6 @@
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -2228,8 +1002,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -2239,8 +1011,6 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
-      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "^1.3.1"
@@ -2254,8 +1024,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -2268,8 +1036,6 @@
     },
     "node_modules/is-in-ci": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-2.0.0.tgz",
-      "integrity": "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==",
       "license": "MIT",
       "bin": {
         "is-in-ci": "cli.js"
@@ -2283,8 +1049,6 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -2294,8 +1058,6 @@
     },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2306,8 +1068,6 @@
     },
     "node_modules/joycon": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
-      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2316,14 +1076,10 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -2350,220 +1106,8 @@
         "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
       ],
@@ -2583,8 +1127,6 @@
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2596,15 +1138,11 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/load-tsconfig": {
       "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
-      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2613,14 +1151,10 @@
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2629,8 +1163,6 @@
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2638,8 +1170,6 @@
     },
     "node_modules/minipass": {
       "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -2648,8 +1178,6 @@
     },
     "node_modules/minizlib": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.1.2"
@@ -2660,8 +1188,6 @@
     },
     "node_modules/minizlib/node_modules/minipass": {
       "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2669,8 +1195,6 @@
     },
     "node_modules/mlly": {
       "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
-      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2682,15 +1206,11 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
       "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2701,8 +1221,6 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
         {
@@ -2720,8 +1238,6 @@
     },
     "node_modules/node-diff3": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/node-diff3/-/node-diff3-3.2.0.tgz",
-      "integrity": "sha512-vLh2xJFSyniBLYDEDbXKqD32fQ5vAxmYT4hco8t0EHQ4CQ4BDHhshi7kdvDc6Y1MwGSi1Mhl4unUukPbCayZdw==",
       "license": "MIT",
       "engines": {
         "bun": ">=1.3.0",
@@ -2730,8 +1246,6 @@
     },
     "node_modules/normalize-package-data": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
-      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^7.0.0",
@@ -2744,8 +1258,6 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -2755,8 +1267,6 @@
     },
     "node_modules/nunjucks": {
       "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
-      "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "a-sync-waterfall": "^1.0.0",
@@ -2780,8 +1290,6 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2790,8 +1298,6 @@
     },
     "node_modules/obug": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
@@ -2801,8 +1307,6 @@
     },
     "node_modules/onetime": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -2816,8 +1320,6 @@
     },
     "node_modules/parse-json": {
       "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
-      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
@@ -2833,8 +1335,6 @@
     },
     "node_modules/parse-json/node_modules/type-fest": {
       "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -2845,8 +1345,6 @@
     },
     "node_modules/pastel": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pastel/-/pastel-4.0.1.tgz",
-      "integrity": "sha512-YvXkCmKxMJ/VidM9ua13J8Udr2RK9/ZIwn8OCQhNdxBojiaLbEZIGrgwr1WpPi9w4J0gtAWTt6Pqub8REbZwWg==",
       "license": "MIT",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",
@@ -2867,8 +1365,6 @@
     },
     "node_modules/pastel/node_modules/commander": {
       "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -2876,8 +1372,6 @@
     },
     "node_modules/patch-console": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
-      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -2885,21 +1379,15 @@
     },
     "node_modules/pathe": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2911,8 +1399,6 @@
     },
     "node_modules/pirates": {
       "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
-      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2921,8 +1407,6 @@
     },
     "node_modules/pkg-types": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2933,8 +1417,6 @@
     },
     "node_modules/plur": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/plur/-/plur-5.1.0.tgz",
-      "integrity": "sha512-VP/72JeXqak2KiOzjgKtQen5y3IZHn+9GOuLDafPv0eXa47xq0At93XahYBs26MsifCQ4enGKwbjBTKgb9QJXg==",
       "license": "MIT",
       "dependencies": {
         "irregular-plurals": "^3.3.0"
@@ -2948,8 +1430,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -2977,8 +1457,6 @@
     },
     "node_modules/postcss-load-config": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
-      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
       "dev": true,
       "funding": [
         {
@@ -3020,8 +1498,6 @@
     },
     "node_modules/react": {
       "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3029,8 +1505,6 @@
     },
     "node_modules/react-reconciler": {
       "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
-      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -3044,8 +1518,6 @@
     },
     "node_modules/read-package-up": {
       "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
-      "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
       "license": "MIT",
       "dependencies": {
         "find-up-simple": "^1.0.0",
@@ -3061,8 +1533,6 @@
     },
     "node_modules/read-package-up/node_modules/type-fest": {
       "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -3073,8 +1543,6 @@
     },
     "node_modules/read-pkg": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
-      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
       "license": "MIT",
       "dependencies": {
         "@types/normalize-package-data": "^2.4.3",
@@ -3092,8 +1560,6 @@
     },
     "node_modules/read-pkg/node_modules/type-fest": {
       "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -3104,8 +1570,6 @@
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -3118,8 +1582,6 @@
     },
     "node_modules/readdirp/node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -3132,8 +1594,6 @@
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3142,8 +1602,6 @@
     },
     "node_modules/restore-cursor": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
       "license": "MIT",
       "dependencies": {
         "onetime": "^5.1.0",
@@ -3158,8 +1616,6 @@
     },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3192,8 +1648,6 @@
     },
     "node_modules/rollup": {
       "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
-      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3237,14 +1691,10 @@
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3255,21 +1705,15 @@
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
-      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
     "node_modules/slice-ansi": {
       "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-9.0.0.tgz",
-      "integrity": "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.3",
@@ -3284,8 +1728,6 @@
     },
     "node_modules/source-map": {
       "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
-      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -3294,8 +1736,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -3304,8 +1744,6 @@
     },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
-      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
@@ -3314,14 +1752,10 @@
     },
     "node_modules/spdx-exceptions": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
-      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "license": "MIT",
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
@@ -3330,14 +1764,10 @@
     },
     "node_modules/spdx-license-ids": {
       "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
-      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "license": "CC0-1.0"
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
-      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -3348,22 +1778,16 @@
     },
     "node_modules/stackback": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
-      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
-      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "^1.5.0",
@@ -3378,8 +1802,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -3393,8 +1815,6 @@
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
-      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3416,8 +1836,6 @@
     },
     "node_modules/sucrase/node_modules/commander": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3426,8 +1844,6 @@
     },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -3438,8 +1854,6 @@
     },
     "node_modules/tar": {
       "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -3454,8 +1868,6 @@
     },
     "node_modules/tar/node_modules/minipass": {
       "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3463,8 +1875,6 @@
     },
     "node_modules/terminal-size": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/terminal-size/-/terminal-size-4.0.1.tgz",
-      "integrity": "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3475,8 +1885,6 @@
     },
     "node_modules/thenify": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3485,8 +1893,6 @@
     },
     "node_modules/thenify-all": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3498,22 +1904,16 @@
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
-      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3529,8 +1929,6 @@
     },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3539,8 +1937,6 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -3553,8 +1949,6 @@
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3563,23 +1957,11 @@
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/tsup": {
       "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
-      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3631,8 +2013,6 @@
     },
     "node_modules/tsup/node_modules/chokidar": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3647,8 +2027,6 @@
     },
     "node_modules/tsup/node_modules/readdirp": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3661,8 +2039,6 @@
     },
     "node_modules/type-fest": {
       "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
-      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -3676,8 +2052,6 @@
     },
     "node_modules/typescript": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3690,22 +2064,16 @@
     },
     "node_modules/ufo": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
-      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
-      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3716,8 +2084,6 @@
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-correct": "^3.0.0",
@@ -3726,8 +2092,6 @@
     },
     "node_modules/vite": {
       "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3804,8 +2168,6 @@
     },
     "node_modules/vitest": {
       "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3894,8 +2256,6 @@
     },
     "node_modules/vitest/node_modules/tinyexec": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3904,8 +2264,6 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
-      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3921,8 +2279,6 @@
     },
     "node_modules/widest-line": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-6.0.0.tgz",
-      "integrity": "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==",
       "license": "MIT",
       "dependencies": {
         "string-width": "^8.1.0"
@@ -3936,8 +2292,6 @@
     },
     "node_modules/wrap-ansi": {
       "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
-      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.3",
@@ -3953,8 +2307,6 @@
     },
     "node_modules/ws": {
       "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -3974,8 +2326,6 @@
     },
     "node_modules/yallist": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -3983,8 +2333,6 @@
     },
     "node_modules/yaml": {
       "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -3998,14 +2346,10 @@
     },
     "node_modules/yoga-layout": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
-      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
       "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -4013,8 +2357,6 @@
     },
     "node_modules/zod-validation-error": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
-      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/react": "^19.2.14",
     "@types/semver": "^7.5.0",
     "@types/tar": "^6.1.0",
+    "ink-testing-library": "^4.0.0",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.4"

--- a/source/commands/install.tsx
+++ b/source/commands/install.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react';
 import { Box, Text } from 'ink';
-import { Spinner, StatusMessage, Alert } from '@inkjs/ui';
+import { Spinner, StatusMessage, Alert } from '../components/ui.js';
 import zod from 'zod';
 
 import { ShardMindError } from '../runtime/types.js';

--- a/source/components/CollisionReview.tsx
+++ b/source/components/CollisionReview.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from 'ink';
-import { Select, Alert } from '@inkjs/ui';
+import { Select, Alert } from './ui.js';
 import type { Collision } from '../core/install-planner.js';
 
 export type CollisionAction = 'backup' | 'overwrite' | 'cancel';

--- a/source/components/ExistingInstallGate.tsx
+++ b/source/components/ExistingInstallGate.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { Box, Text } from 'ink';
 import { Select, TextInput, Alert, StatusMessage } from '@inkjs/ui';
 import type { ShardState, ModuleSelections } from '../runtime/types.js';
@@ -15,6 +15,7 @@ type Screen = 'choose' | 'confirm-reinstall';
 export default function ExistingInstallGate({ state, onChoice }: ExistingInstallGateProps) {
   const [screen, setScreen] = useState<Screen>('choose');
   const [error, setError] = useState<string | null>(null);
+  const lastSubmittedValue = useRef<string | null>(null);
 
   if (screen === 'confirm-reinstall') {
     return (
@@ -30,13 +31,22 @@ export default function ExistingInstallGate({ state, onChoice }: ExistingInstall
           <Text bold>Type REINSTALL to proceed:</Text>
           <TextInput
             placeholder="REINSTALL"
-            onChange={() => {
-              if (error) setError(null);
+            onChange={(v) => {
+              // Clear a stale error only when the user types something
+              // different from the value that caused it. @inkjs/ui's
+              // TextInput fires onChange on parent re-renders too, so
+              // the value-comparison guard prevents the error from
+              // being cleared the same tick it's set.
+              if (lastSubmittedValue.current !== null && v !== lastSubmittedValue.current) {
+                lastSubmittedValue.current = null;
+                setError(null);
+              }
             }}
             onSubmit={(v) => {
               if (v.trim() === 'REINSTALL') {
                 onChoice('reinstall');
               } else {
+                lastSubmittedValue.current = v;
                 setError('Exact text required. Press Esc or Ctrl+C to cancel.');
               }
             }}

--- a/source/components/ExistingInstallGate.tsx
+++ b/source/components/ExistingInstallGate.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef } from 'react';
 import { Box, Text } from 'ink';
-import { Select, TextInput, Alert, StatusMessage } from '@inkjs/ui';
+import { Select, TextInput, Alert, StatusMessage } from './ui.js';
 import type { ShardState, ModuleSelections } from '../runtime/types.js';
 
 export type GateChoice = 'update' | 'reinstall' | 'cancel';
@@ -32,11 +32,11 @@ export default function ExistingInstallGate({ state, onChoice }: ExistingInstall
           <TextInput
             placeholder="REINSTALL"
             onChange={(v) => {
-              // Clear a stale error only when the user types something
-              // different from the value that caused it. @inkjs/ui's
-              // TextInput fires onChange on parent re-renders too, so
-              // the value-comparison guard prevents the error from
-              // being cleared the same tick it's set.
+              // @inkjs/ui fires onChange on parent re-renders, which
+              // would clear the error the same tick it's set. Compare
+              // against lastSubmittedValue so we only clear once the
+              // user actually types something new.
+              // Upstream: vadimdemedes/ink-ui#26 (fix in PR #27).
               if (lastSubmittedValue.current !== null && v !== lastSubmittedValue.current) {
                 lastSubmittedValue.current = null;
                 setError(null);

--- a/source/components/ExistingInstallGate.tsx
+++ b/source/components/ExistingInstallGate.tsx
@@ -43,7 +43,7 @@ export default function ExistingInstallGate({ state, onChoice }: ExistingInstall
               }
             }}
             onSubmit={(v) => {
-              if (v.trim() === 'REINSTALL') {
+              if (v === 'REINSTALL') {
                 onChoice('reinstall');
               } else {
                 lastSubmittedValue.current = v;

--- a/source/components/Header.tsx
+++ b/source/components/Header.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from 'ink';
-import { Badge } from '@inkjs/ui';
+import { Badge } from './ui.js';
 import type { ShardManifest } from '../runtime/types.js';
 
 interface HeaderProps {

--- a/source/components/InstallProgress.tsx
+++ b/source/components/InstallProgress.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from 'ink';
-import { ProgressBar, Spinner } from '@inkjs/ui';
+import { ProgressBar, Spinner } from './ui.js';
 
 interface InstallProgressProps {
   current: number;

--- a/source/components/InstallWizard.tsx
+++ b/source/components/InstallWizard.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
-import { Select } from '@inkjs/ui';
+import { Select } from './ui.js';
 import type { ShardManifest, ShardSchema, ValueDefinition, ModuleSelections } from '../runtime/types.js';
 import Header from './Header.js';
 import ValueInput from './ValueInput.js';

--- a/source/components/ModuleReview.tsx
+++ b/source/components/ModuleReview.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react';
 import { Box, Text } from 'ink';
-import { MultiSelect } from '@inkjs/ui';
+import { MultiSelect } from './ui.js';
 import type { ModuleDefinition, ModuleSelections } from '../runtime/types.js';
 
 interface ModuleReviewProps {

--- a/source/components/Summary.tsx
+++ b/source/components/Summary.tsx
@@ -1,6 +1,6 @@
 import os from 'node:os';
 import { Box, Text } from 'ink';
-import { StatusMessage } from '@inkjs/ui';
+import { StatusMessage } from './ui.js';
 import type { ShardManifest } from '../runtime/types.js';
 import type { BackupRecord } from '../core/install-executor.js';
 

--- a/source/components/ValueInput.tsx
+++ b/source/components/ValueInput.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, type ReactElement } from 'react';
 import { Box, Text } from 'ink';
-import { TextInput, Select, ConfirmInput, StatusMessage } from '@inkjs/ui';
+import { TextInput, Select, ConfirmInput, StatusMessage } from './ui.js';
 import type { ValueDefinition } from '../runtime/types.js';
 import { assertNever } from '../runtime/types.js';
 

--- a/source/components/ValueInput.tsx
+++ b/source/components/ValueInput.tsx
@@ -119,9 +119,9 @@ function renderInput(
       );
     }
     case 'multiselect': {
-      // @inkjs/ui MultiSelect not yet imported here; fall through to a
-      // textual comma-separated input for v0.1 if multiselect is used
-      // (minimal-shard and obsidian-mind don't use multiselect).
+      // Textual comma-separated fallback. Swapping in @inkjs/ui's
+      // MultiSelect widget is v0.2 UX polish; no v0.1 shard uses
+      // multiselect values, so this path is rarely exercised.
       const initial = Array.isArray(initialValue) ? (initialValue as string[]).join(', ') : '';
       return (
         <TextInput

--- a/source/components/ui.ts
+++ b/source/components/ui.ts
@@ -1,0 +1,17 @@
+/**
+ * Single indirection layer over @inkjs/ui. All TUI code imports
+ * components from here rather than directly from @inkjs/ui so that
+ * swapping the backend (vendoring, forking, migrating to another
+ * library) is a one-file change.
+ */
+export {
+  Alert,
+  Badge,
+  ConfirmInput,
+  MultiSelect,
+  ProgressBar,
+  Select,
+  Spinner,
+  StatusMessage,
+  TextInput,
+} from '@inkjs/ui';

--- a/tests/component/CollisionReview.test.tsx
+++ b/tests/component/CollisionReview.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from 'ink-testing-library';
+import React from 'react';
+import CollisionReview from '../../source/components/CollisionReview.js';
+import type { Collision } from '../../source/core/install-planner.js';
+import { ENTER, ARROW_DOWN, tick, waitFor } from './helpers.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+function collision(outputPath: string, kind: 'file' | 'directory' = 'file'): Collision {
+  return {
+    absolutePath: `/vault/${outputPath}`,
+    outputPath,
+    kind,
+    size: 1024,
+    mtime: new Date('2026-04-01T12:00:00Z'),
+  };
+}
+
+async function mount(node: React.ReactElement) {
+  const r = render(node);
+  await tick(30);
+  return r;
+}
+
+describe('CollisionReview', () => {
+  it('renders file count and choices', async () => {
+    const { lastFrame } = await mount(
+      <CollisionReview
+        collisions={[collision('Home.md'), collision('Index.md')]}
+        onChoice={() => {}}
+      />,
+    );
+
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('2 existing paths will be affected');
+    expect(frame).toContain('Home.md');
+    expect(frame).toContain('Index.md');
+    expect(frame).toContain('Back up');
+    expect(frame).toContain('Overwrite');
+    expect(frame).toContain('Cancel');
+  });
+
+  it('warns about directory deletion when a collision is a directory', async () => {
+    const { lastFrame } = await mount(
+      <CollisionReview
+        collisions={[collision('Home.md'), collision('brain/', 'directory')]}
+        onChoice={() => {}}
+      />,
+    );
+
+    expect(lastFrame()).toContain('files AND directories will be deleted');
+  });
+
+  it('truncates collision list above 15 entries', async () => {
+    const many = Array.from({ length: 20 }, (_, i) => collision(`File${i}.md`));
+    const { lastFrame } = await mount(
+      <CollisionReview collisions={many} onChoice={() => {}} />,
+    );
+
+    expect(lastFrame()).toContain('…and 5 more');
+  });
+
+  it('backup choice fires onChoice("backup")', async () => {
+    const onChoice = vi.fn();
+    const { stdin } = await mount(
+      <CollisionReview
+        collisions={[collision('Home.md')]}
+        onChoice={onChoice}
+      />,
+    );
+
+    // First option (backup) is default; Enter commits.
+    stdin.write(ENTER);
+    await waitFor(() => (onChoice.mock.calls.length > 0 ? 'ok' : ''), (f) => f === 'ok');
+
+    expect(onChoice).toHaveBeenCalledWith('backup');
+  });
+
+  it('cancel choice fires onChoice("cancel")', async () => {
+    const onChoice = vi.fn();
+    const { stdin } = await mount(
+      <CollisionReview
+        collisions={[collision('Home.md')]}
+        onChoice={onChoice}
+      />,
+    );
+
+    // Move down twice: backup → overwrite → cancel
+    stdin.write(ARROW_DOWN);
+    await tick(30);
+    stdin.write(ARROW_DOWN);
+    await tick(30);
+    stdin.write(ENTER);
+    await waitFor(() => (onChoice.mock.calls.length > 0 ? 'ok' : ''), (f) => f === 'ok');
+
+    expect(onChoice).toHaveBeenCalledWith('cancel');
+  });
+});

--- a/tests/component/ExistingInstallGate.test.tsx
+++ b/tests/component/ExistingInstallGate.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from 'ink-testing-library';
+import React from 'react';
+import ExistingInstallGate from '../../source/components/ExistingInstallGate.js';
+import type { ShardState } from '../../source/runtime/types.js';
+import { ENTER, ARROW_DOWN, tick, waitFor } from './helpers.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+const state: ShardState = {
+  schema_version: 1,
+  shard: 'breferrari/test-minimal-shard',
+  source: 'github:breferrari/test-minimal-shard',
+  version: '0.1.0',
+  tarball_sha256: 'abc123',
+  installed_at: '2026-04-01T12:00:00Z',
+  updated_at: '2026-04-01T12:00:00Z',
+  values_hash: 'def456',
+  modules: { core: 'included', qmd: 'included' },
+  files: {},
+};
+
+async function mount(node: React.ReactElement) {
+  const r = render(node);
+  await tick(30);
+  return r;
+}
+
+describe('ExistingInstallGate', () => {
+  it('renders shard identity and gate choices', async () => {
+    const { lastFrame } = await mount(
+      <ExistingInstallGate state={state} onChoice={() => {}} />,
+    );
+
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('already has a shard installed');
+    expect(frame).toContain('breferrari/test-minimal-shard');
+    expect(frame).toContain('0.1.0');
+    expect(frame).toContain('Keep the existing install');
+    expect(frame).toContain('Reinstall from scratch');
+    expect(frame).toContain('Cancel');
+  });
+
+  it('choosing update fires onChoice("update") immediately', async () => {
+    const onChoice = vi.fn();
+    const { stdin } = await mount(
+      <ExistingInstallGate state={state} onChoice={onChoice} />,
+    );
+
+    // First option (update) is the default highlight; Enter commits.
+    stdin.write(ENTER);
+    await waitFor(() => (onChoice.mock.calls.length > 0 ? 'ok' : ''), (f) => f === 'ok');
+
+    expect(onChoice).toHaveBeenCalledWith('update');
+  });
+
+  it('empty submit on REINSTALL confirm shows validation error', async () => {
+    const onChoice = vi.fn();
+    const { stdin, lastFrame } = await mount(
+      <ExistingInstallGate state={state} onChoice={onChoice} />,
+    );
+
+    stdin.write(ARROW_DOWN);
+    await tick(30);
+    stdin.write(ENTER);
+    await waitFor(lastFrame, (f) => f.includes('Type REINSTALL to proceed'));
+
+    await tick(50);
+    stdin.write(ENTER);
+    await waitFor(lastFrame, (f) => f.includes('Exact text required'));
+    expect(onChoice).not.toHaveBeenCalled();
+  });
+
+  it('wrong text on REINSTALL confirm rejects submission', async () => {
+    const onChoice = vi.fn();
+    const { stdin, lastFrame } = await mount(
+      <ExistingInstallGate state={state} onChoice={onChoice} />,
+    );
+
+    stdin.write(ARROW_DOWN);
+    await tick(30);
+    stdin.write(ENTER);
+    await waitFor(lastFrame, (f) => f.includes('Type REINSTALL to proceed'));
+    await tick(50);
+
+    // Type one char at a time so the TextInput's submit closure sees
+    // the latest state.value when Enter fires.
+    for (const ch of 'reinstall') {
+      stdin.write(ch);
+      await tick(60);
+    }
+    await waitFor(lastFrame, (f) => f.includes('reinstall'));
+    stdin.write(ENTER);
+    await waitFor(lastFrame, (f) => f.includes('Exact text required'));
+    expect(onChoice).not.toHaveBeenCalled();
+  });
+
+  it('typing REINSTALL exactly fires onChoice("reinstall")', async () => {
+    const onChoice = vi.fn();
+    const { stdin, lastFrame } = await mount(
+      <ExistingInstallGate state={state} onChoice={onChoice} />,
+    );
+
+    stdin.write(ARROW_DOWN);
+    await tick(30);
+    stdin.write(ENTER);
+    await waitFor(lastFrame, (f) => f.includes('Type REINSTALL to proceed'));
+    await tick(50);
+
+    for (const ch of 'REINSTALL') {
+      stdin.write(ch);
+      await tick(60);
+    }
+    stdin.write(ENTER);
+    await waitFor(() => (onChoice.mock.calls.length > 0 ? 'ok' : ''), (f) => f === 'ok');
+
+    expect(onChoice).toHaveBeenCalledWith('reinstall');
+  });
+});

--- a/tests/component/ExistingInstallGate.test.tsx
+++ b/tests/component/ExistingInstallGate.test.tsx
@@ -3,7 +3,7 @@ import { render, cleanup } from 'ink-testing-library';
 import React from 'react';
 import ExistingInstallGate from '../../source/components/ExistingInstallGate.js';
 import type { ShardState } from '../../source/runtime/types.js';
-import { ENTER, ARROW_DOWN, tick, waitFor } from './helpers.js';
+import { ENTER, ARROW_DOWN, tick, typeText, waitFor } from './helpers.js';
 
 afterEach(() => {
   cleanup();
@@ -85,12 +85,7 @@ describe('ExistingInstallGate', () => {
     await waitFor(lastFrame, (f) => f.includes('Type REINSTALL to proceed'));
     await tick(50);
 
-    // Type one char at a time so the TextInput's submit closure sees
-    // the latest state.value when Enter fires.
-    for (const ch of 'reinstall') {
-      stdin.write(ch);
-      await tick(60);
-    }
+    await typeText(stdin, 'reinstall');
     await waitFor(lastFrame, (f) => f.includes('reinstall'));
     stdin.write(ENTER);
     await waitFor(lastFrame, (f) => f.includes('Exact text required'));
@@ -109,10 +104,7 @@ describe('ExistingInstallGate', () => {
     await waitFor(lastFrame, (f) => f.includes('Type REINSTALL to proceed'));
     await tick(50);
 
-    for (const ch of 'REINSTALL') {
-      stdin.write(ch);
-      await tick(60);
-    }
+    await typeText(stdin, 'REINSTALL');
     stdin.write(ENTER);
     await waitFor(() => (onChoice.mock.calls.length > 0 ? 'ok' : ''), (f) => f === 'ok');
 

--- a/tests/component/Header.test.tsx
+++ b/tests/component/Header.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from 'ink-testing-library';
+import React from 'react';
+import Header from '../../source/components/Header.js';
+import type { ShardManifest } from '../../source/runtime/types.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+const base: ShardManifest = {
+  apiVersion: 'v1',
+  name: 'mini',
+  namespace: 'breferrari',
+  version: '0.1.0',
+  dependencies: [],
+  hooks: {},
+};
+
+describe('Header', () => {
+  it('renders namespace/name and version badge', () => {
+    const { lastFrame } = render(<Header manifest={base} />);
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('breferrari/mini');
+    expect(frame).toContain('v0.1.0');
+  });
+
+  it('renders description when present', () => {
+    const { lastFrame } = render(
+      <Header manifest={{ ...base, description: 'A minimal test shard' }} />,
+    );
+    expect(lastFrame()).toContain('A minimal test shard');
+  });
+
+  it('renders persona with "for" prefix when present', () => {
+    const { lastFrame } = render(
+      <Header manifest={{ ...base, persona: 'solo engineers' }} />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('for');
+    expect(frame).toContain('solo engineers');
+  });
+
+  it('omits description and persona sections when absent', () => {
+    const { lastFrame } = render(<Header manifest={base} />);
+    const frame = lastFrame() ?? '';
+    expect(frame).not.toContain('for ');
+    // 'breferrari/mini' + version badge is the only line of content
+    expect(frame.split('\n').filter((l) => l.trim().length > 0).length).toBeLessThan(3);
+  });
+});

--- a/tests/component/InstallProgress.test.tsx
+++ b/tests/component/InstallProgress.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from 'ink-testing-library';
+import React from 'react';
+import InstallProgress from '../../source/components/InstallProgress.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('InstallProgress', () => {
+  it('renders current/total counter and label', () => {
+    const { lastFrame } = render(
+      <InstallProgress current={3} total={10} label="Rendering Home.md" />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('[3/10]');
+    expect(frame).toContain('Rendering Home.md');
+  });
+
+  it('handles total=0 without NaN', () => {
+    const { lastFrame } = render(
+      <InstallProgress current={0} total={0} label="Preparing" />,
+    );
+    // No "NaN" anywhere in the frame (percent calc guards against /0)
+    expect(lastFrame()).not.toContain('NaN');
+  });
+
+  it('clamps percent at 100 when current > total', () => {
+    // Guards against a caller passing bad counts — verify no overflow crash
+    const { lastFrame } = render(
+      <InstallProgress current={15} total={10} label="Finishing" />,
+    );
+    expect(lastFrame()).toContain('[15/10]');
+  });
+
+  it('renders history lines when verbose + history provided', () => {
+    const { lastFrame } = render(
+      <InstallProgress
+        current={2}
+        total={5}
+        label="Rendering"
+        verbose
+        history={['wrote core/Home.md', 'wrote core/Index.md']}
+      />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('wrote core/Home.md');
+    expect(frame).toContain('wrote core/Index.md');
+  });
+
+  it('omits history section when verbose=false', () => {
+    const { lastFrame } = render(
+      <InstallProgress
+        current={2}
+        total={5}
+        label="Rendering"
+        history={['wrote core/Home.md']}
+      />,
+    );
+    expect(lastFrame()).not.toContain('wrote core/Home.md');
+  });
+});

--- a/tests/component/InstallWizard.test.tsx
+++ b/tests/component/InstallWizard.test.tsx
@@ -7,7 +7,7 @@ import type {
   ShardSchema,
   ModuleSelections,
 } from '../../source/runtime/types.js';
-import { ENTER, ESC, tick, waitFor } from './helpers.js';
+import { ENTER, ESC, tick, typeText, waitFor } from './helpers.js';
 
 afterEach(() => {
   cleanup();
@@ -81,10 +81,7 @@ describe('InstallWizard', () => {
     await waitFor(lastFrame, (f) => f.includes('Your name'));
 
     // Value 1: user_name (required string)
-    for (const ch of 'Alice') {
-      stdin.write(ch);
-      await tick(30);
-    }
+    await typeText(stdin, 'Alice');
     stdin.write(ENTER);
     await waitFor(lastFrame, (f) => f.includes('Organization'));
 

--- a/tests/component/InstallWizard.test.tsx
+++ b/tests/component/InstallWizard.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from 'ink-testing-library';
+import React from 'react';
+import InstallWizard from '../../source/components/InstallWizard.js';
+import type {
+  ShardManifest,
+  ShardSchema,
+  ModuleSelections,
+} from '../../source/runtime/types.js';
+import { ENTER, ESC, tick, waitFor } from './helpers.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+const manifest: ShardManifest = {
+  apiVersion: 'v1',
+  name: 'mini',
+  namespace: 'breferrari',
+  version: '0.1.0',
+  dependencies: [],
+  hooks: {},
+};
+
+const schema: ShardSchema = {
+  schema_version: 1,
+  values: {
+    user_name: {
+      type: 'string',
+      required: true,
+      message: 'Your name',
+      group: 'setup',
+    },
+    org_name: {
+      type: 'string',
+      message: 'Organization',
+      default: 'Independent',
+      group: 'setup',
+    },
+  },
+  groups: [{ id: 'setup', label: 'Quick Setup' }],
+  modules: {
+    core: { label: 'Core', paths: ['core/'], removable: false },
+    extras: { label: 'Extras', paths: ['extras/'], removable: true },
+  },
+  signals: [],
+  frontmatter: {},
+  migrations: [],
+};
+
+const moduleFileCounts = { core: 10, extras: 5 };
+
+async function mount(node: React.ReactElement) {
+  const r = render(node);
+  await tick(30);
+  return r;
+}
+
+describe('InstallWizard', () => {
+  it('drives through values → modules → confirm → install', async () => {
+    const onComplete = vi.fn();
+    const onCancel = vi.fn();
+    const onError = vi.fn();
+
+    const { stdin, lastFrame } = await mount(
+      <InstallWizard
+        manifest={manifest}
+        schema={schema}
+        prefillValues={{}}
+        moduleFileCounts={moduleFileCounts}
+        alwaysIncludedFileCount={0}
+        onComplete={onComplete}
+        onCancel={onCancel}
+        onError={onError}
+      />,
+    );
+
+    // Header step — Enter starts the flow
+    await waitFor(lastFrame, (f) => /2 questions to answer/.test(f));
+    stdin.write(ENTER);
+    await waitFor(lastFrame, (f) => f.includes('Your name'));
+
+    // Value 1: user_name (required string)
+    for (const ch of 'Alice') {
+      stdin.write(ch);
+      await tick(30);
+    }
+    stdin.write(ENTER);
+    await waitFor(lastFrame, (f) => f.includes('Organization'));
+
+    // Value 2: org_name — Enter to accept default 'Independent'
+    stdin.write(ENTER);
+    await waitFor(lastFrame, (f) => f.includes('Choose modules to install'));
+
+    // Module review — Enter submits default selections
+    stdin.write(ENTER);
+    await waitFor(lastFrame, (f) => f.includes('Ready to install'));
+
+    // Confirm step — first option is Install
+    stdin.write(ENTER);
+    await waitFor(() => (onComplete.mock.calls.length > 0 ? 'ok' : ''), (f) => f === 'ok');
+
+    const [{ values, selections }] = onComplete.mock.calls[0] as [
+      { values: Record<string, unknown>; selections: ModuleSelections },
+    ];
+    expect(values.user_name).toBe('Alice');
+    expect(values.org_name).toBe('Independent');
+    expect(selections.core).toBe('included');
+    expect(selections.extras).toBe('included');
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('Esc from value step navigates back to the header', async () => {
+    const { stdin, lastFrame } = await mount(
+      <InstallWizard
+        manifest={manifest}
+        schema={schema}
+        prefillValues={{}}
+        moduleFileCounts={moduleFileCounts}
+        alwaysIncludedFileCount={0}
+        onComplete={() => {}}
+        onCancel={() => {}}
+        onError={() => {}}
+      />,
+    );
+
+    await waitFor(lastFrame, (f) => /2 questions to answer/.test(f));
+    stdin.write(ENTER);
+    await waitFor(lastFrame, (f) => f.includes('Your name'));
+
+    // Esc should return to header
+    stdin.write(ESC);
+    await waitFor(lastFrame, (f) => /2 questions to answer/.test(f));
+  });
+
+  it('skips to modules when all values are prefilled', async () => {
+    const { lastFrame } = await mount(
+      <InstallWizard
+        manifest={manifest}
+        schema={schema}
+        prefillValues={{ user_name: 'Alice', org_name: 'Org' }}
+        moduleFileCounts={moduleFileCounts}
+        alwaysIncludedFileCount={0}
+        onComplete={() => {}}
+        onCancel={() => {}}
+        onError={() => {}}
+      />,
+    );
+
+    await waitFor(lastFrame, (f) => f.includes('Choose modules to install'));
+  });
+});

--- a/tests/component/ModuleReview.test.tsx
+++ b/tests/component/ModuleReview.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from 'ink-testing-library';
+import React from 'react';
+import ModuleReview from '../../source/components/ModuleReview.js';
+import type { ModuleDefinition, ModuleSelections } from '../../source/runtime/types.js';
+import { ENTER, SPACE, ARROW_DOWN, tick, waitFor } from './helpers.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+function mod(label: string, removable: boolean): ModuleDefinition {
+  return { label, paths: [], removable };
+}
+
+const modules: Record<string, ModuleDefinition> = {
+  core: mod('Core', false),
+  qmd: mod('QMD', true),
+  research: mod('Research', true),
+};
+
+const fileCounts: Record<string, number> = {
+  core: 10,
+  qmd: 5,
+  research: 8,
+};
+
+const initialSelections: ModuleSelections = {
+  core: 'included',
+  qmd: 'included',
+  research: 'included',
+};
+
+async function mount(node: React.ReactElement) {
+  const r = render(node);
+  await tick(30);
+  return r;
+}
+
+describe('ModuleReview', () => {
+  it('shows initial total including always-on modules + framework files', async () => {
+    const { lastFrame } = await mount(
+      <ModuleReview
+        modules={modules}
+        moduleFileCounts={fileCounts}
+        alwaysIncludedFileCount={3}
+        initialSelections={initialSelections}
+        onSubmit={() => {}}
+      />,
+    );
+
+    const frame = lastFrame() ?? '';
+    // 10 (core) + 5 (qmd) + 8 (research) + 3 (framework) = 26
+    expect(frame).toContain('Will install:');
+    expect(frame).toContain('26 files');
+    expect(frame).toContain('Core');
+    expect(frame).toContain('Framework files');
+  });
+
+  it('total updates when a removable module is toggled off', async () => {
+    const { stdin, lastFrame } = await mount(
+      <ModuleReview
+        modules={modules}
+        moduleFileCounts={fileCounts}
+        alwaysIncludedFileCount={0}
+        initialSelections={initialSelections}
+        onSubmit={() => {}}
+      />,
+    );
+
+    await waitFor(lastFrame, (f) => f.includes('23 files'));
+
+    // MultiSelect starts highlight on first option (qmd). Space toggles it off.
+    stdin.write(SPACE);
+    // 10 (core locked) + 0 (qmd off) + 8 (research on) = 18
+    await waitFor(lastFrame, (f) => f.includes('18 files'));
+  });
+
+  it('onSubmit fires with final selections when Enter pressed', async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = await mount(
+      <ModuleReview
+        modules={modules}
+        moduleFileCounts={fileCounts}
+        alwaysIncludedFileCount={0}
+        initialSelections={initialSelections}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    // Toggle qmd off, leave research on, submit
+    stdin.write(SPACE);
+    await tick(50);
+    stdin.write(ENTER);
+    await waitFor(() => (onSubmit.mock.calls.length > 0 ? 'ok' : ''), (f) => f === 'ok');
+
+    const [selections] = onSubmit.mock.calls[0] as [ModuleSelections];
+    expect(selections.core).toBe('included');
+    expect(selections.qmd).toBe('excluded');
+    expect(selections.research).toBe('included');
+  });
+
+  it('renders "no optional modules" when all are non-removable', async () => {
+    const onlyLocked = {
+      core: mod('Core', false),
+      framework: mod('Framework', false),
+    };
+    const { lastFrame } = await mount(
+      <ModuleReview
+        modules={onlyLocked}
+        moduleFileCounts={{ core: 10, framework: 2 }}
+        alwaysIncludedFileCount={0}
+        initialSelections={{ core: 'included', framework: 'included' }}
+        onSubmit={() => {}}
+      />,
+    );
+
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('No optional modules');
+    expect(frame).toContain('12 files');
+  });
+});

--- a/tests/component/Summary.test.tsx
+++ b/tests/component/Summary.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from 'ink-testing-library';
+import React from 'react';
+import Summary from '../../source/components/Summary.js';
+import type { ShardManifest } from '../../source/runtime/types.js';
+import type { BackupRecord } from '../../source/core/install-executor.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+const manifest: ShardManifest = {
+  apiVersion: 'v1',
+  name: 'mini',
+  namespace: 'breferrari',
+  version: '0.1.0',
+  dependencies: [],
+  hooks: {},
+};
+
+const baseProps = {
+  manifest,
+  vaultRoot: '/home/alice/vault',
+  fileCount: 23,
+  durationMs: 1234,
+  backups: [] as BackupRecord[],
+  hookOutput: null,
+};
+
+describe('Summary', () => {
+  it('renders install success line with shard ref and file count', () => {
+    const { lastFrame } = render(<Summary {...baseProps} />);
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Installed');
+    expect(frame).toContain('breferrari/mini@0.1.0');
+    expect(frame).toContain('23 files');
+    expect(frame).toContain('1.2s');
+  });
+
+  it('renders dry-run line when dryRun=true', () => {
+    const { lastFrame } = render(<Summary {...baseProps} dryRun />);
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Dry run complete');
+    expect(frame).toContain('23 files would be written');
+    expect(frame).not.toContain('Next:');
+  });
+
+  it('renders backup list when backups present, truncates above 10', () => {
+    const backups: BackupRecord[] = Array.from({ length: 13 }, (_, i) => ({
+      originalPath: `/vault/File${i}.md`,
+      backupPath: `/vault/File${i}.md.shardmind-backup-xyz`,
+    }));
+    const { lastFrame } = render(<Summary {...baseProps} backups={backups} />);
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Backed up 13 existing files');
+    expect(frame).toContain('File0.md.shardmind-backup-xyz');
+    expect(frame).toContain('…and 3 more');
+  });
+
+  it('surfaces deferred hook warning', () => {
+    const { lastFrame } = render(
+      <Summary {...baseProps} hookOutput={{ deferred: true }} />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Post-install hook detected but not executed');
+    expect(frame).toContain('#30');
+  });
+
+  it('includes platform-specific open command on success', () => {
+    const { lastFrame } = render(<Summary {...baseProps} />);
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Next:');
+    // One of the three known openers must appear
+    expect(
+      frame.includes('open "') ||
+        frame.includes('start ""') ||
+        frame.includes('xdg-open "'),
+    ).toBe(true);
+    expect(frame).toContain('/home/alice/vault');
+  });
+});

--- a/tests/component/ValueInput.test.tsx
+++ b/tests/component/ValueInput.test.tsx
@@ -3,7 +3,7 @@ import { render, cleanup } from 'ink-testing-library';
 import React from 'react';
 import ValueInput from '../../source/components/ValueInput.js';
 import type { ValueDefinition } from '../../source/runtime/types.js';
-import { ENTER, tick, waitFor } from './helpers.js';
+import { ENTER, ARROW_DOWN, tick, typeText, waitFor } from './helpers.js';
 
 afterEach(() => {
   cleanup();
@@ -46,7 +46,7 @@ describe('ValueInput', () => {
       <ValueInput id="user_name" def={def} initialValue="" onSubmit={onSubmit} />,
     );
 
-    stdin.write('Alice');
+    await typeText(stdin, 'Alice');
     await waitFor(lastFrame, (f) => f.includes('Alice'));
     stdin.write(ENTER);
     await waitFor(() => (onSubmit.mock.calls.length > 0 ? 'ok' : ''), (f) => f === 'ok');
@@ -92,6 +92,72 @@ describe('ValueInput', () => {
     await waitFor(lastFrame, (f) => /Must be ≥ 18/.test(f));
 
     expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('select: arrow + Enter picks an option and calls onSubmit', async () => {
+    const def: ValueDefinition = {
+      type: 'select',
+      required: true,
+      message: 'Purpose?',
+      options: [
+        { value: 'engineering', label: 'Engineering' },
+        { value: 'research', label: 'Research' },
+        { value: 'general', label: 'General' },
+      ],
+      group: 'setup',
+    };
+    const onSubmit = vi.fn();
+    const { stdin, lastFrame } = await mount(
+      <ValueInput id="vault_purpose" def={def} initialValue="" onSubmit={onSubmit} />,
+    );
+
+    // All three options should render
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Engineering');
+    expect(frame).toContain('Research');
+    expect(frame).toContain('General');
+
+    // Move down to 'research' and select
+    stdin.write(ARROW_DOWN);
+    await tick(30);
+    stdin.write(ENTER);
+    await waitFor(() => (onSubmit.mock.calls.length > 0 ? 'ok' : ''), (f) => f === 'ok');
+
+    expect(onSubmit).toHaveBeenCalledWith('research');
+  });
+
+  it('boolean: y confirms → onSubmit(true)', async () => {
+    const def: ValueDefinition = {
+      type: 'boolean',
+      message: 'Enable QMD?',
+      default: false,
+      group: 'setup',
+    };
+    const onSubmit = vi.fn();
+    const { stdin } = await mount(
+      <ValueInput id="qmd_enabled" def={def} initialValue={false} onSubmit={onSubmit} />,
+    );
+
+    stdin.write('y');
+    await waitFor(() => (onSubmit.mock.calls.length > 0 ? 'ok' : ''), (f) => f === 'ok');
+    expect(onSubmit).toHaveBeenCalledWith(true);
+  });
+
+  it('boolean: n cancels → onSubmit(false)', async () => {
+    const def: ValueDefinition = {
+      type: 'boolean',
+      message: 'Enable QMD?',
+      default: true,
+      group: 'setup',
+    };
+    const onSubmit = vi.fn();
+    const { stdin } = await mount(
+      <ValueInput id="qmd_enabled" def={def} initialValue={true} onSubmit={onSubmit} />,
+    );
+
+    stdin.write('n');
+    await waitFor(() => (onSubmit.mock.calls.length > 0 ? 'ok' : ''), (f) => f === 'ok');
+    expect(onSubmit).toHaveBeenCalledWith(false);
   });
 
   it('renders message, hint, and required marker', async () => {

--- a/tests/component/ValueInput.test.tsx
+++ b/tests/component/ValueInput.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from 'ink-testing-library';
+import React from 'react';
+import ValueInput from '../../source/components/ValueInput.js';
+import type { ValueDefinition } from '../../source/runtime/types.js';
+import { ENTER, tick, waitFor } from './helpers.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+async function mount(node: React.ReactElement) {
+  const r = render(node);
+  // Give Ink time to mount useInput handlers before we write.
+  await tick(30);
+  return r;
+}
+
+describe('ValueInput', () => {
+  it('string: required + empty submit shows validation error', async () => {
+    const def: ValueDefinition = {
+      type: 'string',
+      required: true,
+      message: 'Your name?',
+      group: 'identity',
+    };
+    const onSubmit = vi.fn();
+    const { stdin, lastFrame } = await mount(
+      <ValueInput id="user_name" def={def} initialValue="" onSubmit={onSubmit} />,
+    );
+
+    stdin.write(ENTER);
+    await waitFor(lastFrame, (f) => f.includes('Required'));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('string: typed value submits correctly', async () => {
+    const def: ValueDefinition = {
+      type: 'string',
+      message: 'Your name?',
+      group: 'identity',
+    };
+    const onSubmit = vi.fn();
+    const { stdin, lastFrame } = await mount(
+      <ValueInput id="user_name" def={def} initialValue="" onSubmit={onSubmit} />,
+    );
+
+    stdin.write('Alice');
+    await waitFor(lastFrame, (f) => f.includes('Alice'));
+    stdin.write(ENTER);
+    await waitFor(() => (onSubmit.mock.calls.length > 0 ? 'ok' : ''), (f) => f === 'ok');
+
+    expect(onSubmit).toHaveBeenCalledWith('Alice');
+  });
+
+  it('number: non-numeric input shows validation error', async () => {
+    const def: ValueDefinition = {
+      type: 'number',
+      message: 'Age?',
+      group: 'identity',
+    };
+    const onSubmit = vi.fn();
+    const { stdin, lastFrame } = await mount(
+      <ValueInput id="age" def={def} initialValue="" onSubmit={onSubmit} />,
+    );
+
+    stdin.write('abc');
+    await waitFor(lastFrame, (f) => f.includes('abc'));
+    stdin.write(ENTER);
+    await waitFor(lastFrame, (f) => f.includes('Must be a number'));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('number: out-of-range value shows min error', async () => {
+    const def: ValueDefinition = {
+      type: 'number',
+      message: 'Age?',
+      min: 18,
+      max: 99,
+      group: 'identity',
+    };
+    const onSubmit = vi.fn();
+    const { stdin, lastFrame } = await mount(
+      <ValueInput id="age" def={def} initialValue="" onSubmit={onSubmit} />,
+    );
+
+    stdin.write('5');
+    await waitFor(lastFrame, (f) => f.includes('5'));
+    stdin.write(ENTER);
+    await waitFor(lastFrame, (f) => /Must be ≥ 18/.test(f));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('renders message, hint, and required marker', async () => {
+    const def: ValueDefinition = {
+      type: 'string',
+      required: true,
+      message: 'Your name?',
+      hint: 'Shown in CLAUDE.md',
+      group: 'identity',
+    };
+    const { lastFrame } = await mount(
+      <ValueInput id="user_name" def={def} initialValue="" onSubmit={() => {}} />,
+    );
+
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Your name?');
+    expect(frame).toContain('*');
+    expect(frame).toContain('Shown in CLAUDE.md');
+  });
+});

--- a/tests/component/helpers.ts
+++ b/tests/component/helpers.ts
@@ -1,0 +1,33 @@
+export async function tick(ms = 30): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Poll lastFrame() until `predicate` returns true or `timeoutMs` elapses.
+ * Ink renders asynchronously after stdin writes and state updates, so a
+ * fixed sleep is flaky — waitFor is the robust pattern.
+ */
+export async function waitFor(
+  lastFrame: () => string | undefined,
+  predicate: (frame: string) => boolean,
+  timeoutMs = 2000,
+): Promise<string> {
+  const start = Date.now();
+  // Yield once so Ink's stdin listener and render scheduler can process
+  // any inputs queued just before waitFor was called.
+  await tick(30);
+  while (Date.now() - start < timeoutMs) {
+    const frame = lastFrame() ?? '';
+    if (predicate(frame)) return frame;
+    await tick(50);
+  }
+  throw new Error(
+    `waitFor timed out after ${timeoutMs}ms. Last frame:\n${JSON.stringify(lastFrame())}`,
+  );
+}
+
+export const ENTER = '\r';
+export const ESC = '\x1B';
+export const SPACE = ' ';
+export const ARROW_DOWN = '\x1B[B';
+export const ARROW_UP = '\x1B[A';

--- a/tests/component/helpers.ts
+++ b/tests/component/helpers.ts
@@ -51,6 +51,11 @@ export async function typeText(
   text: string,
   perCharDelayMs = 30,
 ): Promise<void> {
+  // Settle first: under Ink 7 / React 19, a TextInput that just
+  // mounted as part of a step transition may not have attached its
+  // useInput handler by the time waitFor sees its text appear. A
+  // small initial tick avoids losing the first keystroke.
+  await tick(perCharDelayMs);
   for (const ch of text) {
     stdin.write(ch);
     await tick(perCharDelayMs);

--- a/tests/component/helpers.ts
+++ b/tests/component/helpers.ts
@@ -31,3 +31,28 @@ export const ESC = '\x1B';
 export const SPACE = ' ';
 export const ARROW_DOWN = '\x1B[B';
 export const ARROW_UP = '\x1B[A';
+
+interface Writable {
+  write: (data: string) => void;
+}
+
+/**
+ * Type a string one character at a time with a tick between each write.
+ *
+ * Why not write the whole string at once: @inkjs/ui TextInput's submit
+ * callback captures `state.value` in a useCallback closure. Multiple
+ * writes in the same microtask get batched into a single render, which
+ * can leave the submit closure stale relative to the rendered value.
+ * Per-character writes with a tick in between ensure React commits
+ * each insert before the next keystroke arrives.
+ */
+export async function typeText(
+  stdin: Writable,
+  text: string,
+  perCharDelayMs = 30,
+): Promise<void> {
+  for (const ch of text) {
+    stdin.write(ch);
+    await tick(perCharDelayMs);
+  }
+}

--- a/tests/component/helpers.ts
+++ b/tests/component/helpers.ts
@@ -13,16 +13,24 @@ export async function waitFor(
   timeoutMs = 2000,
 ): Promise<string> {
   const start = Date.now();
+  let lastObservedFrame = '';
   // Yield once so Ink's stdin listener and render scheduler can process
   // any inputs queued just before waitFor was called.
   await tick(30);
   while (Date.now() - start < timeoutMs) {
-    const frame = lastFrame() ?? '';
-    if (predicate(frame)) return frame;
+    lastObservedFrame = lastFrame() ?? '';
+    if (predicate(lastObservedFrame)) {
+      // Post-predicate settle: the frame matches, but any effects
+      // scheduled for after this render (useInput registration for a
+      // just-mounted input, etc.) may not have fired yet. One more
+      // tick lets them run before the caller writes to stdin.
+      await tick(30);
+      return lastObservedFrame;
+    }
     await tick(50);
   }
   throw new Error(
-    `waitFor timed out after ${timeoutMs}ms. Last frame:\n${JSON.stringify(lastFrame())}`,
+    `waitFor timed out after ${timeoutMs}ms. Last frame:\n${lastObservedFrame}`,
   );
 }
 
@@ -51,11 +59,6 @@ export async function typeText(
   text: string,
   perCharDelayMs = 30,
 ): Promise<void> {
-  // Settle first: under Ink 7 / React 19, a TextInput that just
-  // mounted as part of a step transition may not have attached its
-  // useInput handler by the time waitFor sees its text appear. A
-  // small initial tick avoids losing the first keystroke.
-  await tick(perCharDelayMs);
   for (const ch of text) {
     stdin.write(ch);
     await tick(perCharDelayMs);

--- a/tests/component/inkjs-ui-onchange-quirk.test.tsx
+++ b/tests/component/inkjs-ui-onchange-quirk.test.tsx
@@ -2,6 +2,10 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { render, cleanup } from 'ink-testing-library';
 import React, { useState } from 'react';
 import { Box, Text } from 'ink';
+// Intentional direct @inkjs/ui import. This file tracks upstream
+// behavior; it must keep hitting @inkjs/ui even if we later vendor or
+// fork the component in source/components/ui.ts. Do not route through
+// the shim.
 import { TextInput } from '@inkjs/ui';
 import { ENTER, tick, typeText } from './helpers.js';
 

--- a/tests/component/inkjs-ui-onchange-quirk.test.tsx
+++ b/tests/component/inkjs-ui-onchange-quirk.test.tsx
@@ -29,6 +29,9 @@ afterEach(() => {
  *       understand why we did what we did.
  *
  * See ExistingInstallGate.tsx for the workaround.
+ *
+ * Upstream issue: https://github.com/vadimdemedes/ink-ui/issues/26
+ * Upstream fix (pending review): https://github.com/vadimdemedes/ink-ui/pull/27
  */
 describe('@inkjs/ui TextInput onChange quirk (regression)', () => {
   it('fires onChange spuriously after submit when parent re-renders', async () => {

--- a/tests/component/inkjs-ui-onchange-quirk.test.tsx
+++ b/tests/component/inkjs-ui-onchange-quirk.test.tsx
@@ -7,7 +7,7 @@ import { Box, Text } from 'ink';
 // fork the component in source/components/ui.ts. Do not route through
 // the shim.
 import { TextInput } from '@inkjs/ui';
-import { ENTER, tick, typeText } from './helpers.js';
+import { ENTER, tick, typeText, waitFor } from './helpers.js';
 
 afterEach(() => {
   cleanup();
@@ -61,7 +61,15 @@ describe('@inkjs/ui TextInput onChange quirk (regression)', () => {
     await tick(30);
     await typeText(stdin, 'abc');
     stdin.write(ENTER);
-    await tick(200);
+
+    // Poll for the spurious fire rather than sleeping a fixed amount.
+    // If upstream ever fixes the bug, this times out (fails the test)
+    // instead of passing from a lucky-fast tick or flaking under load.
+    await waitFor(
+      () => (onChangeValues.length > 3 ? 'ok' : ''),
+      (f) => f === 'ok',
+      500,
+    );
 
     expect(submitValues).toEqual(['abc']);
 

--- a/tests/component/inkjs-ui-onchange-quirk.test.tsx
+++ b/tests/component/inkjs-ui-onchange-quirk.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from 'ink-testing-library';
+import React, { useState } from 'react';
+import { Box, Text } from 'ink';
+import { TextInput } from '@inkjs/ui';
+import { ENTER, tick, typeText } from './helpers.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+/**
+ * Regression test documenting a quirk in @inkjs/ui's TextInput.
+ *
+ * When the parent passes an inline onChange closure, useTextInput's
+ * internal useEffect has `onChange` as a dependency. A parent re-render
+ * (e.g. from setState in onSubmit) produces a new onChange identity,
+ * re-runs the effect, and the inner `state.value !== state.previousValue`
+ * guard doesn't prevent a spurious call because `previousValue` holds
+ * the value-before-the-last-insert, not the value last notified.
+ *
+ * Result: onChange fires again with the unchanged value after submit.
+ *
+ * This test captures the observed behavior so that:
+ *   (a) if @inkjs/ui fixes the upstream issue, this test fails loudly
+ *       and we can simplify our ExistingInstallGate workaround;
+ *   (b) if someone simplifies ExistingInstallGate's ref-based guard
+ *       back to the naive `if (error) setError(null)` pattern, they'll
+ *       understand why we did what we did.
+ *
+ * See ExistingInstallGate.tsx for the workaround.
+ */
+describe('@inkjs/ui TextInput onChange quirk (regression)', () => {
+  it('fires onChange spuriously after submit when parent re-renders', async () => {
+    const onChangeValues: string[] = [];
+    const submitValues: string[] = [];
+
+    function Harness() {
+      const [_submitCount, setSubmitCount] = useState(0);
+      return (
+        <Box flexDirection="column">
+          <TextInput
+            onChange={(v) => onChangeValues.push(v)}
+            onSubmit={(v) => {
+              submitValues.push(v);
+              setSubmitCount((c) => c + 1); // triggers a parent re-render
+            }}
+          />
+        </Box>
+      );
+    }
+
+    const { stdin } = render(<Harness />);
+    await tick(30);
+    await typeText(stdin, 'abc');
+    stdin.write(ENTER);
+    await tick(200);
+
+    expect(submitValues).toEqual(['abc']);
+
+    // The typing itself produces exactly 3 onChange calls — one per
+    // keystroke. If @inkjs/ui stops firing spuriously after submit,
+    // this length will drop to 3 and this test should be updated (and
+    // ExistingInstallGate's workaround simplified).
+    const typingFires = onChangeValues.slice(0, 3);
+    expect(typingFires).toEqual(['a', 'ab', 'abc']);
+
+    const postSubmitFires = onChangeValues.slice(3);
+    expect(postSubmitFires.length).toBeGreaterThan(0);
+    expect(postSubmitFires.every((v) => v === 'abc')).toBe(true);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     include: [
       'tests/unit/**/*.test.ts',
+      'tests/component/**/*.test.tsx',
       'tests/integration/**/*.test.ts',
       'tests/e2e/**/*.test.ts',
     ],


### PR DESCRIPTION
## Summary

Started as #38 (ink-testing-library component tests) and grew into a broader "harden the TUI layer" pass. Three coherent pieces:

### 1. TUI component test coverage (original scope)

Pulls #38 forward from v0.2. Adds `ink-testing-library` as a devDependency and **40 component tests** across all 7 Ink components: `ValueInput`, `ModuleReview`, `ExistingInstallGate`, `InstallWizard`, `CollisionReview`, `Header`, `InstallProgress`, `Summary`.

Covers #38's acceptance criteria in full:
- Value validation errors (`ValueInput`)
- Module total updates (`ModuleReview`)
- Typed REINSTALL confirmation, empty + wrong-text rejection (`ExistingInstallGate`)
- Esc-to-back navigation (`InstallWizard`)

### 2. Latent bug fix in `ExistingInstallGate`

Surfaced by the new test harness: `@inkjs/ui`'s `TextInput` fires `onChange` on parent re-renders when `state.value !== state.previousValue`. After `setError` in `onSubmit`, the parent re-render refires `onChange` with the unchanged value, clearing the error the same tick it was set.

Fixed by tracking the last submitted value in a ref — error only clears when the user types something different from the value that caused it.

Also added a regression test at `tests/component/inkjs-ui-onchange-quirk.test.tsx` that locks in the upstream behavior so we'll know if it ever gets fixed.

### 3. `@inkjs/ui` hedge: shim layer + ADR

Investigation surfaced that `@inkjs/ui` is effectively abandoned upstream (no commits since 2024-05-22, 22 open issues, last maintainer engagement June 2023, while `ink` itself actively ships 7.0.x in April 2026).

Filed upstream: [issue #26](https://github.com/vadimdemedes/ink-ui/issues/26) and [PR #27](https://github.com/vadimdemedes/ink-ui/pull/27).

To cap the blast radius of a frozen dependency:

- **New `source/components/ui.ts`** — single re-export shim. All TUI code now imports from `./ui.js` rather than `@inkjs/ui` directly. Swapping the backend (vendor, fork, migrate) is a one-file change.
- **`docs/ARCHITECTURE.md` §11.4** — ADR-style note: status, why we still depend on it, what the shim buys us, swap triggers, v0.2 revisit cadence.
- **`ROADMAP.md` v0.2** — new bullet tracking #43 for re-evaluation.
- **Upstream refs in code** — `ExistingInstallGate.tsx` and the regression test both link back to upstream #26 / #27.

## Test plan

- [x] `npm test` — 182 passed (40 new component tests + 142 existing)
- [x] `npm run typecheck` — clean
- [x] CI green on Ubuntu (Node 22 + 24)
- [x] Tests run under Windows bash (MSYS) without TTY setup

Closes #38. Tracks #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
