### PR TITLE
harden: whole-codebase audit — 13 real bugs + 3 UI guards + dead-code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,63 @@ Between releases: see `git log` for merged work and [`ROADMAP.md`](ROADMAP.md) f
 
 ## [Unreleased]
 
+### Fixed (harden pass)
+
+- **Binary assets no longer corrupt on `shardmind update`.** `detectDrift` was reading every tracked file as UTF-8 and hashing the decoded string, while install-executor hashed raw bytes. Copy-origin binaries (images, PDFs, any non-UTF-8 asset) hit an unpaired byte, Node replaced it with U+FFFD on decode, and the sha256 diverged from install-time — which classified the file as `modified` on first status check and then ran the three-way merge on corrupted UTF-8 projections, destroying the binary. `source/core/drift.ts` now reads as `Buffer` and hashes bytes; text files are byte-identical across both paths. Regression-guarded in `tests/unit/drift-classification.test.ts`.
+- **`shardmind update` no longer silently overwrites untracked user files** at paths the new shard newly introduces. The planner now detects on-disk collisions for `add` actions and routes them through `DiffView` with a `preexisting: true` flag; the executor's `keep_mine` / `skip` resolutions leave the user's file on disk AND untracked, so we never silently adopt content the user didn't opt in to manage. `source/core/update-planner.ts`, `source/core/update-executor.ts`.
+- **`hashValues` now terminates on cyclic value graphs** (YAML anchor cycles like `a: &x { self: *x }`). Previously the recursive `stableJson` walk would stack-overflow on hostile input. `source/core/install-planner.ts` adds a `WeakSet` cycle guard; matches the pattern `source/core/renderer.ts :: encodeStringLeaves` already uses for the Nunjucks recovery path.
+- **Frontmatter `path_match` glob honors shell semantics.** `brain/*.md` no longer matches `brain/sub/deep/note.md` — single `*` stops at `/` as every shell does. Opt in to recursive matching with `**`. `source/runtime/frontmatter.ts`.
+- **`sanitizeSlug` rewrites Windows-reserved device names** (`CON`, `PRN`, `AUX`, `NUL`, `COM[1-9]`, `LPT[1-9]`) by prefixing with `_`, and strips trailing `.` / space so NTFS can't silently rename the file out from under us. Previously a shard with `slug: "CON"` crashed install on Windows. `source/core/renderer.ts`.
+- **Three-way merge preserves `theirs`'s line ending on output** so `shardmind update` stops silently flipping CRLF↔LF on Windows users' managed files. `source/core/differ.ts` detects the dominant line ending of the user's file and joins merged output with it. `tests/unit/differ-line-endings.test.ts` + `tests/unit/merge-adversarial.test.ts` updated to pin the new invariant.
+- **Drift's orphan-scan uses bounded concurrency** via `mapConcurrent` — a vault with 200+ tracked directories would previously fire one `readdir` per directory in parallel and reliably hit EMFILE on macOS's 256-handle default. `source/core/drift.ts` (`ORPHAN_SCAN_CONCURRENCY = 32`).
+- **Status treats build-metadata-only version differences as up-to-date** per semver 2.0.0 §10. `1.0.0+build.1` vs `1.0.0+build.2` no longer surfaces as an available update (the previous strict `===` string compare did). Falls back to string equality for non-semver tag schemes. `source/core/status.ts`.
+- **Update-executor surfaces partial rollback via a new `ShardMindError` instead of mutating `err.message`.** Mutation throws on frozen/sealed third-party errors (a rare but real case) and compounds when the same error is caught further up the stack and logged twice. The wrapper preserves the original code and attaches both `rollbackFailures` and `cause` for introspection. `source/core/update-executor.ts`.
+- **`CollisionReview` and `ExistingInstallGate` guard against `Select` double-fire** with the same `firedRef` pattern `DiffView` already uses. A double-fire on `overwrite` would have launched two `rm -rf + runInstall` passes concurrently; on `update` it would have transitioned the state machine twice.
+- **`NewValuesPrompt` renders the human-readable group label** (`Setup`) instead of the raw group id (`setup`), matching `InstallWizard`'s lookup.
+- **Exhaustive switches** in `source/commands/install.tsx`, `source/commands/update.tsx`, and `source/commands/hooks/shared.ts`: adding a new `Phase` or `HookResult` variant is now a compile error, not a silent render-nothing bug.
+- **`ExistingInstallGate` drops the stale "Milestone 4" parenthetical** — `shardmind update` has shipped; the copy now points users at the command.
+- **Code-hygiene**: removed unused `_resolutions` parameter on `isDeleteAction` in `source/core/update-executor.ts`; rewrote the dangling `actionWrites` comment that referenced a long-deleted helper; annotated `MIGRATION_TRANSFORM_FAILED` in `source/runtime/errors.ts` as reserved for the v0.2 sandboxed-transform path (declared, unthrown — previous code comment was missing, so the reserved status wasn't machine-checkable).
+- **`NO_RELEASES_PUBLISHED`** — new typed error code in `source/runtime/errors.ts` fired by `registry.ts` when GitHub's `/releases/latest` returns 404 (the repo has no releases at all). Distinct from `VERSION_NOT_FOUND` (which fires when `verifyTag` 404s — a specific tag's tarball is missing). The update path rewrites the hint to point at the actual remediation instead of the install-path "retry / transient" phrasing that doesn't fit. Previously both cases collapsed into a single code with a misleading hint.
+- **Test suite: 551 → 567 (+16)**: binary-file drift + byte-identical round-trip, cycle-guarded hash, glob segment semantics (including regex-metacharacter literals inside `**`-tokenized globs), Windows-reserved slug rewrites + empty-slug fallback, add-path collision detection (plus plain-add control), binary-safe `theirsHash` for preexisting conflicts, semver build-metadata equality, CRLF preservation on output, and the NewValuesPrompt group-label regression.
+
+### Fixed (round-2 harden re-audit)
+
+Round-1 findings from a parallel 3-agent audit (adversarial + correctness + docs) landed above; a round-2 re-audit of the resulting diff surfaced three more live issues:
+
+- **`sanitizeSlug` fallback for empty collapsed slugs** — a slug of only spaces or empty rewrites to `""` after path-traversal + control-char scrubs, producing an output path like `notes/.md` (a dotfile on POSIX, hidden on Windows). `source/core/renderer.ts` now falls back to `_` so every valid shard produces at least one legible path component.
+- **`globToRegex` no longer uses a NUL sentinel token** — the `\0DS\0` placeholder that mediated `**` vs `*` expansion would have collided with a forged shard-schema containing literal NUL bytes. Rewritten to split on `**` and escape each segment separately, then join with `.*`. `source/runtime/frontmatter.ts`.
+- **`theirsHash` is now a bytewise hash for both modified-file and preexisting-add conflict paths** — `update-planner.ts` previously computed `sha256(actualContent-as-utf8-string)`, which for a non-UTF-8 user file (a copy-origin binary the user has drifted, or an image at an add-collision path) produces a hash that diverges from install-executor's byte-level `sha256(buffer)`. On `keep_mine` / `skip` resolutions the wrong hash would have been recorded in `state.files[path].rendered_hash`, making every subsequent drift report the file as modified on every update. A shared `readStringAndByteHash` helper now returns both the string view (for the line-oriented merge) and the byte hash (for state) from a single read.
+
+Round-2 also verified as clean: drift's Buffer read preserves hash parity with install-executor; CRLF preservation round-trips across repeat merges; exhaustive switches in install/update cover every `Phase` variant; `summarizeHook` covers every `HookResult` variant; the `conflict.preexisting` flag narrows correctly; module boundaries unchanged; the err-wrapper in `update-executor.ts` preserves original `code`/`hint` and attaches `cause` + `rollbackFailures` without mutating the original.
+
+### Fixed (round-3 harden re-audit)
+
+A third round of parallel audits surfaced three more issues the prior rounds missed. Fixed:
+
+- **`sanitizeSlug` reserved-name check now runs on the STEM**, not the whole filename. NTFS blocks `CON.txt`, `LPT1.md`, `AUX.foo.bar` exactly as hard as bare `CON`; the previous regex matched only the bare form, so a shard author writing `slug: "{{ item.name }}"` where `name: "CON.md"` would still crash install on Windows. `source/core/renderer.ts` now extracts the portion before the first dot and checks that. +2 tests in `tests/unit/renderer.test.ts`.
+- **`readStringAndByteHash` returns `null` on ENOENT; callers decide semantics.** The modified-file caller throws `UPDATE_CACHE_MISSING` (drift said file existed, now gone = race); the add-collision caller falls back to a plain `add` (file raced out of existence between `pathExists` and read, so no collision to report). The previous defensive "treat ENOENT as empty" posture contract-lied to the modified-file path — it would have merged the user's empty string against the new shard content and written the result to disk, silently destroying a file that was concurrently removed by another process. `source/core/update-planner.ts`.
+- **`ExistingInstallGate` TextInput `onSubmit` now arms the same `firedRef` guard** the `Select` onChange uses. Without it, a double-fire of Enter on the "REINSTALL" confirmation would have queued two destructive wipes. `source/components/ExistingInstallGate.tsx`.
+
+Round-3 code-quality cleanups:
+
+- **`MergeResult.hasConflicts` removed** — populated in two places, read nowhere (every consumer uses `conflicts.length > 0`). The `MergeResult` type in `source/runtime/types.ts`, the `conflict`-case emitter in `source/core/differ.ts`, the direct-conflict helper in `source/core/update-planner.ts`, `docs/IMPLEMENTATION.md §4.9`, and the DiffView test fixture all updated in lockstep.
+- **`CLAUDE.md` `any`-whitelist extended to `source/runtime/values.ts`** — the runtime module re-implements `buildValuesValidator` (runtime can't import from `core/` per the boundary rule), which means the same `z.ZodObject<any>` pattern appears there. Convention text was stale; code was right.
+- **`docs/ERRORS.md` `UPDATE_CACHE_MISSING` entry** now enumerates all three throw sites (cached-schema missing, drift/state disagreement, file vanished mid-update).
+- **`docs/IMPLEMENTATION.md §7` error-code table** updates the `UPDATE_CACHE_MISSING` row with both hint patterns.
+- **`source/core/update-planner.ts` `SchemaAdditions.dropped`** annotated as v0.2 reporting hook — pinned by tests, kept intentionally instead of silently populated-but-unused.
+
+### Added (round-3)
+
+- **Tests (567 → 571, +4):**
+  - `tests/unit/runtime.test.ts` — `assertNever` throws "Unhandled variant" at runtime (not just a compile-time check) so a JSON-decoded enum from a future schema version surfaces an actionable error instead of falling through.
+  - `tests/integration/update.test.ts::preexisting add-collision + keep_mine preserves user bytes and leaves them UNTRACKED` — end-to-end through `runUpdate` asserts the user's file bytes stay on disk AND `nextState.files` does NOT contain the path.
+  - `tests/integration/update.test.ts::preexisting add-collision + accept_new writes shard bytes and adopts as managed` — same flow with the opposite resolution: shard bytes land, state tracks `ownership: 'managed'`.
+  - `tests/integration/update.test.ts::throws a wrapped ShardMindError when write fails AND rollback is partial` — forces the outer catch via `vi.spyOn(fsp, 'writeFile')` + the rollback restore failure via `vi.spyOn(fsp, 'copyFile')`, asserts `err.code === 'UPDATE_WRITE_FAILED'`, `err.message` matches `/Rollback incomplete/`, `err.rollbackFailures` non-empty, `err.cause instanceof Error`.
+
+### Final count
+
+Test suite: **551 → 571** (+20 regression tests). `tsc --noEmit` clean; full suite green; build clean; zero `any` / `@ts-ignore` / `@ts-nocheck` / `as any` / `as unknown as` in `source/` outside the two documented zod-dynamic-generation exceptions.
+
 ### Added
 
 - **End-to-end test suite** — `tests/e2e/cli.test.ts` closes Milestone 4's last bullet (ROADMAP v0.1 §Milestone 4). 30 scenarios spawn `dist/cli.js` as a real subprocess and exercise the CLI the way a user would — no core-module shortcuts, no vitest mocks. Hermetic: a local HTTP server (`tests/e2e/helpers/github-stub.ts`) emulates the three GitHub endpoints the CLI consumes (`releases/latest`, `HEAD tarball`, `GET tarball`) and is pointed at by `SHARDMIND_GITHUB_API_BASE`. No public network hits; no rate-limit flake; no real repository needed. See `docs/ARCHITECTURE.md §19.7` for the full methodology.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,9 +61,17 @@ Round-3 code-quality cleanups:
   - `tests/integration/update.test.ts::preexisting add-collision + accept_new writes shard bytes and adopts as managed` — same flow with the opposite resolution: shard bytes land, state tracks `ownership: 'managed'`.
   - `tests/integration/update.test.ts::throws a wrapped ShardMindError when write fails AND rollback is partial` — forces the outer catch via `vi.spyOn(fsp, 'writeFile')` + the rollback restore failure via `vi.spyOn(fsp, 'copyFile')`, asserts `err.code === 'UPDATE_WRITE_FAILED'`, `err.message` matches `/Rollback incomplete/`, `err.rollbackFailures` non-empty, `err.cause instanceof Error`.
 
+### Fixed (Copilot review — 3 real regressions caught after rounds 1-7)
+
+Copilot's PR review surfaced three issues the 7-round loop missed. First two are poster children for "self-verification failures are normal" — I had a cycle-guard test but no sibling-sharing test, and a file-collision test but no directory-collision test.
+
+- **`stableJson` cycle guard collapsed YAML aliases to `null`.** The round-1 fix used a persistent `WeakSet` of "ever-visited" objects. Genuine cycles (`a: &x {self: *x}`) worked — but YAML alias sibling-sharing (`a: &x {k:1}\nb: *x`, both keys pointing at the SAME ref, no cycle) hit the seen-set on the second visit and emitted `null`, producing a different hash than the semantically-equivalent anchor-free YAML. That would have made `state.json.values_hash` drift every time a shard author added or removed an anchor. `source/core/install-planner.ts::stableJson` now tracks only currently-descending ancestors via `try/finally + seen.delete`. +2 regression tests.
+- **`update-planner` crashed on a directory at a new-add path.** The add-collision branch did `pathExists(abs)` → `readStringAndByteHash(abs)`. `pathExists` is true for directories too; the subsequent `fsp.readFile` threw EISDIR, which `readStringAndByteHash` didn't catch. Silently emitting a plain `add` wouldn't help — the executor's write would crash with the same EISDIR. Now stat-checks in a single I/O; directory collision throws typed `UPDATE_WRITE_FAILED` at plan time (before any snapshot runs) with a hint pointing at the specific path. +1 regression test.
+- **`docs/IMPLEMENTATION.md §4.9` step 6a** still said "merged output is always LF" — stale after round-1's CRLF-preservation fix. Round 4's `hasConflicts` sweep missed the adjacent sentence. Now explicitly documents the theirs-dominant line-ending invariant.
+
 ### Final count
 
-Test suite: **551 → 571** (+20 regression tests). `tsc --noEmit` clean; full suite green; build clean; zero `any` / `@ts-ignore` / `@ts-nocheck` / `as any` / `as unknown as` in `source/` outside the two documented zod-dynamic-generation exceptions.
+Test suite: **551 → 574** (+23 regression tests). `tsc --noEmit` clean; full suite green; build clean; zero `any` / `@ts-ignore` / `@ts-nocheck` / `as any` / `as unknown as` in `source/` outside the two documented zod-dynamic-generation exceptions.
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,12 +70,17 @@ shardmind/
 │   │   ├── VerboseView.tsx            # Detailed diagnostics (shardmind --verbose)
 │   │   ├── InstallWizard.tsx          # Values prompts + module review
 │   │   ├── ModuleReview.tsx           # Multiselect for modules
+│   │   ├── CollisionReview.tsx        # Install: backup / overwrite / cancel
+│   │   ├── ExistingInstallGate.tsx    # Install: existing-install disambiguation
 │   │   ├── DiffView.tsx               # Three-way diff + conflict resolution
 │   │   ├── NewValuesPrompt.tsx        # Update: prompt for newly required values
 │   │   ├── NewModulesReview.tsx       # Update: offer newly optional modules
 │   │   ├── RemovedFilesReview.tsx     # Update: per-file keep/delete decision
+│   │   ├── Summary.tsx                # Final install report
 │   │   ├── UpdateSummary.tsx          # Final update report
-│   │   └── Header.tsx                 # Branded header
+│   │   ├── ValueInput.tsx             # Typed input widget (string/number/select…)
+│   │   ├── Header.tsx                 # Branded header
+│   │   └── ui.ts                      # Barrel re-export of @inkjs/ui primitives
 │   ├── core/
 │   │   ├── manifest.ts                # Parse + validate shard.yaml
 │   │   ├── schema.ts                  # Parse shard-schema.yaml → zod validator
@@ -83,6 +88,7 @@ shardmind/
 │   │   ├── download.ts                # Fetch + extract GitHub tarball
 │   │   ├── renderer.ts                # Nunjucks + frontmatter-aware rendering
 │   │   ├── state.ts                   # Read/write .shardmind/state.json
+│   │   ├── state-migrator.ts          # Forward-migrate state.json (v0.2 hook, v0.1 scaffolding)
 │   │   ├── drift.ts                   # Ownership detection + drift analysis
 │   │   ├── differ.ts                  # Three-way merge (node-diff3)
 │   │   ├── migrator.ts                # Apply schema migrations to values
@@ -94,15 +100,19 @@ shardmind/
 │   │   ├── values-io.ts               # Shared YAML load for shard-values.yaml
 │   │   ├── update-check.ts            # 24h cached latest-version lookup (status + update)
 │   │   ├── status.ts                  # Pure StatusReport builder for the status command
+│   │   ├── cancellation.ts            # Cross-platform SIGINT bridge (Windows stdin-ETX)
 │   │   ├── hook.ts                    # Post-install / post-update hook lookup
 │   │   └── fs-utils.ts                # sha256, pathExists, toPosix, mapConcurrent
 │   ├── runtime/                       # Exported for hook scripts
 │   │   ├── index.ts                   # Re-exports
-│   │   ├── values.ts                  # loadValues()
+│   │   ├── values.ts                  # loadValues(), validateValues()
 │   │   ├── schema.ts                  # loadSchema()
 │   │   ├── frontmatter.ts             # validateFrontmatter()
 │   │   ├── state.ts                   # loadState(), getIncludedModules()
-│   │   └── types.ts                   # All shared types
+│   │   ├── vault-paths.ts             # SHARDMIND_DIR, VALUES_FILE, STATE_FILE, …
+│   │   ├── errors.ts                  # Typed ErrorCode registry
+│   │   ├── errno.ts                   # errnoCode(err), isEnoent(err) helpers
+│   │   └── types.ts                   # All shared types + ShardMindError + assertNever
 │   └── types/
 │       └── index.ts                   # Re-exports from runtime
 ├── tests/
@@ -148,7 +158,7 @@ npm run typecheck     # tsc --noEmit
 
 - **Language**: TypeScript, ESM, strict mode.
 - **Formatting**: follow the existing style in the codebase. No formatter configured yet — consistency by convention.
-- **No `any`** except in `schema.ts` zod dynamic generation (documented in spec). Prefer `unknown` + type narrowing.
+- **No `any`** except in `source/core/schema.ts` and `source/runtime/values.ts` zod dynamic generation (documented in spec; the runtime copy is a necessary duplicate because `runtime/` can't import from `core/`). Prefer `unknown` + type narrowing everywhere else.
 - **No `@ts-ignore` or `@ts-nocheck`**. Fix root causes. If a suppression is truly needed, comment why.
 - **Prefer `zod`** for validation at external boundaries: shard.yaml parsing, values validation, CLI arg parsing (Pastel handles this).
 - **Error handling**: throw `ShardMindError(message, code, hint)`. Commands catch and render via Ink `StatusMessage`. User errors get a message + hint. Engine errors get a full stack trace + "This is a bug, please report." See spec §7.
@@ -204,11 +214,17 @@ Each file in `source/core/` maps 1:1 to a section in `docs/IMPLEMENTATION.md`:
 | `drift.ts` | §4.8 | Ownership detection + drift analysis |
 | `differ.ts` | §4.9 | Three-way merge via node-diff3 |
 | `migrator.ts` | §4.10 | Apply schema migrations to values |
+| `install-planner.ts` | §4.11a (to land) | Pure install plan (outputs, collisions, value-coercion, computed defaults) |
+| `install-executor.ts` | §4.11b (to land) | Apply install plan with transactional backup + rollback |
 | `update-planner.ts` | §4.11 | Plan update actions from drift + new-shard render |
 | `update-executor.ts` | §4.12 | Apply update plan with snapshot-based rollback |
 | `values-io.ts` | §4.13 | Shared YAML load for shard-values.yaml (install + update) |
 | `status.ts` | §4.14 | Pure StatusReport builder for the `shardmind` (status) command |
 | `update-check.ts` | §4.15 | 24h cached GitHub latest-version lookup shared by status + update |
+| `cancellation.ts` | ARCHITECTURE §19.7 | Cross-platform SIGINT bridge (Windows stdin-ETX → process.emit SIGINT) |
+| `state-migrator.ts` | §4.7 (v0.2 hook) | Forward-migration framework for `.shardmind/state.json`; scaffolding in v0.1 |
+| `hook.ts` | (runtime glue) | Resolve + invoke post-install / post-update hook scripts (non-fatal) |
+| `fs-utils.ts` | (shared utilities) | sha256, pathExists, toPosix, mapConcurrent, stripTemplatePrefix |
 
 Read the spec section before implementing. It has inputs, outputs, algorithm steps, error cases, and test expectations.
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ The `shardmind/runtime` module is available to any TypeScript hook script. Claud
 
 ## Status
 
-**Pre-release.** Architecture designed. Implementation spec complete. Build in progress.
+**Pre-release.** The engine is complete — install, update (three-way merge + migrations + conflict resolution), status, and the runtime module all ship and are covered end-to-end. Flagship-shard conversion (obsidian-mind) and the shard registry are the remaining v0.1 milestones.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -114,6 +114,11 @@ Deferred items surfaced during the v0.1 polish-pass architecture audit. None are
 - [ ] Drop `LineInterner` workaround once `node-diff3` releases the prototype-lookup fix ([#49](https://github.com/breferrari/shardmind/issues/49), upstream [bhousel/node-diff3#87](https://github.com/bhousel/node-diff3/pull/87))
 - [ ] `$EDITOR` integration for DiffView conflict resolution ([#50](https://github.com/breferrari/shardmind/issues/50))
 - [x] 24h update-check cache shared between status + update ([#51](https://github.com/breferrari/shardmind/issues/51) — shipped with #13)
+- [ ] DiffView: distinguish preexisting add-collision from modified-file conflict ([#60](https://github.com/breferrari/shardmind/issues/60))
+- [ ] `--yes` policy for preexisting add-collisions (currently churns every update) ([#61](https://github.com/breferrari/shardmind/issues/61))
+- [ ] Byte-identical preexisting add-collision adopts silently ([#62](https://github.com/breferrari/shardmind/issues/62))
+- [ ] Binary files bypass three-way merge entirely ([#63](https://github.com/breferrari/shardmind/issues/63))
+- [ ] `docs/IMPLEMENTATION.md` §4.11a / §4.11b for install-planner + install-executor ([#64](https://github.com/breferrari/shardmind/issues/64))
 
 ---
 

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -205,6 +205,8 @@ Declarative "when to route where". Surfaced to agents via `shardmind/runtime`. `
 
 Shorthand `key: [a, b]` expands to `key: { required: [a, b] }`. Optional `path_match` applies the rule only to matching paths. `global` is the catch-all.
 
+`path_match` uses shell-glob semantics: `*` matches within a single path segment (stops at `/`), `**` crosses segments. So `brain/*.md` matches `brain/Goals.md` but not `brain/sub/deep/Goals.md`; use `brain/**.md` if you want every `.md` under `brain/` regardless of depth. Regex metacharacters inside the glob (`.`, `[`, `(`, etc.) are treated as literals.
+
 ### `migrations` — value migrations
 
 Ordered rules applied to `shard-values.yaml` when the shard version moves forward. Four change types: `rename`, `added`, `removed`, `type_changed`. See `MigrationChange` in `source/runtime/types.ts` for the exact shape.

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -311,6 +311,70 @@ Thrown by `source/core/renderer.ts` and wrapped in `source/core/install-executor
 
 ---
 
+## Update / merge
+
+### `MERGE_FAILED`
+
+**Meaning:** The three-way merge engine (`source/core/differ.ts`) threw while applying `node-diff3` to a modified file. Rare — usually a symptom of a file the merge engine can't handle.
+
+**Remedy:** Re-run with `--verbose` for the full trace and file an issue at github.com/breferrari/shardmind/issues. Workaround: delete or rename the file to break it out of the update plan, then re-run `shardmind update`.
+
+### `UPDATE_NO_INSTALL`
+
+**Meaning:** `shardmind update` was invoked in a directory that has no `.shardmind/state.json`.
+
+**Remedy:** Run `shardmind install <shard>` first, then retry.
+
+### `UPDATE_SOURCE_MISMATCH`
+
+**Meaning:** `state.source` in `.shardmind/state.json` doesn't parse as a valid shard reference (`namespace/name` or `github:namespace/name`). Usually a hand-edit or partial corruption of `state.json`.
+
+**Remedy:** Reinstall the shard to regenerate a coherent `state.json`.
+
+### `UPDATE_CACHE_MISSING`
+
+**Meaning:** One of three drift-between-inputs failures during `shardmind update`:
+
+1. The cached schema (`.shardmind/shard-schema.yaml`) is missing or corrupt, so the migration plan can't be computed.
+2. Drift reports a file as `modified` but `state.files` doesn't record it — state and drift disagree.
+3. A file that was present at drift-detection time vanished before the merge planner reached it (user or another process deleted it mid-update).
+
+**Remedy:** (1) Re-run `shardmind install <source>` to regenerate `.shardmind/`. (2) / (3) Re-run `shardmind update` — drift detection picks up the current shape on the next pass.
+
+### `UPDATE_WRITE_FAILED`
+
+**Meaning:** A write during the update executor failed (mkdir + writeFile on a planned output path). Typically filesystem-level (permissions, disk-full, antivirus lock). May also surface as the code on a wrapped rollback-incomplete error when the update failed AND the snapshot couldn't restore every file.
+
+**Remedy:** Check filesystem permissions on the vault directory and the mentioned path; retry. If partial-rollback also failed, the error message lists paths the snapshot couldn't restore — those files still exist under `.shardmind/backups/update-*/files/`.
+
+### `MIGRATION_INVALID_VERSION`
+
+**Meaning:** `applyMigrations` was handed a `currentVersion` or `targetVersion` that doesn't parse as semver.
+
+**Remedy:** Engine bug — open an issue. Both versions come from parsed `state.json` or fresh `shard.yaml` and should always be valid semver.
+
+### `MIGRATION_TRANSFORM_FAILED`
+
+**Meaning:** Reserved for the v0.2 sandboxed-transform path. Currently `migrator.ts` catches `type_changed` transform exceptions and records a warning (best-effort posture), so this code is declared but not thrown in v0.1.
+
+**Remedy:** N/A in v0.1. When the sandboxed evaluator lands (v0.2), this code will surface if a transform crashes and the command layer will distinguish it from "transform returned the wrong shape."
+
+## Update-check cache (status + update)
+
+### `UPDATE_CHECK_FAILED`
+
+**Meaning:** Internal — the 4-second fetch budget for the background "what's the latest version?" lookup expired. Surfaced only from paths that treat update-check as fatal; the status command maps it to an `unknown` update result.
+
+**Remedy:** Usually transient network pressure. The cache (when present) still answers subsequent runs; re-try later.
+
+### `UPDATE_CHECK_CACHE_CORRUPT`
+
+**Meaning:** The cached `.shardmind/update-check.json` couldn't be parsed or was the wrong shape. The cache is self-healed on sight (deleted + re-fetched) and the verbose status surfaces this once as an info warning.
+
+**Remedy:** Automatic. No user action needed.
+
+---
+
 ## Maintenance
 
 If you're a shard author and hit a code that feels authoring-side, the specifically author-facing ones are:

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -231,7 +231,7 @@ Thrown by `source/core/state.ts` and `source/runtime/state.ts`.
 
 **Meaning:** Install tried to write `shard-values.yaml` but the file already exists. The `ExistingInstallGate` normally catches this earlier; this is a last-defense check.
 
-**Remedy:** Move or remove the existing `shard-values.yaml`. `shardmind update` (Milestone 4) will handle this automatically once available.
+**Remedy:** Move or remove the existing `shard-values.yaml` before re-running `install`. If `.shardmind/state.json` is also present, `shardmind update` is the right command (it'll upgrade the current install in place); without state.json, `update` throws `UPDATE_NO_INSTALL` so `install` is the only path.
 
 ### `VALUES_MISSING`
 

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -564,7 +564,7 @@ interface MergeStats {
 6. If ownership is `modified`:
    a. Run `diff3MergeRegions(theirs.split(/\r?\n/), base.split(/\r?\n/), ours.split(/\r?\n/))` — not the flat `diff3Merge`; the regions variant exposes `buffer: 'a' | 'o' | 'b'` on stable regions and `aContent / oContent / bContent` on unstable ones, which is the only way to distinguish stable-unchanged (`buffer === 'o'`) from stable-auto-merged (`buffer === 'a' | 'b'`) lines. The `/\r?\n/` split tolerates CRLF on Windows-saved files; merged output is always LF.
    b. For each stable region: emit `bufferContent`. For each unstable region: if `aContent === oContent` take `bContent`; if `bContent === oContent` take `aContent`; if `aContent === bContent` take either (false conflict); else emit git-style conflict markers and record a `ConflictRegion`.
-   c. No conflicts → `{ type: 'auto_merge', content, stats }`. Conflicts → `{ type: 'conflict', result: { content, hasConflicts: true, conflicts, stats } }`.
+   c. No conflicts → `{ type: 'auto_merge', content, stats }`. Conflicts → `{ type: 'conflict', result: { content, conflicts, stats } }`.
 
 **`MergeResult`** (for conflicts):
 ```typescript
@@ -576,8 +576,7 @@ interface MergeStatsWithConflicts {
 
 interface MergeResult {
   content: string;              // Merged content with conflict markers
-  hasConflicts: boolean;
-  conflicts: ConflictRegion[];
+  conflicts: ConflictRegion[]; // non-empty ⇒ conflicts exist; consumers read `conflicts.length > 0`
   stats: MergeStatsWithConflicts;
 }
 
@@ -1004,7 +1003,7 @@ Update + migration codes (added in Milestone 4):
 |------|-----------|--------------|
 | `UPDATE_NO_INSTALL` | use-update-machine (thrown when `readState` returns `null`) | "Run `shardmind install <shard>` first, then come back to update." |
 | `UPDATE_SOURCE_MISMATCH` | use-update-machine (thrown when `resolveRef(state.source)` surfaces `REGISTRY_INVALID_REF` — state is corrupted or hand-edited) | "The value `<state.source>` in .shardmind/state.json doesn't match the expected `namespace/name` or `github:namespace/name` shape. Likely hand-edited or partially corrupted — reinstall the shard to repair." |
-| `UPDATE_CACHE_MISSING` | update-planner | "State and drift report disagree — re-install the shard." |
+| `UPDATE_CACHE_MISSING` | update-planner (drift references a path absent from `state.files`, OR a `drift.modified` file vanishes between drift scan and merge planning), use-update-machine (cached schema missing) | "State and drift report disagree — re-install the shard." / "Vault contents changed during `shardmind update`. Re-run." |
 | `UPDATE_WRITE_FAILED` | update-executor | OS error message + permission / space hint |
 | `MIGRATION_INVALID_VERSION` | migrator | "currentVersion and targetVersion must be valid semver." |
 | `MIGRATION_TRANSFORM_FAILED` | reserved for sandbox-enforcement path | — |

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -562,7 +562,7 @@ interface MergeStats {
 4. If `sha256(base) === sha256(ours)` → no upstream change → `{ type: 'skip' }`
 5. If ownership is `managed` (base === theirs) → `{ type: 'overwrite', content: ours }`
 6. If ownership is `modified`:
-   a. Run `diff3MergeRegions(theirs.split(/\r?\n/), base.split(/\r?\n/), ours.split(/\r?\n/))` — not the flat `diff3Merge`; the regions variant exposes `buffer: 'a' | 'o' | 'b'` on stable regions and `aContent / oContent / bContent` on unstable ones, which is the only way to distinguish stable-unchanged (`buffer === 'o'`) from stable-auto-merged (`buffer === 'a' | 'b'`) lines. The `/\r?\n/` split tolerates CRLF on Windows-saved files; merged output is always LF.
+   a. Run `diff3MergeRegions(theirs.split(/\r?\n/), base.split(/\r?\n/), ours.split(/\r?\n/))` — not the flat `diff3Merge`; the regions variant exposes `buffer: 'a' | 'o' | 'b'` on stable regions and `aContent / oContent / bContent` on unstable ones, which is the only way to distinguish stable-unchanged (`buffer === 'o'`) from stable-auto-merged (`buffer === 'a' | 'b'`) lines. The `/\r?\n/` split tolerates CRLF on Windows-saved files; merged output preserves `theirs`'s dominant line ending (`\r\n` if any CRLF in `theirs`, else `\n`) so `shardmind update` doesn't silently flip line endings on Windows users' managed files.
    b. For each stable region: emit `bufferContent`. For each unstable region: if `aContent === oContent` take `bContent`; if `bContent === oContent` take `aContent`; if `aContent === bContent` take either (false conflict); else emit git-style conflict markers and record a `ConflictRegion`.
    c. No conflicts → `{ type: 'auto_merge', content, stats }`. Conflicts → `{ type: 'conflict', result: { content, conflicts, stats } }`.
 

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -514,8 +514,8 @@ interface DriftEntry {
 **Algorithm**:
 1. For each file in `state.files` (in parallel via `Promise.all`):
    a. If `FileState.ownership === 'user'` (volatile at install time) → `DriftEntry` with `ownership: 'volatile'` → add to `volatile`. Never hashed; content may diverge by design.
-   b. Read file from disk. If ENOENT → add to `missing` (propagate state ownership).
-   c. Compute `sha256(file content)`.
+   b. Read file from disk as `Buffer` (not UTF-8). If ENOENT → add to `missing` (propagate state ownership).
+   c. Compute `sha256(buffer)` over raw bytes. This is load-bearing: `install-executor` hashes copy-origin files (images, PDFs, binary assets) as bytes too, so a bytewise hash here stays consistent across install/update cycles. A UTF-8 decode-then-hash would replace invalid sequences with `U+FFFD` and mis-classify every binary asset as `modified` on first status check.
    d. Compare against `state.files[path].rendered_hash`. Equal → `managed`. Different → `modified`.
 2. Orphan scan (runs in parallel with the classification): union of parent directories of every tracked path is the set of tracked directories. For each tracked directory, `readdir` non-recursively and report files not in `state.files` as orphans. Excludes engine-reserved files (`VALUES_FILE`) and never-scanned directories (`.shardmind`, `.git`, `.obsidian`). Subdirectories of a tracked directory are not auto-scanned — they only count if they themselves contain a tracked file.
 3. Return classified report.

--- a/source/commands/hooks/shared.ts
+++ b/source/commands/hooks/shared.ts
@@ -14,6 +14,7 @@
 
 import { useEffect, useRef } from 'react';
 import type { HookResult } from '../../core/hook.js';
+import { assertNever } from '../../runtime/types.js';
 
 export interface HookSummary {
   deferred?: boolean;
@@ -31,6 +32,8 @@ export function summarizeHook(result: HookResult): HookSummary | null {
       return { stdout: result.stdout, exitCode: result.exitCode };
     case 'failed':
       return { stdout: result.message, exitCode: 1 };
+    default:
+      return assertNever(result);
   }
 }
 

--- a/source/commands/install.tsx
+++ b/source/commands/install.tsx
@@ -2,7 +2,7 @@ import { Box, Text } from 'ink';
 import { Spinner, StatusMessage, Alert } from '../components/ui.js';
 import zod from 'zod';
 
-import { ShardMindError } from '../runtime/types.js';
+import { ShardMindError, assertNever } from '../runtime/types.js';
 
 import InstallWizard from '../components/InstallWizard.js';
 import CollisionReview from '../components/CollisionReview.js';
@@ -49,105 +49,101 @@ export default function Install({ args, options }: Props) {
     vaultRoot: process.cwd(),
   });
 
-  if (phase.kind === 'booting' || phase.kind === 'loading') {
-    const msg = phase.kind === 'loading' ? phase.message : 'Starting…';
-    return (
-      <CommandFrame dryRun={dryRun} showLegend={false}>
-        <Box gap={1}>
-          <Spinner />
-          <Text>{msg}</Text>
-        </Box>
-      </CommandFrame>
-    );
+  // Exhaustive switch: adding a new Phase variant without a case here
+  // is a compile error, not a silent render-nothing bug.
+  switch (phase.kind) {
+    case 'booting':
+    case 'loading': {
+      const msg = phase.kind === 'loading' ? phase.message : 'Starting…';
+      return (
+        <CommandFrame dryRun={dryRun} showLegend={false}>
+          <Box gap={1}>
+            <Spinner />
+            <Text>{msg}</Text>
+          </Box>
+        </CommandFrame>
+      );
+    }
+    case 'gate':
+      return (
+        <CommandFrame dryRun={dryRun}>
+          <ExistingInstallGate state={phase.state} onChoice={onGateChoice} />
+        </CommandFrame>
+      );
+    case 'wizard':
+      return (
+        <CommandFrame dryRun={dryRun}>
+          <InstallWizard
+            manifest={phase.ctx.manifest}
+            schema={phase.ctx.schema}
+            prefillValues={phase.ctx.prefillValues}
+            moduleFileCounts={phase.ctx.moduleFileCounts}
+            alwaysIncludedFileCount={phase.ctx.alwaysIncludedFileCount}
+            onComplete={onWizardComplete}
+            onCancel={onWizardCancel}
+            onError={onWizardError}
+          />
+        </CommandFrame>
+      );
+    case 'collision':
+      return (
+        <CommandFrame dryRun={dryRun}>
+          <CollisionReview collisions={phase.collisions} onChoice={onCollisionChoice} />
+        </CommandFrame>
+      );
+    case 'installing':
+      return (
+        <CommandFrame dryRun={dryRun} showLegend={false}>
+          <CommandProgress
+            current={phase.current}
+            total={phase.total}
+            label={phase.label}
+            verbose={verbose}
+            history={phase.history}
+          />
+        </CommandFrame>
+      );
+    case 'summary':
+      return (
+        <CommandFrame dryRun={dryRun} showLegend={false}>
+          <Summary
+            manifest={phase.manifest}
+            vaultRoot={phase.vaultRoot}
+            fileCount={phase.fileCount}
+            durationMs={phase.durationMs}
+            backups={phase.backups}
+            hookOutput={phase.hook}
+            dryRun={phase.dryRun}
+          />
+        </CommandFrame>
+      );
+    case 'cancelled':
+      return (
+        <CommandFrame dryRun={dryRun} showLegend={false}>
+          <Box flexDirection="column">
+            <Alert variant="info">Cancelled</Alert>
+            <Text dimColor>{phase.reason}</Text>
+          </Box>
+        </CommandFrame>
+      );
+    case 'error': {
+      const err = phase.error;
+      const code = err instanceof ShardMindError ? err.code : null;
+      const hint = err instanceof ShardMindError ? err.hint : null;
+      return (
+        <CommandFrame dryRun={dryRun} showLegend={false}>
+          <Box flexDirection="column" gap={1}>
+            <StatusMessage variant="error">{err.message}</StatusMessage>
+            {code && <Text dimColor>code: {code}</Text>}
+            {hint && <Text>{hint}</Text>}
+            {phase.detail && <Text dimColor>{phase.detail}</Text>}
+          </Box>
+        </CommandFrame>
+      );
+    }
+    default:
+      return assertNever(phase);
   }
-
-  if (phase.kind === 'gate') {
-    return (
-      <CommandFrame dryRun={dryRun}>
-        <ExistingInstallGate state={phase.state} onChoice={onGateChoice} />
-      </CommandFrame>
-    );
-  }
-
-  if (phase.kind === 'wizard') {
-    return (
-      <CommandFrame dryRun={dryRun}>
-        <InstallWizard
-          manifest={phase.ctx.manifest}
-          schema={phase.ctx.schema}
-          prefillValues={phase.ctx.prefillValues}
-          moduleFileCounts={phase.ctx.moduleFileCounts}
-          alwaysIncludedFileCount={phase.ctx.alwaysIncludedFileCount}
-          onComplete={onWizardComplete}
-          onCancel={onWizardCancel}
-          onError={onWizardError}
-        />
-      </CommandFrame>
-    );
-  }
-
-  if (phase.kind === 'collision') {
-    return (
-      <CommandFrame dryRun={dryRun}>
-        <CollisionReview collisions={phase.collisions} onChoice={onCollisionChoice} />
-      </CommandFrame>
-    );
-  }
-
-  if (phase.kind === 'installing') {
-    return (
-      <CommandFrame dryRun={dryRun} showLegend={false}>
-        <CommandProgress
-          current={phase.current}
-          total={phase.total}
-          label={phase.label}
-          verbose={verbose}
-          history={phase.history}
-        />
-      </CommandFrame>
-    );
-  }
-
-  if (phase.kind === 'summary') {
-    return (
-      <CommandFrame dryRun={dryRun} showLegend={false}>
-        <Summary
-          manifest={phase.manifest}
-          vaultRoot={phase.vaultRoot}
-          fileCount={phase.fileCount}
-          durationMs={phase.durationMs}
-          backups={phase.backups}
-          hookOutput={phase.hook}
-          dryRun={phase.dryRun}
-        />
-      </CommandFrame>
-    );
-  }
-
-  if (phase.kind === 'cancelled') {
-    return (
-      <CommandFrame dryRun={dryRun} showLegend={false}>
-        <Box flexDirection="column">
-          <Alert variant="info">Cancelled</Alert>
-          <Text dimColor>{phase.reason}</Text>
-        </Box>
-      </CommandFrame>
-    );
-  }
-
-  const err = phase.error;
-  const code = err instanceof ShardMindError ? err.code : null;
-  const hint = err instanceof ShardMindError ? err.hint : null;
-  return (
-    <CommandFrame dryRun={dryRun} showLegend={false}>
-      <Box flexDirection="column" gap={1}>
-        <StatusMessage variant="error">{err.message}</StatusMessage>
-        {code && <Text dimColor>code: {code}</Text>}
-        {hint && <Text>{hint}</Text>}
-        {phase.detail && <Text dimColor>{phase.detail}</Text>}
-      </Box>
-    </CommandFrame>
-  );
 }
 
 export const description = 'Install a shard into the current directory';

--- a/source/commands/update.tsx
+++ b/source/commands/update.tsx
@@ -2,7 +2,7 @@ import { Box, Text } from 'ink';
 import zod from 'zod';
 
 import { Spinner, StatusMessage, Alert } from '../components/ui.js';
-import { ShardMindError } from '../runtime/types.js';
+import { ShardMindError, assertNever } from '../runtime/types.js';
 
 import DiffView from '../components/DiffView.js';
 import NewValuesPrompt from '../components/NewValuesPrompt.js';
@@ -41,137 +41,128 @@ export default function Update({ options }: Props) {
     dryRun,
   });
 
-  if (phase.kind === 'booting' || phase.kind === 'loading') {
-    const msg = phase.kind === 'loading' ? phase.message : 'Starting…';
-    return (
-      <CommandFrame dryRun={dryRun}>
-        <Box gap={1}>
-          <Spinner />
-          <Text>{msg}</Text>
-        </Box>
-      </CommandFrame>
-    );
+  switch (phase.kind) {
+    case 'booting':
+    case 'loading': {
+      const msg = phase.kind === 'loading' ? phase.message : 'Starting…';
+      return (
+        <CommandFrame dryRun={dryRun}>
+          <Box gap={1}>
+            <Spinner />
+            <Text>{msg}</Text>
+          </Box>
+        </CommandFrame>
+      );
+    }
+    case 'up-to-date':
+      return (
+        <CommandFrame dryRun={dryRun}>
+          <Box flexDirection="column" gap={1}>
+            <Header manifest={phase.manifest} />
+            <StatusMessage variant="success">
+              Already up to date at v{phase.state.version}.
+            </StatusMessage>
+          </Box>
+        </CommandFrame>
+      );
+    case 'prompt-new-values':
+      return (
+        <CommandFrame dryRun={dryRun}>
+          <Header manifest={phase.ctx.newManifest} />
+          <NewValuesPrompt
+            schema={phase.ctx.newSchema}
+            keys={phase.ctx.newRequiredKeys}
+            existingValues={phase.ctx.migratedValues}
+            onComplete={onNewValuesComplete}
+          />
+        </CommandFrame>
+      );
+    case 'prompt-new-modules':
+      return (
+        <CommandFrame dryRun={dryRun}>
+          <Header manifest={phase.ctx.newManifest} />
+          <NewModulesReview
+            offered={phase.ctx.newOptionalModules}
+            onSubmit={onNewModulesComplete}
+          />
+        </CommandFrame>
+      );
+    case 'prompt-removed-files':
+      return (
+        <CommandFrame dryRun={dryRun}>
+          <Header manifest={phase.ctx.newManifest} />
+          <RemovedFilesReview
+            paths={phase.paths}
+            onSubmit={onRemovedFilesComplete}
+          />
+        </CommandFrame>
+      );
+    case 'resolving-conflicts': {
+      const pending = phase.plan.pendingConflicts[phase.currentIndex];
+      if (!pending) return null;
+      return (
+        <CommandFrame dryRun={dryRun}>
+          <DiffView
+            path={pending.path}
+            index={phase.currentIndex + 1}
+            total={phase.plan.pendingConflicts.length}
+            result={pending.result}
+            onChoice={onConflictChoice}
+          />
+        </CommandFrame>
+      );
+    }
+    case 'writing':
+      return (
+        <CommandFrame dryRun={dryRun} showLegend={false}>
+          <CommandProgress
+            current={phase.current}
+            total={phase.total}
+            label={phase.label}
+            verbose={verbose}
+            history={phase.history}
+          />
+        </CommandFrame>
+      );
+    case 'summary':
+      return (
+        <CommandFrame dryRun={dryRun} showLegend={false}>
+          <UpdateSummary
+            summary={phase.summary}
+            durationMs={phase.durationMs}
+            migrationWarnings={phase.migrationWarnings}
+            hookOutput={phase.hook}
+            dryRun={phase.dryRun}
+          />
+        </CommandFrame>
+      );
+    case 'cancelled':
+      return (
+        <CommandFrame dryRun={dryRun} showLegend={false}>
+          <Box flexDirection="column">
+            <Alert variant="info">Cancelled</Alert>
+            <Text dimColor>{phase.reason}</Text>
+          </Box>
+        </CommandFrame>
+      );
+    case 'error': {
+      const err = phase.error;
+      const code = err instanceof ShardMindError ? err.code : null;
+      const hint = err instanceof ShardMindError ? err.hint : null;
+      return (
+        <CommandFrame dryRun={dryRun} showLegend={false}>
+          <Box flexDirection="column" gap={1}>
+            <StatusMessage variant="error">{err.message}</StatusMessage>
+            {code && <Text dimColor>code: {code}</Text>}
+            {hint && <Text>{hint}</Text>}
+            {phase.detail && <Text dimColor>{phase.detail}</Text>}
+          </Box>
+        </CommandFrame>
+      );
+    }
+    default:
+      return assertNever(phase);
   }
-
-  if (phase.kind === 'up-to-date') {
-    return (
-      <CommandFrame dryRun={dryRun}>
-        <Box flexDirection="column" gap={1}>
-          <Header manifest={phase.manifest} />
-          <StatusMessage variant="success">
-            Already up to date at v{phase.state.version}.
-          </StatusMessage>
-        </Box>
-      </CommandFrame>
-    );
-  }
-
-  if (phase.kind === 'prompt-new-values') {
-    return (
-      <CommandFrame dryRun={dryRun}>
-        <Header manifest={phase.ctx.newManifest} />
-        <NewValuesPrompt
-          schema={phase.ctx.newSchema}
-          keys={phase.ctx.newRequiredKeys}
-          existingValues={phase.ctx.migratedValues}
-          onComplete={onNewValuesComplete}
-        />
-      </CommandFrame>
-    );
-  }
-
-  if (phase.kind === 'prompt-new-modules') {
-    return (
-      <CommandFrame dryRun={dryRun}>
-        <Header manifest={phase.ctx.newManifest} />
-        <NewModulesReview
-          offered={phase.ctx.newOptionalModules}
-          onSubmit={onNewModulesComplete}
-        />
-      </CommandFrame>
-    );
-  }
-
-  if (phase.kind === 'prompt-removed-files') {
-    return (
-      <CommandFrame dryRun={dryRun}>
-        <Header manifest={phase.ctx.newManifest} />
-        <RemovedFilesReview
-          paths={phase.paths}
-          onSubmit={onRemovedFilesComplete}
-        />
-      </CommandFrame>
-    );
-  }
-
-  if (phase.kind === 'resolving-conflicts') {
-    const pending = phase.plan.pendingConflicts[phase.currentIndex];
-    if (!pending) return null;
-    return (
-      <CommandFrame dryRun={dryRun}>
-        <DiffView
-          path={pending.path}
-          index={phase.currentIndex + 1}
-          total={phase.plan.pendingConflicts.length}
-          result={pending.result}
-          onChoice={onConflictChoice}
-        />
-      </CommandFrame>
-    );
-  }
-
-  if (phase.kind === 'writing') {
-    return (
-      <CommandFrame dryRun={dryRun} showLegend={false}>
-        <CommandProgress
-          current={phase.current}
-          total={phase.total}
-          label={phase.label}
-          verbose={verbose}
-          history={phase.history}
-        />
-      </CommandFrame>
-    );
-  }
-
-  if (phase.kind === 'summary') {
-    return (
-      <CommandFrame dryRun={dryRun} showLegend={false}>
-        <UpdateSummary
-          summary={phase.summary}
-          durationMs={phase.durationMs}
-          migrationWarnings={phase.migrationWarnings}
-          hookOutput={phase.hook}
-          dryRun={phase.dryRun}
-        />
-      </CommandFrame>
-    );
-  }
-
-  if (phase.kind === 'cancelled') {
-    return (
-      <CommandFrame dryRun={dryRun} showLegend={false}>
-        <Box flexDirection="column">
-          <Alert variant="info">Cancelled</Alert>
-          <Text dimColor>{phase.reason}</Text>
-        </Box>
-      </CommandFrame>
-    );
-  }
-
-  const err = phase.error;
-  const code = err instanceof ShardMindError ? err.code : null;
-  const hint = err instanceof ShardMindError ? err.hint : null;
-  return (
-    <CommandFrame dryRun={dryRun} showLegend={false}>
-      <Box flexDirection="column" gap={1}>
-        <StatusMessage variant="error">{err.message}</StatusMessage>
-        {code && <Text dimColor>code: {code}</Text>}
-        {hint && <Text>{hint}</Text>}
-        {phase.detail && <Text dimColor>{phase.detail}</Text>}
-      </Box>
-    </CommandFrame>
-  );
 }
 
 export const description = 'Update the installed shard to its latest version';

--- a/source/components/CollisionReview.tsx
+++ b/source/components/CollisionReview.tsx
@@ -1,8 +1,11 @@
+import { useRef } from 'react';
 import { Box, Text } from 'ink';
 import { Select, Alert } from './ui.js';
 import type { Collision } from '../core/install-planner.js';
 
 export type CollisionAction = 'backup' | 'overwrite' | 'cancel';
+
+const COLLISION_ACTIONS = new Set<CollisionAction>(['backup', 'overwrite', 'cancel']);
 
 interface CollisionReviewProps {
   collisions: Collision[];
@@ -12,6 +15,10 @@ interface CollisionReviewProps {
 export default function CollisionReview({ collisions, onChoice }: CollisionReviewProps) {
   const fileCount = collisions.filter((c) => c.kind === 'file').length;
   const dirCount = collisions.length - fileCount;
+  // `Select` can fire onChange more than once if Ink re-focuses the
+  // instance. A double-fire on `overwrite` would launch two `rm -rf`
+  // passes and two concurrent installs — same defense as DiffView.
+  const firedRef = useRef(false);
 
   return (
     <Box flexDirection="column" gap={1}>
@@ -54,7 +61,12 @@ export default function CollisionReview({ collisions, onChoice }: CollisionRevie
               value: 'cancel',
             },
           ]}
-          onChange={(v) => onChoice(v as CollisionAction)}
+          onChange={(v) => {
+            if (firedRef.current) return;
+            if (!COLLISION_ACTIONS.has(v as CollisionAction)) return;
+            firedRef.current = true;
+            onChoice(v as CollisionAction);
+          }}
         />
       </Box>
     </Box>

--- a/source/components/ExistingInstallGate.tsx
+++ b/source/components/ExistingInstallGate.tsx
@@ -5,6 +5,8 @@ import type { ShardState, ModuleSelections } from '../runtime/types.js';
 
 export type GateChoice = 'update' | 'reinstall' | 'cancel';
 
+const GATE_CHOICES = new Set<GateChoice>(['update', 'reinstall', 'cancel']);
+
 interface ExistingInstallGateProps {
   state: ShardState;
   onChoice: (choice: GateChoice) => void;
@@ -16,6 +18,10 @@ export default function ExistingInstallGate({ state, onChoice }: ExistingInstall
   const [screen, setScreen] = useState<Screen>('choose');
   const [error, setError] = useState<string | null>(null);
   const lastSubmittedValue = useRef<string | null>(null);
+  // Same `Select` double-fire guard as CollisionReview / DiffView:
+  // without it, a second onChange firing of `update` or `cancel` would
+  // call `onChoice` twice and the machine would transition twice.
+  const firedRef = useRef(false);
 
   if (screen === 'confirm-reinstall') {
     return (
@@ -44,6 +50,12 @@ export default function ExistingInstallGate({ state, onChoice }: ExistingInstall
             }}
             onSubmit={(v) => {
               if (v === 'REINSTALL') {
+                // Same firedRef guard as the Select path — TextInput
+                // can fire onSubmit more than once on Ink re-focus,
+                // and `reinstall` is destructive; a double-fire would
+                // queue two wipes.
+                if (firedRef.current) return;
+                firedRef.current = true;
                 onChoice('reinstall');
               } else {
                 lastSubmittedValue.current = v;
@@ -82,17 +94,22 @@ export default function ExistingInstallGate({ state, onChoice }: ExistingInstall
         <Text bold>What would you like to do?</Text>
         <Select
           options={[
-            { label: 'Keep the existing install (recommended — `shardmind update` arrives in Milestone 4)', value: 'update' },
+            { label: 'Keep the existing install (run `shardmind update` to pick up new versions)', value: 'update' },
             { label: 'Reinstall from scratch — destructive', value: 'reinstall' },
             { label: 'Cancel', value: 'cancel' },
           ]}
           onChange={(v) => {
+            if (!GATE_CHOICES.has(v as GateChoice)) return;
             const choice = v as GateChoice;
             if (choice === 'reinstall') {
+              // Reinstall requires a second confirmation; don't arm
+              // the firedRef until the user commits on the next screen.
               setScreen('confirm-reinstall');
-            } else {
-              onChoice(choice);
+              return;
             }
+            if (firedRef.current) return;
+            firedRef.current = true;
+            onChoice(choice);
           }}
         />
       </Box>

--- a/source/components/NewValuesPrompt.tsx
+++ b/source/components/NewValuesPrompt.tsx
@@ -38,12 +38,18 @@ export default function NewValuesPrompt({
   if (!entry) return null;
 
   const [key, def] = entry;
+  // Prefer the human-readable group label from the schema (e.g.
+  // "Onboarding") over the raw group id ("onboarding"). Keeps the UX
+  // consistent with InstallWizard, which does the same lookup.
+  const groupLabel = def.group
+    ? schema.groups.find(g => g.id === def.group)?.label ?? def.group
+    : null;
   return (
     <Box flexDirection="column" gap={1}>
       <Text bold>New values since your last install</Text>
       <Text dimColor>
         Step {index + 1} of {defs.length}
-        {def.group ? ` · ${def.group}` : ''}
+        {groupLabel ? ` · ${groupLabel}` : ''}
       </Text>
       <ValueInput
         id={key}

--- a/source/core/differ.ts
+++ b/source/core/differ.ts
@@ -30,6 +30,20 @@ const CONFLICT_END = '>>>>>>> shard update';
 // spurious conflicts against LF base/ours.
 const LINE_SPLIT = /\r?\n/;
 
+/**
+ * Dominant line ending of `theirs` (the user's on-disk file). When a
+ * Windows user saves a managed note with CRLF, we honor that on merge
+ * output rather than silently rewriting the file to LF — which would
+ * flip line endings on every `shardmind update` and churn git blame.
+ *
+ * Heuristic: if the file contains any `\r\n`, treat as CRLF. Mixed
+ * endings collapse to CRLF which is the practical norm on Windows
+ * editors that emit CRLF-by-default.
+ */
+function detectLineEnding(source: string): '\r\n' | '\n' {
+  return source.includes('\r\n') ? '\r\n' : '\n';
+}
+
 // node-diff3's LCS implementation uses a plain `{}` as a hash map keyed by
 // line content. If any line equals a string that collides with
 // Object.prototype (`constructor`, `__proto__`, `toString`, ...), the
@@ -101,7 +115,6 @@ export async function computeMergeAction(
     type: 'conflict',
     result: {
       content: merge.content,
-      hasConflicts: true,
       conflicts: merge.conflicts,
       stats: merge.stats,
     },
@@ -183,8 +196,12 @@ export function threeWayMerge(
     stats.linesUnchanged -= 1;
   }
 
-  // Merged output is always LF; callers convert at the write boundary.
-  return { content: merged.join('\n'), conflicts, stats };
+  // Restore theirs's line ending on merged output. Renderer output is
+  // LF-canonical and so is `base`/`ours`, but the user's `theirs` may be
+  // CRLF — preserving it here means `shardmind update` doesn't silently
+  // flip the file's line endings on write.
+  const lineEnding = detectLineEnding(theirs);
+  return { content: merged.join(lineEnding), conflicts, stats };
 }
 
 class LineInterner {

--- a/source/core/drift.ts
+++ b/source/core/drift.ts
@@ -50,6 +50,14 @@ const UNSCANNED_DIR_NAMES: ReadonlySet<string> = new Set([
  */
 const DRIFT_READ_CONCURRENCY = 32;
 
+/**
+ * Cap on concurrent `readdir` calls during orphan detection. Vaults that
+ * track hundreds of files across hundreds of directories would otherwise
+ * fan out one open-directory handle per tracked dir, reliably hitting
+ * EMFILE on macOS's 256-handle default.
+ */
+const ORPHAN_SCAN_CONCURRENCY = 32;
+
 export async function detectDrift(
   vaultRoot: string,
   state: ShardState,
@@ -98,7 +106,13 @@ async function classifyFile(
   }
 
   try {
-    const content = await fsp.readFile(path.join(vaultRoot, relPath), 'utf-8');
+    // Read as Buffer so the hash matches install time for ANY content —
+    // copy-origin files (images, PDFs, binary assets) are hashed as bytes
+    // by install-executor, and reading them as utf-8 here would replace
+    // invalid sequences with U+FFFD and produce a different sha256 every
+    // run. Both `sha256` and `update(buf)` accept Buffer, so rendered
+    // text files produce the same hash whether read as Buffer or utf-8.
+    const content = await fsp.readFile(path.join(vaultRoot, relPath));
     return classifyByHash(relPath, file, content);
   } catch (err) {
     if (isEnoent(err)) {
@@ -108,7 +122,7 @@ async function classifyFile(
   }
 }
 
-function classifyByHash(relPath: string, file: FileState, content: string): Classified {
+function classifyByHash(relPath: string, file: FileState, content: Buffer): Classified {
   const actualHash = sha256(content);
   const ownership = actualHash === file.rendered_hash ? 'managed' : 'modified';
   return {
@@ -171,8 +185,10 @@ async function detectOrphans(
     trackedDirs.add(normalizedDir);
   }
 
-  const perDir = await Promise.all(
-    [...trackedDirs].map(relDir => scanDirForOrphans(vaultRoot, relDir, trackedPaths)),
+  const perDir = await mapConcurrent(
+    [...trackedDirs],
+    ORPHAN_SCAN_CONCURRENCY,
+    relDir => scanDirForOrphans(vaultRoot, relDir, trackedPaths),
   );
 
   return perDir.flat().sort();

--- a/source/core/install-executor.ts
+++ b/source/core/install-executor.ts
@@ -364,7 +364,7 @@ async function writeValuesFile(
       throw new ShardMindError(
         'shard-values.yaml already exists at the install target',
         'VALUES_FILE_COLLISION',
-        'Move or remove shard-values.yaml before installing. `shardmind update` (Milestone 4) will handle this automatically once available.',
+        'Move or remove shard-values.yaml before re-running install. If `.shardmind/state.json` also exists, run `shardmind update` instead to upgrade the current install in place; without state.json, update throws UPDATE_NO_INSTALL.',
       );
     }
     throw err;

--- a/source/core/install-planner.ts
+++ b/source/core/install-planner.ts
@@ -231,24 +231,28 @@ export function hashValues(values: Record<string, unknown>): string {
  * through. Unlike the `replacer` array overload of JSON.stringify, this
  * does NOT drop nested object keys.
  *
- * A WeakSet guards against YAML anchor cycles — `yaml.parse` produces
- * cyclic objects for documents like `a: &x { self: *x }`, and a naive
- * recursion would stack-overflow on user input. A cycle is replaced with
- * `null` in the emitted shape; that's stable across runs (the same anchor
- * round-trips to the same null) which is all `hashValues` actually needs.
+ * The WeakSet tracks ONLY currently-descending ancestors — entries are
+ * removed on exit via `try/finally`. This distinguishes genuine cycles
+ * (same reference re-encountered during its own descent → emit `null`)
+ * from shared-but-non-cyclic references (YAML aliases like
+ * `a: &x {k:1}\nb: *x` that resolve to the same object across sibling
+ * positions → each position emits the full expansion). A persistent
+ * "visited-ever" set would collapse the alias second-visit to `null`
+ * and change the hash, making the semantically-equivalent anchor-free
+ * YAML hash differently — a silent data-corruption foot-gun.
  */
 function stableJson(value: unknown, seen: WeakSet<object> = new WeakSet()): unknown {
-  if (value !== null && typeof value === 'object') {
-    if (seen.has(value as object)) return null;
-    seen.add(value as object);
-  }
-  if (Array.isArray(value)) return value.map(v => stableJson(v, seen));
-  if (value && typeof value === 'object') {
+  if (value === null || typeof value !== 'object') return value;
+  if (seen.has(value as object)) return null;
+  seen.add(value as object);
+  try {
+    if (Array.isArray(value)) return value.map(v => stableJson(v, seen));
     const sorted: Record<string, unknown> = {};
     for (const key of Object.keys(value as Record<string, unknown>).sort()) {
       sorted[key] = stableJson((value as Record<string, unknown>)[key], seen);
     }
     return sorted;
+  } finally {
+    seen.delete(value as object);
   }
-  return value;
 }

--- a/source/core/install-planner.ts
+++ b/source/core/install-planner.ts
@@ -230,13 +230,23 @@ export function hashValues(values: Record<string, unknown>): string {
  * a deterministic byte sequence. Arrays keep their order; primitives pass
  * through. Unlike the `replacer` array overload of JSON.stringify, this
  * does NOT drop nested object keys.
+ *
+ * A WeakSet guards against YAML anchor cycles — `yaml.parse` produces
+ * cyclic objects for documents like `a: &x { self: *x }`, and a naive
+ * recursion would stack-overflow on user input. A cycle is replaced with
+ * `null` in the emitted shape; that's stable across runs (the same anchor
+ * round-trips to the same null) which is all `hashValues` actually needs.
  */
-function stableJson(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(stableJson);
+function stableJson(value: unknown, seen: WeakSet<object> = new WeakSet()): unknown {
+  if (value !== null && typeof value === 'object') {
+    if (seen.has(value as object)) return null;
+    seen.add(value as object);
+  }
+  if (Array.isArray(value)) return value.map(v => stableJson(v, seen));
   if (value && typeof value === 'object') {
     const sorted: Record<string, unknown> = {};
     for (const key of Object.keys(value as Record<string, unknown>).sort()) {
-      sorted[key] = stableJson((value as Record<string, unknown>)[key]);
+      sorted[key] = stableJson((value as Record<string, unknown>)[key], seen);
     }
     return sorted;
   }

--- a/source/core/renderer.ts
+++ b/source/core/renderer.ts
@@ -262,12 +262,41 @@ function renderTemplate(
   }
 }
 
+/**
+ * Windows-reserved device names. NTFS refuses to create a file with any
+ * of these as its basename (case-insensitive), WITH OR WITHOUT an
+ * extension — `CON.txt`, `LPT1.md`, `AUX.foo.bar` all crash on Windows
+ * the same way bare `CON` does. The regex matches on the STEM (the
+ * portion before the first dot) so we catch both shapes.
+ *
+ * Install succeeds on POSIX but crashes on Windows with EINVAL / EACCES;
+ * we rewrite them to a safe form so shards written against Linux don't
+ * silently break on a Windows user.
+ */
+const WINDOWS_RESERVED_NAMES_RE = /^(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/i;
+
 function sanitizeSlug(slug: string): string {
-  return slug
+  let out = slug
     .replace(/[/\\]/g, '-')
     .replace(/\.\./g, '-')
     .replace(/[<>:"|?*\x00-\x1f]/g, '-')
     .trim();
+  // NTFS silently strips trailing `.` and space from filenames, which
+  // produces a different-named file than the slug we planned with —
+  // fold them up front so the output path and the rendered state agree.
+  out = out.replace(/[. ]+$/, '');
+  // A slug of only dots / spaces / control chars collapses to an empty
+  // string after the rewrites above. Emitting "" produces an output
+  // path like `foo/.md` (a dotfile on POSIX; invisible on Windows),
+  // which disagrees with the planned shape. Fall back to `_` so every
+  // valid shard produces at least one legible path component.
+  if (!out) out = '_';
+  // Reserved-name check runs on the stem — NTFS blocks `CON.txt` just
+  // as hard as bare `CON`.
+  const dotIndex = out.indexOf('.');
+  const stem = dotIndex === -1 ? out : out.slice(0, dotIndex);
+  if (WINDOWS_RESERVED_NAMES_RE.test(stem)) out = `_${out}`;
+  return out;
 }
 
 function buildRenderedFile(outputPath: string, content: string, volatile: boolean): RenderedFile {

--- a/source/core/status.ts
+++ b/source/core/status.ts
@@ -25,6 +25,7 @@
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import { diffLines } from 'diff';
+import semver from 'semver';
 import type {
   ShardManifest,
   ShardSchema,
@@ -413,7 +414,15 @@ async function resolveUpdate(
     };
   }
 
-  if (result.latest_version === currentVersion) {
+  // Use semver equality where possible so `1.0.0` == `1.0.0+build.2`
+  // (build metadata is non-precedence per semver 2.0.0 §10). Fall back
+  // to strict string compare for non-semver version strings (custom
+  // tag schemes, pre-release tags without normalization).
+  const isSame =
+    semver.valid(result.latest_version) !== null && semver.valid(currentVersion) !== null
+      ? semver.eq(result.latest_version, currentVersion)
+      : result.latest_version === currentVersion;
+  if (isSame) {
     return { kind: 'up-to-date', current: currentVersion };
   }
 

--- a/source/core/update-check.ts
+++ b/source/core/update-check.ts
@@ -14,8 +14,9 @@
  * Cache file: `.shardmind/update-check.json` (vault-local, next to state.json).
  *
  * TTL: 24 hours. Any read older than that re-fetches from GitHub, succeeds or
- *   falls back to the stale value. This matches ROADMAP.md v0.2 item #51 — the
- *   status command depends on this cache to be useful, so it's built here.
+ *   falls back to the stale value. Shipped under the status-command work
+ *   (ROADMAP #51, pulled forward into v0.1) because status depends on this
+ *   cache to stay responsive across frequent invocations.
  *
  * Safety properties:
  *   - Writes are atomic (write-to-tempfile + rename) so a crashed or concurrent

--- a/source/core/update-executor.ts
+++ b/source/core/update-executor.ts
@@ -152,8 +152,9 @@ export async function runUpdate(opts: UpdateRunnerOptions): Promise<UpdateResult
 
     // Every action that emits an `onProgress 'file'` event counts toward
     // `total` — including conflicts resolved as keep_mine/skip that emit
-    // progress but don't actually write. Using `actionWrites` here would
-    // under-count total and let `index` overshoot 100% on the progress bar.
+    // progress but don't actually write. Counting only write-actions
+    // would under-count total and let `index` overshoot 100% on the
+    // progress bar.
     const progressTotal = plan.actions.filter(actionEmitsProgress).length;
     onProgress?.({ kind: 'start', total: progressTotal });
 
@@ -176,7 +177,7 @@ export async function runUpdate(opts: UpdateRunnerOptions): Promise<UpdateResult
     // + add at a different path) won't clobber a new file.
     let index = 0;
     for (const action of plan.actions) {
-      if (isDeleteAction(action, conflictResolutions)) continue;
+      if (isDeleteAction(action)) continue;
       await applyWriteAction(action, {
         vaultRoot,
         conflictResolutions,
@@ -191,7 +192,7 @@ export async function runUpdate(opts: UpdateRunnerOptions): Promise<UpdateResult
       });
     }
     for (const action of plan.actions) {
-      if (!isDeleteAction(action, conflictResolutions)) continue;
+      if (!isDeleteAction(action)) continue;
       await applyDeleteAction(action, {
         vaultRoot,
         nextFiles,
@@ -229,29 +230,44 @@ export async function runUpdate(opts: UpdateRunnerOptions): Promise<UpdateResult
     return { state: nextState, summary, backupDir };
   } catch (err) {
     if (!dryRun && backupDir) {
+      let rollbackFailures: RollbackFailure[] = [];
       try {
-        const rollbackFailures = await rollbackUpdate(vaultRoot, backupDir, addedPaths);
-        if (rollbackFailures.length > 0) {
-          // Attach rollback failures to the thrown error so the command
-          // layer can surface "update failed AND rollback was partial" —
-          // silently swallowing would tell the user the vault is back
-          // to pre-update when it isn't.
-          const summary = rollbackFailures
-            .slice(0, 5)
-            .map((f) => `  - ${f.path}: ${f.reason}`)
-            .join('\n');
-          const more = rollbackFailures.length > 5
-            ? `\n  …and ${rollbackFailures.length - 5} more`
-            : '';
-          (err as Error & { rollbackFailures?: RollbackFailure[] }).rollbackFailures =
-            rollbackFailures;
-          if (err instanceof Error) {
-            err.message = `${err.message}\nRollback incomplete (${rollbackFailures.length} files):\n${summary}${more}`;
-          }
-        }
+        rollbackFailures = await rollbackUpdate(vaultRoot, backupDir, addedPaths);
       } catch {
-        // rollback itself crashed — swallow and re-throw the original
-        // so we don't mask the underlying failure cause
+        // Rollback itself crashed — swallow and fall through to rethrow
+        // the original so we never mask the root-cause failure.
+      }
+      if (rollbackFailures.length > 0) {
+        // Surface partial-rollback detail in a NEW error rather than
+        // mutating `err.message`. Mutation throws on frozen/sealed
+        // third-party errors (a rare but real case for wrapped native
+        // errors) and compounds if the same error is caught again
+        // further up the stack and logged twice. Preserve the code when
+        // we can so command-layer code-based branching still works;
+        // attach the failures list and the original as `cause`.
+        const summary = rollbackFailures
+          .slice(0, 5)
+          .map((f) => `  - ${f.path}: ${f.reason}`)
+          .join('\n');
+        const more = rollbackFailures.length > 5
+          ? `\n  …and ${rollbackFailures.length - 5} more`
+          : '';
+        const baseMessage = err instanceof Error ? err.message : String(err);
+        const wrapped = err instanceof ShardMindError
+          ? new ShardMindError(
+              `${baseMessage}\nRollback incomplete (${rollbackFailures.length} files):\n${summary}${more}`,
+              err.code,
+              err.hint,
+            )
+          : new ShardMindError(
+              `${baseMessage}\nRollback incomplete (${rollbackFailures.length} files):\n${summary}${more}`,
+              'UPDATE_WRITE_FAILED',
+              'The update failed AND the rollback could not restore every snapshot. Check the listed paths manually.',
+            );
+        (wrapped as Error & { rollbackFailures?: RollbackFailure[] }).rollbackFailures =
+          rollbackFailures;
+        (wrapped as Error & { cause?: unknown }).cause = err;
+        throw wrapped;
       }
     }
     throw err;
@@ -371,13 +387,21 @@ async function applyWriteAction(action: UpdateAction, ctx: ApplyContext): Promis
       } else {
         // keep_mine / skip: leave the user's file on disk. `theirsHash`
         // was captured at plan time so we don't need to re-read + rehash
-        // here. Track as modified so next drift picks up their version.
-        ctx.nextFiles[action.path] = {
-          template: action.templateKey,
-          rendered_hash: action.theirsHash,
-          ownership: 'modified',
-          ...(action.iteratorKey ? { iterator_key: action.iteratorKey } : {}),
-        };
+        // here. For a preexisting-untracked add collision, the user's
+        // file stays UNTRACKED — we never silently adopt content they
+        // didn't opt in to manage. For the standard modified-file
+        // conflict, track as modified so next drift picks up their
+        // version.
+        if (action.preexisting) {
+          delete ctx.nextFiles[action.path];
+        } else {
+          ctx.nextFiles[action.path] = {
+            template: action.templateKey,
+            rendered_hash: action.theirsHash,
+            ownership: 'modified',
+            ...(action.iteratorKey ? { iterator_key: action.iteratorKey } : {}),
+          };
+        }
         if (resolution === 'keep_mine') ctx.summary.conflictsKeptMine++;
         else ctx.summary.conflictsSkipped++;
       }
@@ -418,19 +442,16 @@ function buildFileState(
   };
 }
 
-function isDeleteAction(
-  action: UpdateAction,
-  _resolutions: Record<string, ConflictResolution>,
-): boolean {
+function isDeleteAction(action: UpdateAction): boolean {
   return action.kind === 'delete';
 }
 
 /**
  * Whether an action emits an `onProgress` event during application.
- * Broader than `actionWrites`: every `conflict` emits progress even if
- * its resolution is `keep_mine`/`skip` (no disk write), so we use this
- * to compute the progress `total` — otherwise `index` could exceed
- * `total` and the progress bar would overshoot 100%.
+ * Every `conflict` emits progress even if its resolution is
+ * `keep_mine`/`skip` (no disk write), so we use this to compute the
+ * progress `total` — otherwise `index` could exceed `total` and the
+ * progress bar would overshoot 100%.
  */
 function actionEmitsProgress(action: UpdateAction): boolean {
   switch (action.kind) {

--- a/source/core/update-planner.ts
+++ b/source/core/update-planner.ts
@@ -30,7 +30,7 @@ import { isEnoent } from '../runtime/errno.js';
 import { computeMergeAction } from './differ.js';
 import { resolveModules } from './modules.js';
 import { renderFile, createRenderer } from './renderer.js';
-import { sha256, mapConcurrent, stripTemplatePrefix, pathExists } from './fs-utils.js';
+import { sha256, mapConcurrent, stripTemplatePrefix } from './fs-utils.js';
 import {
   SHARD_TEMPLATES_DIR,
   CACHED_TEMPLATES,
@@ -520,22 +520,45 @@ export async function planUpdate(input: PlanUpdateInput): Promise<UpdatePlan> {
     PLAN_IO_CONCURRENCY,
     async (output) => {
       const abs = path.join(vaultRoot, output.outputPath);
-      if (!(await pathExists(abs))) {
-        return {
-          kind: 'add',
-          path: output.outputPath,
-          content: output.content,
-          renderedHash: output.hash,
-          templateKey: toTemplateKey(newTempDir, output.entry.sourcePath),
-          ...(output.entry.iterator ? { iteratorKey: output.entry.iterator } : {}),
-          ...(output.copyFromSourcePath ? { copyFromSourcePath: output.copyFromSourcePath } : {}),
-        };
+      // Stat in a single I/O so we can tell "free path" from "file collision"
+      // from "directory collision" without a pathExists → readFile race.
+      // ENOENT → free path. EISDIR branch below handles the directory case.
+      let stat;
+      try {
+        stat = await fsp.stat(abs);
+      } catch (err) {
+        if (isEnoent(err)) {
+          return {
+            kind: 'add',
+            path: output.outputPath,
+            content: output.content,
+            renderedHash: output.hash,
+            templateKey: toTemplateKey(newTempDir, output.entry.sourcePath),
+            ...(output.entry.iterator ? { iteratorKey: output.entry.iterator } : {}),
+            ...(output.copyFromSourcePath ? { copyFromSourcePath: output.copyFromSourcePath } : {}),
+          };
+        }
+        throw err;
       }
+
+      if (stat.isDirectory()) {
+        // User has a directory at a path the new shard wants as a file.
+        // Reading it as a file below would crash with EISDIR; silently
+        // emitting plain `add` would crash the same way on write. Surface
+        // a typed error at plan time so the user sees actionable guidance
+        // BEFORE any snapshot or write runs.
+        throw new ShardMindError(
+          `Update cannot proceed: the new shard adds a file at '${output.outputPath}', but a directory exists there.`,
+          'UPDATE_WRITE_FAILED',
+          `Remove or rename the directory at '${abs}' before re-running \`shardmind update\`. This directory is not part of the previous install — it's user content at a path the new shard now claims.`,
+        );
+      }
+
       // Preexisting untracked file at an add path. Read bytes so
       // `theirsHash` stays consistent with install-executor's
       // bytewise hashing (binary assets were silently mishashed when
       // the previous implementation decoded as UTF-8 first). If the
-      // file raced out of existence between `pathExists` above and
+      // file raced out of existence between the stat above and
       // this read, fall back to a plain `add` — there's nothing to
       // collide with anymore.
       const actualRead = await readStringAndByteHash(abs);
@@ -629,7 +652,7 @@ function conflictFromDirect(
  * Returns `null` on ENOENT so callers decide semantics:
  *   - modified-file path: file was in `drift.modified` at scan time, so
  *     ENOENT now is a race. Caller throws `UPDATE_CACHE_MISSING`.
- *   - add-collision path: ENOENT between `pathExists` and read is a race;
+ *   - add-collision path: ENOENT between `fsp.stat` and read is a race;
  *     caller degrades to a plain `add` (no collision to report).
  */
 async function readStringAndByteHash(

--- a/source/core/update-planner.ts
+++ b/source/core/update-planner.ts
@@ -30,7 +30,7 @@ import { isEnoent } from '../runtime/errno.js';
 import { computeMergeAction } from './differ.js';
 import { resolveModules } from './modules.js';
 import { renderFile, createRenderer } from './renderer.js';
-import { sha256, mapConcurrent, stripTemplatePrefix } from './fs-utils.js';
+import { sha256, mapConcurrent, stripTemplatePrefix, pathExists } from './fs-utils.js';
 import {
   SHARD_TEMPLATES_DIR,
   CACHED_TEMPLATES,
@@ -61,6 +61,15 @@ export type UpdateAction =
       theirsHash: string;
       templateKey: string | null;
       iteratorKey?: string;
+      /**
+       * Set when the user has untracked content at a path the new shard
+       * newly introduces (`add` that collided with a user-created file).
+       * On `accept_new` the shard content adopts the path as managed; on
+       * `keep_mine` / `skip` the user's file stays on disk AND stays
+       * untracked — we never silently start managing a file the user
+       * didn't opt in to.
+       */
+      preexisting?: boolean;
     }
   | { kind: 'skip_volatile'; path: string }
   | { kind: 'add'; path: string; content: string; renderedHash: string; templateKey: string | null; iteratorKey?: string; copyFromSourcePath?: string }
@@ -144,7 +153,15 @@ export interface SchemaAdditions {
    * whether to opt in; default is to include.
    */
   newOptionalModules: Array<{ id: string; def: ModuleDefinition }>;
-  /** Modules present in the current install but gone from the new schema. */
+  /**
+   * Modules present in the current install but gone from the new schema.
+   * v0.1 surfaces this only via the update summary's silent-delete count
+   * (`mergeModuleSelections` already omits dropped ids from the new
+   * selections); the list is populated here so v0.2 can render a
+   * dedicated "these modules were removed upstream" block without a
+   * second computation pass. Kept intentionally instead of deleted —
+   * exported shape, pinned by tests.
+   */
   dropped: string[];
 }
 
@@ -397,17 +414,32 @@ export async function planUpdate(input: PlanUpdateInput): Promise<UpdatePlan> {
         );
       }
 
-      const [actualContent, oldTemplate] = await Promise.all([
-        readUtf8(path.join(vaultRoot, entry.path)),
+      const [actualRead, oldTemplate] = await Promise.all([
+        readStringAndByteHash(path.join(vaultRoot, entry.path)),
         loadOldTemplate(vaultRoot, fileState.template),
       ]);
+      if (actualRead === null) {
+        // Drift reported this file as `modified` at scan time, so ENOENT
+        // now is a race between scan and merge — the user (or another
+        // process) deleted the file mid-update. Pretending it was empty
+        // would overwrite their absence with the merged shard content
+        // on the next write. Surface a typed error instead so the user
+        // can re-run the update against a coherent vault.
+        throw new ShardMindError(
+          `File '${entry.path}' vanished between drift detection and merge planning`,
+          'UPDATE_CACHE_MISSING',
+          `Vault contents changed during \`shardmind update\`. Re-run — drift detection picks up the current shape and either classifies '${entry.path}' as missing (restored from the shard) or excludes it from the plan.`,
+        );
+      }
+      const actualContent = actualRead.content;
+      const theirsHash = actualRead.hash;
 
       if (oldTemplate === null) {
         return conflictFromDirect(
           entry.path,
           target,
           actualContent,
-          sha256(actualContent),
+          theirsHash,
           newTempDir,
         );
       }
@@ -450,7 +482,7 @@ export async function planUpdate(input: PlanUpdateInput): Promise<UpdatePlan> {
             result: mergeAction.result,
             newContent: target.content,
             newContentHash: target.hash,
-            theirsHash: sha256(actualContent),
+            theirsHash,
             templateKey: toTemplateKey(newTempDir, target.entry.sourcePath),
             ...(target.entry.iterator ? { iteratorKey: target.entry.iterator } : {}),
           };
@@ -475,19 +507,71 @@ export async function planUpdate(input: PlanUpdateInput): Promise<UpdatePlan> {
     }
   }
 
+  // New-add actions: for each shard-produced output that isn't tracked
+  // in state.files, decide between a plain `add` (path is free on disk)
+  // and a `conflict` (user has untracked content at the same path).
+  // Silently overwriting an untracked user file is a data-loss bug on
+  // par with the install command's collision handling — route the
+  // user's content through DiffView instead.
   const trackedPaths = new Set(Object.keys(currentState.files));
-  for (const output of newPlan.outputs) {
-    if (trackedPaths.has(output.outputPath)) continue;
-    actions.push({
-      kind: 'add',
-      path: output.outputPath,
-      content: output.content,
-      renderedHash: output.hash,
-      templateKey: toTemplateKey(newTempDir, output.entry.sourcePath),
-      ...(output.entry.iterator ? { iteratorKey: output.entry.iterator } : {}),
-      ...(output.copyFromSourcePath ? { copyFromSourcePath: output.copyFromSourcePath } : {}),
-    });
-    counts.added++;
+  const addCandidates = newPlan.outputs.filter(o => !trackedPaths.has(o.outputPath));
+  const addActions = await mapConcurrent<typeof addCandidates[number], UpdateAction>(
+    addCandidates,
+    PLAN_IO_CONCURRENCY,
+    async (output) => {
+      const abs = path.join(vaultRoot, output.outputPath);
+      if (!(await pathExists(abs))) {
+        return {
+          kind: 'add',
+          path: output.outputPath,
+          content: output.content,
+          renderedHash: output.hash,
+          templateKey: toTemplateKey(newTempDir, output.entry.sourcePath),
+          ...(output.entry.iterator ? { iteratorKey: output.entry.iterator } : {}),
+          ...(output.copyFromSourcePath ? { copyFromSourcePath: output.copyFromSourcePath } : {}),
+        };
+      }
+      // Preexisting untracked file at an add path. Read bytes so
+      // `theirsHash` stays consistent with install-executor's
+      // bytewise hashing (binary assets were silently mishashed when
+      // the previous implementation decoded as UTF-8 first). If the
+      // file raced out of existence between `pathExists` above and
+      // this read, fall back to a plain `add` — there's nothing to
+      // collide with anymore.
+      const actualRead = await readStringAndByteHash(abs);
+      if (actualRead === null) {
+        return {
+          kind: 'add',
+          path: output.outputPath,
+          content: output.content,
+          renderedHash: output.hash,
+          templateKey: toTemplateKey(newTempDir, output.entry.sourcePath),
+          ...(output.entry.iterator ? { iteratorKey: output.entry.iterator } : {}),
+          ...(output.copyFromSourcePath ? { copyFromSourcePath: output.copyFromSourcePath } : {}),
+        };
+      }
+      return {
+        ...(conflictFromDirect(
+          output.outputPath,
+          output,
+          actualRead.content,
+          actualRead.hash,
+          newTempDir,
+        ) as Extract<UpdateAction, { kind: 'conflict' }>),
+        preexisting: true,
+      };
+    },
+  );
+  for (const action of addActions) {
+    actions.push(action);
+    if (action.kind === 'add') {
+      counts.added++;
+    } else if (action.kind === 'conflict') {
+      // Same accounting as a modified-file conflict so the pending-
+      // conflicts count in the summary stays coherent.
+      pendingConflicts.push({ path: action.path, result: action.result });
+      counts.conflicts++;
+    }
   }
 
   return { actions, pendingConflicts, counts };
@@ -512,7 +596,6 @@ function conflictFromDirect(
     path: filePath,
     result: {
       content: `<<<<<<< yours\n${actualContent}\n=======\n${target.content}\n>>>>>>> shard update\n`,
-      hasConflicts: true,
       conflicts: [
         {
           lineStart: 1,
@@ -535,11 +618,28 @@ function conflictFromDirect(
   };
 }
 
-async function readUtf8(absPath: string): Promise<string> {
+/**
+ * Read a user file and produce both its string view (for the three-way
+ * merge, which is line-oriented) and its bytewise hash (for `theirsHash`
+ * which is recorded in state.files on `keep_mine`/`skip` resolutions).
+ * Always hashes bytes — install-executor hashes copy-origin files this
+ * way, so a bytewise hash here stays consistent across install/update
+ * cycles even for content that isn't valid UTF-8.
+ *
+ * Returns `null` on ENOENT so callers decide semantics:
+ *   - modified-file path: file was in `drift.modified` at scan time, so
+ *     ENOENT now is a race. Caller throws `UPDATE_CACHE_MISSING`.
+ *   - add-collision path: ENOENT between `pathExists` and read is a race;
+ *     caller degrades to a plain `add` (no collision to report).
+ */
+async function readStringAndByteHash(
+  absPath: string,
+): Promise<{ content: string; hash: string } | null> {
   try {
-    return await fsp.readFile(absPath, 'utf-8');
+    const buf = await fsp.readFile(absPath);
+    return { content: buf.toString('utf-8'), hash: sha256(buf) };
   } catch (err) {
-    if (isEnoent(err)) return '';
+    if (isEnoent(err)) return null;
     throw err;
   }
 }

--- a/source/runtime/errors.ts
+++ b/source/runtime/errors.ts
@@ -75,6 +75,12 @@ export type ErrorCode =
   | 'UPDATE_CACHE_MISSING'
   | 'UPDATE_WRITE_FAILED'
   | 'MIGRATION_INVALID_VERSION'
+  // Reserved for the v0.2 sandboxed-transform path: currently migrator.ts
+  // swallows `type_changed` transform exceptions and records a warning
+  // (best-effort posture), so this code is declared but unthrown. When
+  // the sandboxed evaluator lands it will fire this code so the command
+  // layer can distinguish "transform crashed" from "transform returned
+  // the wrong shape". See IMPLEMENTATION.md §7.
   | 'MIGRATION_TRANSFORM_FAILED'
 
   // Update-check cache (status command + update command share this)

--- a/source/runtime/frontmatter.ts
+++ b/source/runtime/frontmatter.ts
@@ -95,10 +95,28 @@ export function validateFrontmatter(
   };
 }
 
+/**
+ * Shell-glob → regex. Matches shell semantics:
+ *   - `**` crosses path segments (`.*`)
+ *   - `*`  does not (`[^/]*`) — `brain/*.md` matches `brain/Index.md` but
+ *     not `brain/sub/Index.md`, consistent with every shell and the
+ *     frontmatter rules shard authors write.
+ *   - `?`  matches a single non-separator character.
+ *
+ * `**` is handled by splitting on the literal sequence first, then
+ * escaping + expanding `*` / `?` inside each segment, then joining with
+ * `.*`. No sentinel tokens — that avoids the attack where user input
+ * containing the sentinel would be misinterpreted.
+ */
 function globToRegex(glob: string): RegExp {
   const escaped = glob
-    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-    .replace(/\*/g, '.*')
-    .replace(/\?/g, '.');
+    .split('**')
+    .map(segment =>
+      segment
+        .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+        .replace(/\*/g, '[^/]*')
+        .replace(/\?/g, '[^/]'),
+    )
+    .join('.*');
   return new RegExp(`^${escaped}$`);
 }

--- a/source/runtime/types.ts
+++ b/source/runtime/types.ts
@@ -211,7 +211,6 @@ export interface MergeStatsWithConflicts extends MergeStats {
 
 export interface MergeResult {
   content: string;
-  hasConflicts: boolean;
   conflicts: ConflictRegion[];
   stats: MergeStatsWithConflicts;
 }

--- a/tests/component/DiffView.test.tsx
+++ b/tests/component/DiffView.test.tsx
@@ -23,7 +23,6 @@ function makeResult(overrides: Partial<MergeResult> = {}): MergeResult {
       'after line 2',
       '',
     ].join('\n'),
-    hasConflicts: true,
     conflicts: [
       {
         lineStart: 3,

--- a/tests/component/NewValuesPrompt.test.tsx
+++ b/tests/component/NewValuesPrompt.test.tsx
@@ -38,7 +38,9 @@ describe('NewValuesPrompt', () => {
     const frame = lastFrame() ?? '';
     expect(frame).toContain('New values since your last install');
     expect(frame).toContain('Step 1 of 1');
-    expect(frame).toContain('setup');
+    // Renders the human-readable group label ("Setup"), not the raw id
+    // ("setup") — same lookup InstallWizard uses for consistency.
+    expect(frame).toContain('Setup');
     expect(frame).toContain('Your name?');
   });
 

--- a/tests/e2e/helpers/spawn-cli.ts
+++ b/tests/e2e/helpers/spawn-cli.ts
@@ -61,13 +61,19 @@ export interface SpawnCliOptions {
   cwd: string;
   env?: NodeJS.ProcessEnv;
   stdin?: string;
-  /** Default 15_000. The outer ceiling on how long we wait before SIGKILL. */
+  /** Default 45_000. The outer ceiling on how long we wait before SIGKILL. */
   timeoutMs?: number;
   /** Deliver a signal after a stdout regex matches. */
   signalAt?: SignalAt;
 }
 
-const DEFAULT_TIMEOUT = 15_000;
+// 45s accommodates the slowest CI cell (GitHub Actions windows-latest +
+// node 24) where Defender + cold-start stdlib dispatch can blow install
+// timing past 15s even for the minimal shard. A full install + update
+// cycle on that runner measures ~25s; same test on ubuntu-22 is ~2s. The
+// timeout is a SIGKILL safety net against a genuinely stuck child, not
+// a perf budget — individual tests can still override when they care.
+const DEFAULT_TIMEOUT = 45_000;
 
 /**
  * Spawn the CLI, wait for it to exit (or timeout), return captured output.

--- a/tests/integration/update.test.ts
+++ b/tests/integration/update.test.ts
@@ -15,7 +15,7 @@
  * runUpdate) against real filesystem state.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fsp from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -48,6 +48,7 @@ import type {
   ShardManifest,
   ShardSchema,
 } from '../../source/runtime/types.js';
+import { ShardMindError } from '../../source/runtime/types.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -624,5 +625,206 @@ describe('update pipeline (against examples/minimal-shard)', () => {
     expect(conflict.result.conflicts).toHaveLength(1);
     expect(conflict.result.conflicts[0]!.theirs).toContain('entirely different user content');
     expect(conflict.result.conflicts[0]!.ours).toContain('shard update replacement');
+  });
+
+  it('preexisting add-collision + keep_mine preserves user bytes and leaves them UNTRACKED', async () => {
+    // The round-1 harden fix for silent-data-loss on add: user creates
+    // their own file at a path the new shard wants to introduce; the
+    // planner emits `conflict` with `preexisting: true`; on `keep_mine`
+    // the executor leaves the file on disk AND drops it from
+    // state.files so we never silently adopt content the user didn't
+    // opt in to manage.
+    await installBaseline(vault, MINIMAL_SHARD, 'sha-0.1.0');
+    const newPath = 'brain/Backlog.md';
+    const userBytes = '# My own backlog\n\nPersonal notes I made myself.\n';
+    await fsp.writeFile(path.join(vault, newPath), userBytes, 'utf-8');
+
+    await copyShard(MINIMAL_SHARD, newShard);
+    await bumpVersion(newShard, '0.2.0');
+    await fsp.writeFile(
+      path.join(newShard, 'templates/brain/Backlog.md.njk'),
+      'Shard-managed backlog for {{ user_name }}\n',
+      'utf-8',
+    );
+
+    const state = (await readState(vault)) as ShardState;
+    const oldValues = parseYaml(await fsp.readFile(path.join(vault, 'shard-values.yaml'), 'utf-8')) as Record<string, unknown>;
+    const newManifest = await parseManifest(path.join(newShard, 'shard.yaml'));
+    const newSchema = await parseSchema(path.join(newShard, 'shard-schema.yaml'));
+    const selections = mergeModuleSelections(state.modules, newSchema, {});
+    const renderCtx = buildRenderContext(newManifest, oldValues, selections);
+    const drift = await detectDrift(vault, state);
+
+    const plan = await planUpdate({
+      vault: { root: vault, state, drift },
+      values: { old: oldValues, new: oldValues },
+      newShard: {
+        schema: newSchema,
+        selections,
+        tempDir: newShard,
+        renderContext: renderCtx,
+      },
+      removedFileDecisions: {},
+    });
+
+    const conflict = plan.actions.find((a) => a.kind === 'conflict' && a.path === newPath);
+    if (!conflict || conflict.kind !== 'conflict') throw new Error('expected preexisting conflict');
+    expect(conflict.preexisting).toBe(true);
+
+    await runUpdate({
+      vaultRoot: vault,
+      plan,
+      conflictResolutions: { [newPath]: 'keep_mine' },
+      currentState: state,
+      newManifest,
+      newSchema,
+      newValues: oldValues,
+      newSelections: selections,
+      resolved: { ...RESOLVED, version: newManifest.version },
+      tarballSha256: 'sha-0.2.0',
+      newTempDir: newShard,
+    });
+
+    // User bytes intact.
+    expect(await fsp.readFile(path.join(vault, newPath), 'utf-8')).toBe(userBytes);
+    // State does NOT record this path — we never adopted it.
+    const nextState = (await readState(vault)) as ShardState;
+    expect(nextState.files[newPath]).toBeUndefined();
+  });
+
+  it('throws a wrapped ShardMindError when write fails AND rollback is partial', async () => {
+    // End-to-end validation of the round-1 err-wrapper (update-executor's
+    // catch block): if an update write throws AND the snapshot rollback
+    // cannot restore every snapshot, the wrapper carries the rollback
+    // failures list, the original error as `cause`, and preserves the
+    // original code / hint. Previously this path mutated `err.message`
+    // in place — which throws on frozen errors and compounds across
+    // re-catches.
+    const { state, oldValues, newManifest, newSchema } = await setUpUpdate({
+      bumpTo: '0.2.0',
+      newHomeTemplate: 'Welcome to your vault, {{ user_name }} (wrapper-test)\n',
+    });
+
+    const selections = mergeModuleSelections(state.modules, newSchema, {});
+    const renderCtx = buildRenderContext(newManifest, oldValues, selections);
+    const drift = await detectDrift(vault, state);
+    const plan = await planUpdate({
+      vault: { root: vault, state, drift },
+      values: { old: oldValues, new: oldValues },
+      newShard: {
+        schema: newSchema,
+        selections,
+        tempDir: newShard,
+        renderContext: renderCtx,
+      },
+      removedFileDecisions: {},
+    });
+
+    const targetAbs = path.join(vault, 'Home.md');
+    const backupRoot = path.join(vault, '.shardmind', 'backups');
+    // Fail the update write for Home.md — triggers the executor's outer
+    // catch so rollback runs.
+    const realWrite = fsp.writeFile;
+    const writeSpy = vi.spyOn(fsp, 'writeFile').mockImplementation(async (p, data, opts) => {
+      if (typeof p === 'string' && p === targetAbs) {
+        throw Object.assign(new Error('simulated EACCES on Home.md'), { code: 'EACCES' });
+      }
+      return realWrite(p, data, opts);
+    });
+    // Fail the rollback restore for the same path — triggers the
+    // `rollbackFailures.length > 0` branch inside the catch handler.
+    const realCopy = fsp.copyFile;
+    const copySpy = vi.spyOn(fsp, 'copyFile').mockImplementation(async (src, dst, mode) => {
+      if (typeof dst === 'string' && dst === targetAbs && typeof src === 'string' && src.startsWith(backupRoot)) {
+        throw Object.assign(new Error('simulated EACCES on restore'), { code: 'EACCES' });
+      }
+      return realCopy(src, dst, mode);
+    });
+
+    try {
+      const err = await runUpdate({
+        vaultRoot: vault,
+        plan,
+        conflictResolutions: {},
+        currentState: state,
+        newManifest,
+        newSchema,
+        newValues: oldValues,
+        newSelections: selections,
+        resolved: { ...RESOLVED, version: newManifest.version },
+        tarballSha256: 'sha-0.2.0',
+        newTempDir: newShard,
+      }).catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(ShardMindError);
+      const wrapped = err as ShardMindError & { rollbackFailures?: Array<{ path: string; reason: string }>; cause?: unknown };
+      expect(wrapped.code).toBe('UPDATE_WRITE_FAILED');
+      expect(wrapped.message).toMatch(/Rollback incomplete/);
+      expect(wrapped.rollbackFailures?.length ?? 0).toBeGreaterThan(0);
+      // `cause` chains back to the original thrown error — no mutation
+      // of its message.
+      expect(wrapped.cause).toBeInstanceOf(Error);
+    } finally {
+      writeSpy.mockRestore();
+      copySpy.mockRestore();
+    }
+  });
+
+  it('preexisting add-collision + accept_new writes shard bytes and adopts as managed', async () => {
+    await installBaseline(vault, MINIMAL_SHARD, 'sha-0.1.0');
+    const newPath = 'brain/Backlog.md';
+    const userBytes = '# My own backlog\n';
+    await fsp.writeFile(path.join(vault, newPath), userBytes, 'utf-8');
+
+    await copyShard(MINIMAL_SHARD, newShard);
+    await bumpVersion(newShard, '0.2.0');
+    const shardBody = 'Shard-managed backlog for {{ user_name }}\n';
+    await fsp.writeFile(
+      path.join(newShard, 'templates/brain/Backlog.md.njk'),
+      shardBody,
+      'utf-8',
+    );
+
+    const state = (await readState(vault)) as ShardState;
+    const oldValues = parseYaml(await fsp.readFile(path.join(vault, 'shard-values.yaml'), 'utf-8')) as Record<string, unknown>;
+    const newManifest = await parseManifest(path.join(newShard, 'shard.yaml'));
+    const newSchema = await parseSchema(path.join(newShard, 'shard-schema.yaml'));
+    const selections = mergeModuleSelections(state.modules, newSchema, {});
+    const renderCtx = buildRenderContext(newManifest, oldValues, selections);
+    const drift = await detectDrift(vault, state);
+
+    const plan = await planUpdate({
+      vault: { root: vault, state, drift },
+      values: { old: oldValues, new: oldValues },
+      newShard: {
+        schema: newSchema,
+        selections,
+        tempDir: newShard,
+        renderContext: renderCtx,
+      },
+      removedFileDecisions: {},
+    });
+
+    await runUpdate({
+      vaultRoot: vault,
+      plan,
+      conflictResolutions: { [newPath]: 'accept_new' },
+      currentState: state,
+      newManifest,
+      newSchema,
+      newValues: oldValues,
+      newSelections: selections,
+      resolved: { ...RESOLVED, version: newManifest.version },
+      tarballSha256: 'sha-0.2.0',
+      newTempDir: newShard,
+    });
+
+    // Shard bytes now on disk.
+    const onDisk = await fsp.readFile(path.join(vault, newPath), 'utf-8');
+    expect(onDisk).toContain(`Shard-managed backlog for ${oldValues['user_name'] as string}`);
+    // Tracked as managed in state.
+    const nextState = (await readState(vault)) as ShardState;
+    expect(nextState.files[newPath]).toBeDefined();
+    expect(nextState.files[newPath]!.ownership).toBe('managed');
   });
 });

--- a/tests/unit/differ-line-endings.test.ts
+++ b/tests/unit/differ-line-endings.test.ts
@@ -3,6 +3,9 @@
  * file may be saved with CRLF; base/ours are renderer output (always LF).
  * Without normalization every line in `theirs` would trail with '\r' and
  * diff3 would report every line as different.
+ *
+ * Merged output preserves `theirs`'s dominant line ending so `shardmind
+ * update` doesn't silently flip LF↔CRLF on Windows users' managed files.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -18,6 +21,9 @@ describe('threeWayMerge — line ending robustness', () => {
 
     expect(result.conflicts).toHaveLength(0);
     expect(result.stats.linesConflicted).toBe(0);
+    // Theirs was CRLF — so is the merged output, byte-preserving on
+    // round-trip rather than silently rewriting to LF.
+    expect(result.content).toContain('\r\n');
   });
 
   it('detects a real conflict even when theirs uses CRLF', () => {
@@ -29,6 +35,18 @@ describe('threeWayMerge — line ending robustness', () => {
 
     expect(result.conflicts).toHaveLength(1);
     expect(result.content).toContain('<<<<<<< yours');
+    // CRLF preserved on output because theirs was CRLF — the merge
+    // engine honors the user's existing line-ending style.
+    expect(result.content).toContain('\r\n');
+  });
+
+  it('emits LF output when theirs is pure LF', () => {
+    const base = '# Title\n\nOriginal.\n';
+    const theirs = '# Title\n\nUser.\n';
+    const ours = '# Title\n\nShard.\n';
+
+    const result = threeWayMerge(base, theirs, ours);
+
     expect(result.content).not.toContain('\r');
   });
 });

--- a/tests/unit/drift-classification.test.ts
+++ b/tests/unit/drift-classification.test.ts
@@ -255,3 +255,84 @@ describe('detectDrift — orphan detection', () => {
     expect(report.orphaned).toEqual(['extra-at-root.md', 'skills/my-extra.md']);
   });
 });
+
+describe('detectDrift — binary assets', () => {
+  // Install-executor hashes copy-origin files as raw bytes (`sha256(buffer)`).
+  // Drift must do the same — reading as `utf-8` replaces invalid byte
+  // sequences with U+FFFD and produces a different sha256, which would
+  // mis-classify every binary asset as `modified` on first status check
+  // and then corrupt the bytes on `shardmind update`.
+  it('classifies a binary asset by BYTE hash, matching install-time', async () => {
+    // Bytes that fail utf-8 decoding: an unpaired 0xFF never appears in
+    // valid utf-8. Reading this as utf-8 would emit `\uFFFD` replacements
+    // and the hash would diverge from the install-time buffer hash.
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xfe]);
+    const abs = path.join(vaultRoot, 'assets/logo.png');
+    await fsp.mkdir(path.dirname(abs), { recursive: true });
+    await fsp.writeFile(abs, bytes);
+
+    const state = makeShardState({ files: {
+      'assets/logo.png': {
+        template: 'assets/logo.png',
+        rendered_hash: sha256(bytes),
+        ownership: 'managed',
+      },
+    } });
+
+    const report = await detectDrift(vaultRoot, state);
+
+    expect(report.managed).toHaveLength(1);
+    expect(report.managed[0]?.path).toBe('assets/logo.png');
+    expect(report.managed[0]?.actualHash).toBe(sha256(bytes));
+    expect(report.modified).toHaveLength(0);
+  });
+});
+
+describe('detectDrift — orphan scan scale', () => {
+  // A state.files with 200+ tracked directories previously fan-outed
+  // unbounded `readdir` calls, reliably hitting EMFILE on macOS's
+  // 256-handle default. The scan now runs through `mapConcurrent`.
+  it('round-trips a preinstalled-then-tracked binary through install+drift', async () => {
+    // Byte parity sanity: install-executor stores `sha256(buffer)` for
+    // copy-origin files, drift.ts reads as Buffer and hashes bytes, so
+    // a binary file classifies as `managed` on first check.
+    const pngPrefix = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const abs = path.join(vaultRoot, 'assets/logo.png');
+    await fsp.mkdir(path.dirname(abs), { recursive: true });
+    await fsp.writeFile(abs, pngPrefix);
+
+    const state = makeShardState({ files: {
+      'assets/logo.png': {
+        template: 'assets/logo.png',
+        rendered_hash: sha256(pngPrefix),
+        ownership: 'managed',
+      },
+    } });
+
+    const report1 = await detectDrift(vaultRoot, state);
+    expect(report1.managed).toHaveLength(1);
+    expect(report1.modified).toHaveLength(0);
+
+    // Second pass with the exact same bytes still stable.
+    const report2 = await detectDrift(vaultRoot, state);
+    expect(report2.managed[0]?.actualHash).toBe(report1.managed[0]?.actualHash);
+  });
+
+  it('handles 200 tracked directories without EMFILE', async () => {
+    const files: Record<string, import('../../source/runtime/types.js').FileState> = {};
+    for (let i = 0; i < 200; i++) {
+      const rel = `dir-${i.toString().padStart(3, '0')}/note.md`;
+      const content = `# Note ${i}\n`;
+      const abs = path.join(vaultRoot, rel);
+      await fsp.mkdir(path.dirname(abs), { recursive: true });
+      await fsp.writeFile(abs, content, 'utf-8');
+      files[rel] = { template: 't.njk', rendered_hash: sha256(content), ownership: 'managed' };
+    }
+    const state = makeShardState({ files });
+
+    const report = await detectDrift(vaultRoot, state);
+
+    expect(report.managed).toHaveLength(200);
+    expect(report.orphaned).toEqual([]);
+  });
+});

--- a/tests/unit/install-planner.test.ts
+++ b/tests/unit/install-planner.test.ts
@@ -421,6 +421,31 @@ describe('hashValues', () => {
     const b = hashValues({ items: [{ x: 1 }, { x: 3 }] });
     expect(a).not.toBe(b);
   });
+
+  it('terminates on cyclic values without stack overflow', () => {
+    // YAML anchors can produce cyclic object graphs — e.g.
+    //   a: &x
+    //     self: *x
+    // `yaml.parse` returns a real cycle. Without a cycle guard the
+    // recursive walk stack-overflows on hostile input; here we just
+    // assert the call returns a string.
+    const cyclic: Record<string, unknown> = { name: 'alice' };
+    cyclic['self'] = cyclic;
+    const hash = hashValues(cyclic);
+    expect(typeof hash).toBe('string');
+    expect(hash).toHaveLength(64);
+  });
+
+  it('produces a stable hash across two cyclic references to the same graph', () => {
+    // Two callers producing equivalent cyclic shapes hash to the same
+    // value — the cycle-break emits `null` at the recursion point, and
+    // null is deterministic.
+    const a: Record<string, unknown> = { name: 'alice' };
+    a['self'] = a;
+    const b: Record<string, unknown> = { name: 'alice' };
+    b['self'] = b;
+    expect(hashValues(a)).toBe(hashValues(b));
+  });
 });
 
 describe('defaultModuleSelections', () => {

--- a/tests/unit/install-planner.test.ts
+++ b/tests/unit/install-planner.test.ts
@@ -446,6 +446,33 @@ describe('hashValues', () => {
     b['self'] = b;
     expect(hashValues(a)).toBe(hashValues(b));
   });
+
+  it('hashes YAML-alias sibling sharing identically to the anchor-free equivalent', () => {
+    // YAML `a: &x {k: 1}\nb: *x` resolves to `{a, b}` with both keys
+    // pointing at the SAME object reference. The cycle guard must
+    // distinguish a real cycle (re-encounter during descent) from a
+    // shared-but-non-cyclic sibling (re-encounter AFTER descent
+    // finished). Emitting `null` for the second sibling — as a
+    // persistent visited-ever set would — silently changes the hash
+    // vs. anchor-free YAML, which would produce `values_hash` drift
+    // every time a shard author added or removed an anchor.
+    const shared = { k: 1 };
+    const withAnchor = { a: shared, b: shared };
+    const expanded = { a: { k: 1 }, b: { k: 1 } };
+    expect(hashValues(withAnchor)).toBe(hashValues(expanded));
+  });
+
+  it('distinguishes a real cycle from shared non-cyclic siblings', () => {
+    // Guard against the other direction of regression: if descent
+    // tracking ever stops firing at all, the cycle case would hash
+    // identically to a non-cyclic "just a shared sibling" graph. They
+    // are genuinely different shapes.
+    const cyclic: Record<string, unknown> = { name: 'a' };
+    cyclic['self'] = cyclic;
+    const shared = { name: 'a' };
+    const nonCyclic = { name: 'a', self: shared };
+    expect(hashValues(cyclic)).not.toBe(hashValues(nonCyclic));
+  });
 });
 
 describe('defaultModuleSelections', () => {

--- a/tests/unit/merge-adversarial.test.ts
+++ b/tests/unit/merge-adversarial.test.ts
@@ -100,13 +100,15 @@ describe('merge adversarial — line ending edge cases', () => {
     expect(result.content).toBe(withLn);
   });
 
-  it('handles mixed CRLF/LF in theirs', () => {
+  it('handles mixed CRLF/LF in theirs by picking CRLF (dominant Windows style)', () => {
     const base = 'a\nb\nc\n';
     const theirs = 'a\r\nb\nc\r\n';
     const ours = 'a\nb\nc\n';
     const result = threeWayMerge(base, theirs, ours);
     expect(result.conflicts).toHaveLength(0);
-    expect(result.content).not.toContain('\r');
+    // Mixed → CRLF: whenever theirs contains ANY CRLF we honor it on
+    // output so we never silently rewrite a Windows user's file to LF.
+    expect(result.content).toContain('\r\n');
   });
 
   it('handles pure CR (old Mac) line endings gracefully — no crash', () => {

--- a/tests/unit/renderer.test.ts
+++ b/tests/unit/renderer.test.ts
@@ -168,6 +168,131 @@ describe('renderFile', () => {
         await fs.rm(tmpDir, { recursive: true, force: true });
       }
     });
+
+    it('rewrites Windows-reserved slugs so fsp.writeFile succeeds on NTFS', async () => {
+      // CON / PRN / AUX / NUL / COM[1-9] / LPT[1-9] are NTFS device
+      // names; a shard author writing `slug: CON` produces an output
+      // path `projects/CON.md` that crashes install on Windows. The
+      // reserved-name check runs on the STEM (portion before first dot)
+      // so `CON.txt` and `LPT1.md` also rewrite — NTFS blocks them too.
+      const os = await import('node:os');
+      const tmpDir = path.join(os.tmpdir(), `renderer-test-${crypto.randomUUID()}`);
+      await fs.mkdir(tmpDir, { recursive: true });
+      await fs.writeFile(path.join(tmpDir, '_each.md.njk'), '# {{ item.name }}\n');
+
+      try {
+        const env = createRenderer(tmpDir);
+        const entry = makeEntry({
+          sourcePath: path.join(tmpDir, '_each.md.njk'),
+          outputPath: 'projects/_each.md',
+          iterator: 'projects',
+        });
+        const ctx = makeContext({
+          values: {
+            projects: [
+              { name: 'Bare', slug: 'CON' },
+              { name: 'Lower', slug: 'com1' },
+              { name: 'StemReserved', slug: 'CON.txt' },
+              { name: 'MultiDot', slug: 'LPT1.foo.bar' },
+              { name: 'Normal', slug: 'normal-slug' },
+            ],
+          },
+        });
+
+        const results = await renderFile(entry, ctx, env) as import('../../source/runtime/types.js').RenderedFile[];
+        expect(results.map(r => r.outputPath)).toEqual([
+          'projects/_CON.md',
+          'projects/_com1.md',
+          'projects/_CON.txt.md',
+          'projects/_LPT1.foo.bar.md',
+          'projects/normal-slug.md',
+        ]);
+      } finally {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it('falls back to `_` when the slug collapses to empty after rewrites', async () => {
+      // A slug that's only spaces, or empty, would rewrite to "" —
+      // producing an output path like `notes/.md` (dotfile on POSIX,
+      // hidden on Windows). Fall back to `_` so every output path has
+      // a legible stem. (Pure-dots collapses to `-` via `..` rewrite
+      // plus trailing-dot strip; `-` is a fine filename stem, so
+      // only the truly-empty case needs the fallback.)
+      const os = await import('node:os');
+      const tmpDir = path.join(os.tmpdir(), `renderer-test-${crypto.randomUUID()}`);
+      await fs.mkdir(tmpDir, { recursive: true });
+      await fs.writeFile(path.join(tmpDir, '_each.md.njk'), '# {{ item.name }}\n');
+
+      try {
+        const env = createRenderer(tmpDir);
+        const entry = makeEntry({
+          sourcePath: path.join(tmpDir, '_each.md.njk'),
+          outputPath: 'notes/_each.md',
+          iterator: 'notes',
+        });
+        const ctx = makeContext({
+          values: {
+            notes: [
+              { name: 'OnlySpaces', slug: '   ' },
+              { name: 'Empty', slug: '' },
+            ],
+          },
+        });
+
+        const results = await renderFile(entry, ctx, env) as import('../../source/runtime/types.js').RenderedFile[];
+        for (const r of results) {
+          expect(r.outputPath).toBe('notes/_.md');
+        }
+      } finally {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it('strips trailing dots and spaces from slugs (NTFS strips them silently)', async () => {
+      const os = await import('node:os');
+      const tmpDir = path.join(os.tmpdir(), `renderer-test-${crypto.randomUUID()}`);
+      await fs.mkdir(tmpDir, { recursive: true });
+      await fs.writeFile(path.join(tmpDir, '_each.md.njk'), '# {{ item.name }}\n');
+
+      try {
+        const env = createRenderer(tmpDir);
+        const entry = makeEntry({
+          sourcePath: path.join(tmpDir, '_each.md.njk'),
+          outputPath: 'notes/_each.md',
+          iterator: 'notes',
+        });
+        const ctx = makeContext({
+          values: {
+            notes: [
+              // `..` is the path-traversal guard; any leftover trailing
+              // dot is then stripped so NTFS doesn't silently drop it.
+              // `trailing...` → `trailing-.` (traversal guard) → `trailing-`.
+              { name: 'Dots', slug: 'trailing...' },
+              { name: 'TrailingSpace', slug: 'trailing ' },
+              // Pure trailing dots without traversal → stripped cleanly.
+              { name: 'PureDot', slug: 'singledot.' },
+            ],
+          },
+        });
+
+        const results = await renderFile(entry, ctx, env) as import('../../source/runtime/types.js').RenderedFile[];
+        const paths = results.map(r => r.outputPath);
+        // What matters: no output path ends in `.md` with an NTFS-
+        // strippable `. ` before the extension. Validate by asserting
+        // the slug portion (before `.md`) never ends with a bare dot
+        // or space.
+        for (const p of paths) {
+          const stem = p.replace(/\.md$/, '');
+          const tail = stem.slice(stem.lastIndexOf('/') + 1);
+          expect(tail).not.toMatch(/[. ]$/);
+        }
+        expect(paths[1]).toBe('notes/trailing.md');
+        expect(paths[2]).toBe('notes/singledot.md');
+      } finally {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('hashing', () => {

--- a/tests/unit/runtime.test.ts
+++ b/tests/unit/runtime.test.ts
@@ -7,7 +7,7 @@ import { resolveVaultRoot, loadState, getIncludedModules } from '../../source/ru
 import { loadValues, validateValues } from '../../source/runtime/values.js';
 import { loadSchema } from '../../source/runtime/schema.js';
 import { validateFrontmatter } from '../../source/runtime/frontmatter.js';
-import type { ShardSchema } from '../../source/runtime/types.js';
+import { assertNever, type ShardSchema } from '../../source/runtime/types.js';
 
 let mockVault: string;
 const originalCwd = process.cwd;
@@ -282,5 +282,61 @@ describe('validateFrontmatter', () => {
     const result = validateFrontmatter('README.md', '# README\nNo frontmatter here.\n', schema);
     expect(result.valid).toBe(true);
     expect(result.noteType).toBeNull();
+  });
+
+  it('path_match glob does NOT cross path segments', () => {
+    // `brain/*.md` (single `*`) must not match `brain/sub/note.md` —
+    // shell-glob semantics say `*` stops at `/`. The previous naive
+    // `*` → `.*` rewrite matched across segments and picked the wrong
+    // note-type rule for deeply-nested files.
+    const content = '---\ndate: 2026-04-01\ntags:\n  - t\n---\n# Deep\n';
+    const result = validateFrontmatter('brain/sub/deep/note.md', content, schema);
+    // The global rule still applies (date + tags both present), but the
+    // `brain-note` rule (path_match: `brain/*.md`) must not claim a
+    // file three levels deep.
+    expect(result.noteType).toBeNull();
+    expect(result.valid).toBe(true);
+  });
+
+  it('path_match `**` DOES cross path segments (recursive glob)', () => {
+    // `**` is the opt-in escape hatch for cross-segment matching.
+    const localSchema: ShardSchema = {
+      ...schema,
+      frontmatter: {
+        global: { required: [] },
+        'deep-note': { required: ['date'], path_match: 'brain/**.md' },
+      },
+    };
+    const content = '---\ndate: 2026-04-01\n---\n# Deep\n';
+    const result = validateFrontmatter('brain/sub/deep/note.md', content, localSchema);
+    expect(result.noteType).toBe('deep-note');
+  });
+
+  it('assertNever throws with the received value when called at runtime', () => {
+    // Type-level exhaustiveness checks trip at compile time; the runtime
+    // arm exists so a dynamically-wrong dispatch (library caller passing
+    // a typo'd discriminant, or a JSON-decoded enum from a future
+    // schema version) surfaces an actionable error instead of falling
+    // through to whatever code followed the switch.
+    expect(() => assertNever('bogus' as never)).toThrow(/Unhandled variant/);
+    expect(() => assertNever({ kind: 'bogus' } as never)).toThrow();
+  });
+
+  it('path_match escapes regex metacharacters literally', () => {
+    // A glob like `notes/[draft].md` should match that exact filename,
+    // not treat `[draft]` as a regex character class. The escape step
+    // runs per-segment inside the `**` tokenizer.
+    const localSchema: ShardSchema = {
+      ...schema,
+      frontmatter: {
+        global: { required: [] },
+        'bracket-note': { required: ['date'], path_match: 'notes/[draft].md' },
+      },
+    };
+    const content = '---\ndate: 2026-04-01\n---\n# Draft\n';
+    const match = validateFrontmatter('notes/[draft].md', content, localSchema);
+    expect(match.noteType).toBe('bracket-note');
+    const miss = validateFrontmatter('notes/d.md', content, localSchema);
+    expect(miss.noteType).toBeNull();
   });
 });

--- a/tests/unit/status.test.ts
+++ b/tests/unit/status.test.ts
@@ -135,6 +135,28 @@ describe('buildStatusReport', () => {
     expect(upd?.severity).toBe('info');
   });
 
+  it('treats build-metadata-only differences as up-to-date (semver §10)', async () => {
+    // Per semver 2.0.0 §10, build metadata (`+build.2`) does not
+    // participate in precedence. A cached latest of `0.1.0+build.2`
+    // against an installed `0.1.0+build.1` must report up-to-date,
+    // not endlessly prompt the user to update to a phantom newer
+    // version. The previous strict `===` comparison surfaced every
+    // build-metadata bump as an update.
+    await installMinimal(vault);
+
+    // Tweak the installed state's version to include build metadata.
+    const statePath = path.join(vault, '.shardmind', 'state.json');
+    const raw = await fsp.readFile(statePath, 'utf-8');
+    const state = JSON.parse(raw);
+    state.version = '0.1.0+build.1';
+    await fsp.writeFile(statePath, JSON.stringify(state, null, 2), 'utf-8');
+
+    await primeLatestVersion(vault, RESOLVED.source, '0.1.0+build.2');
+
+    const report = await buildStatusReport(vault, { verbose: false });
+    expect(report!.update).toMatchObject({ kind: 'up-to-date' });
+  });
+
   it('reports "unknown / cache-miss" when the update check is skipped', async () => {
     // `skipUpdateCheck` is semantically distinct from network failure:
     // the caller opted out of the lookup, so the reason is cache-miss,

--- a/tests/unit/update-planner.test.ts
+++ b/tests/unit/update-planner.test.ts
@@ -749,4 +749,159 @@ describe('planUpdate', () => {
     });
     expect(plan.counts.volatile).toBe(1);
   });
+
+  it('routes an `add` through DiffView when user has untracked content at the same path', async () => {
+    // Silent data-loss regression guard: if the new shard produces a
+    // file at a path the user already has content at, we must NOT
+    // emit a plain `add` (which overwrites silently). Route through
+    // `conflict` with `preexisting: true` so the executor's keep_mine
+    // path leaves the file alone AND untracked.
+    const schema = baseSchema({
+      modules: { brain: { label: 'Brain', paths: ['brain/'], removable: false } },
+    });
+    const selections: ModuleSelections = { brain: 'included' };
+    const values = { user_name: 'brenno' };
+
+    const newTemplate = 'Welcome {{ user_name }}! From shard v2.\n';
+    const userContent = '# My own Backlog\n\nPersonal notes.\n';
+
+    const vault = await buildVault({
+      vaultFiles: { 'brain/Backlog.md': userContent },
+      cachedTemplates: {},
+    });
+    const shardDir = await buildShardTempDir({ 'brain/Backlog.md.njk': newTemplate });
+
+    const drift: DriftReport = {
+      managed: [],
+      modified: [],
+      volatile: [],
+      missing: [],
+      orphaned: ['brain/Backlog.md'],
+    };
+
+    const plan = await planUpdate({
+      vault: { root: vault, state: makeShardState({
+        version: '1.0.0',
+        modules: selections,
+        files: {},
+      }), drift },
+      values: { old: values, new: values },
+      newShard: {
+        schema,
+        selections,
+        tempDir: shardDir,
+        renderContext: renderCtx(values),
+      },
+      removedFileDecisions: {},
+    });
+
+    const addKinds = plan.actions.map((a) => a.kind);
+    expect(addKinds).not.toContain('add');
+    expect(addKinds).toContain('conflict');
+    const conflict = plan.actions.find((a) => a.kind === 'conflict');
+    if (!conflict || conflict.kind !== 'conflict') throw new Error('narrowing');
+    expect(conflict.path).toBe('brain/Backlog.md');
+    expect(conflict.preexisting).toBe(true);
+    expect(plan.pendingConflicts).toHaveLength(1);
+    expect(plan.counts.conflicts).toBe(1);
+    expect(plan.counts.added).toBe(0);
+  });
+
+  it('preexisting-add conflict records a BYTE hash for theirs, not the utf-8 decode', async () => {
+    // If the preexisting file is binary, decoding as utf-8 mangles
+    // invalid byte sequences with U+FFFD, and hashing the decoded
+    // string produces a value that drifts from install-executor's
+    // byte-level hash. The planner now reads bytes for the hash.
+    const schema = baseSchema({
+      modules: { brain: { label: 'Brain', paths: ['brain/'], removable: false } },
+    });
+    const selections: ModuleSelections = { brain: 'included' };
+
+    // Bytes that include an unpaired 0xFF — invalid as utf-8.
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0xff, 0xfe]);
+
+    const vault = path.join(tempRoot, 'vault-binconflict');
+    await fsp.mkdir(vault, { recursive: true });
+    await fsp.mkdir(path.join(vault, 'brain', 'assets'), { recursive: true });
+    await fsp.writeFile(path.join(vault, 'brain', 'assets', 'logo.png'), bytes);
+
+    const shardDir = await buildShardTempDir({
+      'brain/assets/logo.png.njk': 'placeholder render\n',
+    });
+
+    const drift: DriftReport = {
+      managed: [],
+      modified: [],
+      volatile: [],
+      missing: [],
+      orphaned: ['brain/assets/logo.png'],
+    };
+
+    const plan = await planUpdate({
+      vault: { root: vault, state: makeShardState({
+        version: '1.0.0',
+        modules: selections,
+        files: {},
+      }), drift },
+      values: { old: {}, new: {} },
+      newShard: {
+        schema,
+        selections,
+        tempDir: shardDir,
+        renderContext: renderCtx({}),
+      },
+      removedFileDecisions: {},
+    });
+
+    const conflict = plan.actions.find((a) => a.kind === 'conflict');
+    if (!conflict || conflict.kind !== 'conflict') throw new Error('narrowing');
+    expect(conflict.preexisting).toBe(true);
+    // theirsHash must be the raw byte hash, not the hash of the
+    // U+FFFD-polluted utf-8 decode.
+    expect(conflict.theirsHash).toBe(sha256(bytes));
+  });
+
+  it('emits a plain `add` when the new-shard path is free on disk', async () => {
+    const schema = baseSchema({
+      modules: { brain: { label: 'Brain', paths: ['brain/'], removable: false } },
+    });
+    const selections: ModuleSelections = { brain: 'included' };
+    const values = { user_name: 'brenno' };
+
+    const newTemplate = 'Welcome!\n';
+
+    const vault = await buildVault({
+      vaultFiles: {},
+      cachedTemplates: {},
+    });
+    const shardDir = await buildShardTempDir({ 'brain/NewFile.md.njk': newTemplate });
+
+    const drift: DriftReport = {
+      managed: [],
+      modified: [],
+      volatile: [],
+      missing: [],
+      orphaned: [],
+    };
+
+    const plan = await planUpdate({
+      vault: { root: vault, state: makeShardState({
+        version: '1.0.0',
+        modules: selections,
+        files: {},
+      }), drift },
+      values: { old: values, new: values },
+      newShard: {
+        schema,
+        selections,
+        tempDir: shardDir,
+        renderContext: renderCtx(values),
+      },
+      removedFileDecisions: {},
+    });
+
+    expect(plan.actions.map((a) => a.kind)).toEqual(['add']);
+    expect(plan.counts.added).toBe(1);
+    expect(plan.counts.conflicts).toBe(0);
+  });
 });

--- a/tests/unit/update-planner.test.ts
+++ b/tests/unit/update-planner.test.ts
@@ -904,4 +904,52 @@ describe('planUpdate', () => {
     expect(plan.counts.added).toBe(1);
     expect(plan.counts.conflicts).toBe(0);
   });
+
+  it('throws UPDATE_WRITE_FAILED at plan time when a directory sits at a new-add path', async () => {
+    // Copilot round-8 finding: the previous `pathExists` → `readFile`
+    // sequence would throw EISDIR from `fsp.readFile` on a directory
+    // collision, crashing the planner mid-flight with an unfriendly
+    // error. Silently emitting a plain `add` would just move the crash
+    // to the executor's write-time EISDIR. Stat-based detection lets
+    // the planner surface a typed error BEFORE any snapshot runs.
+    const schema = baseSchema({
+      modules: { brain: { label: 'Brain', paths: ['brain/'], removable: false } },
+    });
+    const selections: ModuleSelections = { brain: 'included' };
+
+    // Pre-create a DIRECTORY at the path the new shard wants as a file.
+    const vault = path.join(tempRoot, 'vault-dircollide');
+    await fsp.mkdir(vault, { recursive: true });
+    await fsp.mkdir(path.join(vault, 'brain', 'Backlog.md'), { recursive: true });
+
+    const shardDir = await buildShardTempDir({
+      'brain/Backlog.md.njk': 'Welcome!\n',
+    });
+
+    const drift: DriftReport = {
+      managed: [],
+      modified: [],
+      volatile: [],
+      missing: [],
+      orphaned: [],
+    };
+
+    await expect(
+      planUpdate({
+        vault: { root: vault, state: makeShardState({
+          version: '1.0.0',
+          modules: selections,
+          files: {},
+        }), drift },
+        values: { old: {}, new: {} },
+        newShard: {
+          schema,
+          selections,
+          tempDir: shardDir,
+          renderContext: renderCtx({}),
+        },
+        removedFileDecisions: {},
+      }),
+    ).rejects.toMatchObject({ code: 'UPDATE_WRITE_FAILED' });
+  });
 });


### PR DESCRIPTION
Cross-cutting quality pass across the entire codebase. Seven parallel audit rounds (adversarial + correctness + docs, repeated on each round's diff) surfaced 19 real findings — every one fixed in this PR. The loop exited dry on round 7.

## Bar

PR #56 — 30-scenario E2E + 5 real defects + two-cycle harden. Gates matched:
- Zero `any` / `@ts-ignore` / `@ts-nocheck` / `as any` / `as unknown as` in `source/` outside two documented zod-dynamic-generation exceptions.
- Every finding either fixed with a commit ref OR tracked as a follow-up issue.
- CHANGELOG entry in proportional density.
- Audit artifact kept out of the repo (on author's Desktop).

## Real bugs fixed

### Data-destructive (commit `41b2c21`)

1. **Binary assets corrupted on `shardmind update`.** `drift.ts` read tracked files as utf-8 and hashed the decoded string; `install-executor` hashed raw bytes. Copy-origin binaries classified as `modified` on first status and got their UTF-8 projection written back on merge. Now reads as `Buffer`.
2. **Three-way merge silently flipped CRLF → LF** on Windows users' managed files. `differ.ts` now preserves `theirs`'s dominant line ending on output.
3. **`sanitizeSlug` crashed install on Windows** for reserved device names (CON / PRN / AUX / NUL / COM[1-9] / LPT[1-9]) — including stem variants like `CON.txt` and `LPT1.md`. Now rewrites with `_` prefix; strips trailing `.`/space; falls back to `_` for empty-collapse.
4. **`hashValues` stack-overflowed on YAML anchor cycles.** `stableJson` now guards via `WeakSet`.
5. **Orphan scan hit EMFILE** on macOS for vaults with 200+ tracked directories. Now routes `readdir` through `mapConcurrent(32)`.
6. **Status reported phantom updates for build-metadata-only diffs** (`1.0.0+build.1` vs `1.0.0+build.2` — non-precedence per semver 2.0.0 §10). Now uses `semver.eq` for valid-semver pairs.
7. **`globToRegex` crossed `/` boundaries.** `brain/*.md` matched `brain/sub/deep/note.md`. Now splits on `**` and expands `*` → `[^/]*` per segment (shell semantics).

### Update pipeline safety (commit `f1151ca`)

8. **Silent data-loss on `add` collision.** Planner emitted a plain `add` even when the user had untracked content at the target path. Now routes through `DiffView` with `preexisting: true`; keep_mine/skip leaves the user's file on disk AND untracked.
9. **`theirsHash` drifted from install-time bytes** for non-UTF-8 user content (modified-file + preexisting-add paths). A new `readStringAndByteHash` helper returns both the string view and the bytewise hash from a single read.
10. **Modified-file ENOENT race** corrupted the merge by treating the vanished file as empty. Now throws typed `UPDATE_CACHE_MISSING`; the add-collision caller races safely to plain `add`.
11. **`update-executor` mutated `err.message`** to append rollback detail — throws on frozen errors, compounds on re-catch. Replaced with a new `ShardMindError` wrapper that preserves original `code` + `hint` and attaches `rollbackFailures` + `cause`.

### UI + convention (commit `bbe0ec7`)

12. **`CollisionReview` + `ExistingInstallGate` lacked `firedRef` guards.** A second `onChange` of `overwrite` would have queued two `rm -rf + runInstall` cycles; a double-fire of Enter on "REINSTALL" would have queued two vault wipes. Both paths now match `DiffView`'s guard.
13. **Phase dispatch in `install.tsx` + `update.tsx` + `summarizeHook`** used if-ladders that silently render-nothing on a new variant. Now `switch` + `assertNever` default — compile-error on drift.

### Round-5/6 follow-ups (commit `1a553e6`)

14. **`VALUES_FILE_COLLISION` hint promised a Milestone-4 feature that shipped.** Round 5 rewrote it to recommend `shardmind update`; round 6 caught that `update` throws `UPDATE_NO_INSTALL` in the exact precondition where the collision fires (state.json absent — the only path reaching `writeValuesFile`'s `wx` catch, since `ExistingInstallGate` handles the state.json-present case). Hint now qualifies the recommendation on state.json presence and names the error `update` would throw otherwise.
15. **`docs/ERRORS.md` carried the same stale copy** with the same round-5/6 rewrite arc; now mirrors the corrected source hint.
16. **`docs/IMPLEMENTATION.md §4.8` algorithm omitted the bytewise-read invariant** that finding #1 relies on. Future contributors reading the spec alone could reintroduce the binary-drift bug. Now calls out `Buffer` read + byte hash with explicit U+FFFD / binary-asset rationale.
17. **`docs/AUTHORING.md §frontmatter`** didn't explain `*` vs `**` glob semantics despite finding #7 changing the behavior. Added a paragraph describing single-segment `*` vs cross-segment `**` + regex-metacharacter literal handling.

### Minor + dead-code

- `NewValuesPrompt` rendered raw group id (`setup`) instead of schema label (`Setup`).
- `ExistingInstallGate` dropped stale "`shardmind update` arrives in Milestone 4" parenthetical.
- `MergeResult.hasConflicts` removed — populated in two places, read nowhere.
- `isDeleteAction` lost unused `_resolutions` param; stale `actionWrites` comment updated.
- `update-check.ts` docstring rewritten (feature shipped in v0.1 via #51, not v0.2).
- `MIGRATION_TRANSFORM_FAILED` annotated as reserved for v0.2 sandboxed-transform path so its status is machine-checkable.
- `SchemaAdditions.dropped` annotated as v0.2 reporting hook (pinned by tests, intentionally kept).
- CLAUDE.md `any`-whitelist extended to `source/runtime/values.ts` (necessary duplicate; runtime can't import from core).

### Docs (commit `82b0bac`)

- `CLAUDE.md` Project Structure tree adds 13 previously-missing files; module table gains `install-planner`, `install-executor`, `cancellation`, `state-migrator`, `hook`, `fs-utils`.
- `docs/ERRORS.md` + 9 previously-missing codes under "Update / merge" + "Update-check cache"; `UPDATE_CACHE_MISSING` enumerates all 3 throw sites.
- `docs/IMPLEMENTATION.md` §4.9 no longer documents the removed `hasConflicts` field; §7 error-code table row updated with both hint patterns.
- `README.md` status line updated from "spec complete, build in progress" to the current reality.
- `CHANGELOG.md` `[Unreleased]` — three new blocks describing round-1 + round-2 + round-3 in proportional density to PR #56.

## Test delta

**551 → 571 (+20)**. New regression tests cover every bug above:

- `tests/unit/drift-classification.test.ts` — binary byte-hash round-trip, 200-dir orphan scan.
- `tests/unit/install-planner.test.ts` — `hashValues` cyclic termination.
- `tests/unit/renderer.test.ts` — Windows-reserved slugs (bare + stem variants), trailing-dot strip, empty-collapse fallback.
- `tests/unit/runtime.test.ts` — glob `*` vs `**` segment semantics, regex-metacharacter escaping inside `**` tokenization, `assertNever` runtime throw.
- `tests/unit/update-planner.test.ts` — add-collision routing, plain-add control, bytewise theirsHash for non-UTF-8 preexisting.
- `tests/unit/status.test.ts` — semver build-metadata equality.
- `tests/integration/update.test.ts` — preexisting + keep_mine (user bytes preserved, untracked), preexisting + accept_new (shard bytes, managed), wrapped rollback error (`vi.spyOn` forces write + restore failures).
- `tests/unit/differ-line-endings.test.ts` + `tests/unit/merge-adversarial.test.ts` — CRLF preservation pinned.
- `tests/component/NewValuesPrompt.test.tsx` — group label not raw id.
- `tests/component/DiffView.test.tsx` — fixture updated after `hasConflicts` removal.

## Audit rounds

Seven rounds. Findings-per-round converged to zero.

| Round | Agents | Real findings | Notes |
|-------|--------|---------------|-------|
| 1 | 3 parallel (adversarial + correctness + docs) | 13 bugs + 11 doc drifts | First-pass sweep of the whole codebase. |
| 2 | 2 parallel on round-1 diff | 3 new bugs (slug empty-collapse, glob sentinel, theirsHash binary gap) | Pushback surfaced that round 2 wasn't actually dry. |
| 3 | 2 parallel on cumulative diff | 3 new bugs (sanitizeSlug stem, readStringAndByteHash ENOENT, ExistingInstallGate TextInput firedRef) + 5 gaps | Gaps resolved: `MergeResult.hasConflicts` deleted, 3 missing tests added, CLAUDE.md whitelist updated. |
| 4 | Self re-read (agents rate-limited) | 4 stale doc refs | Resolved: `hasConflicts` in IMPLEMENTATION.md §4.9, `UPDATE_CACHE_MISSING` expansions, `SchemaAdditions.dropped` reviewer comment, CHANGELOG round-3 block. |
| 5 | 2 parallel on cumulative diff | 3 stale strings + 1 nit | Stale "Milestone 4" hint in `VALUES_FILE_COLLISION` (source + docs), `docs/IMPLEMENTATION.md §4.8` missing bytewise invariant, `docs/AUTHORING.md §frontmatter` missing glob semantics. |
| 6 | 1 agent verification | 1 regression (self-introduced in round 5) | The rewritten `VALUES_FILE_COLLISION` hint recommended `shardmind update`, which itself throws `UPDATE_NO_INSTALL` in the exact precondition where the collision fires. Fixed by qualifying on state.json presence. |
| 7 | 1 agent verification | **0** | Loop dry. |

The skill's 5-round circuit-breaker signals "scope too big to harden in one PR." I went to 7 because findings-per-round clearly converged (13 → 3 → 3 → 4 → 3+1 → 1 → 0); the trajectory was dry, not expanding. Round 6 specifically caught a regression I introduced in round 5's doc rewrite — the exact class of self-verification failure the loop exists to catch.

## Deferrals (tracked as follow-up issues)

Filed as GitHub issues + ROADMAP bullets:

- **#60** DiffView UX distinction for `preexisting: true` conflicts
- **#61** `--yes` policy for preexisting add-collisions (currently churns every update)
- **#62** Byte-identical preexisting add-collision adopts silently
- **#63** Binary files bypass three-way merge entirely
- **#64** `docs/IMPLEMENTATION.md §4.11a` / `§4.11b` for install-planner + install-executor

## Final gate

- `npm run typecheck` — zero errors.
- `npm test` — **571 / 571 passing, 0 skipped** on Windows 11 (vitest 4.1.4; 46 test files).
- `grep -rn ': any\b|@ts-ignore|@ts-nocheck|as any\b|as unknown as' source/` — zero matches.

## Test plan

- [ ] CI green on `{ubuntu, windows, macos} × {node 22, node 24}`.
- [ ] Windows CI cell green — load-bearing because the binary-drift fix and the Windows-reserved-slug rewrites only surface on NTFS.
- [ ] Manual smoke-check: install + update against `examples/minimal-shard` with a user-created file at a path the shard newly introduces; verify DiffView surfaces the preexisting conflict instead of silently overwriting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
