### PR TITLE
docs(roadmap): drop duplicate M2 verify step blocked by M5/M6

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,7 +29,6 @@ Ship the core: install, update, status. Prove that vault template upgrades work 
 - [x] `commands/install.tsx` — full install flow with Ink wizard ([#8](https://github.com/breferrari/shardmind/issues/8))
 - [x] Integration test: install pipeline against `examples/minimal-shard` (real obsidian-mind shard verified at Milestone 5)
 - [x] `ink-testing-library` component tests for ValueInput, ModuleReview, ExistingInstallGate, InstallWizard ([#38](https://github.com/breferrari/shardmind/issues/38) — pulled forward from v0.2)
-- [ ] Verify: `shardmind install breferrari/obsidian-mind` works end to end
 
 ### Milestone 3: Merge Engine (Day 3)
 


### PR DESCRIPTION
## Summary
- The M2 verify bullet `shardmind install breferrari/obsidian-mind` depends on the shard registry (M6) and obsidian-mind being a shard (M5), so it can't pass in M2 by construction.
- It's also a duplicate of the M6 registry-mode verify on line 58 — line 30 already notes "real obsidian-mind shard verified at Milestone 5."
- M2's install pipeline remains covered by the minimal-shard integration test and the @inkjs component tests above.

Confirmed with a clean run in a temp dir:
```
✘ Could not fetch shard registry: HTTP 404
code: REGISTRY_NETWORK
```
That's `source/core/registry.ts:107-115` hitting the unpublished `shardmind/registry/index.json` — working as designed; the step just isn't reachable yet.

## Test plan
- [x] Diff shows a single-line removal in ROADMAP.md M2 section
- [x] No code changes; typecheck/tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)