### PR TITLE
docs: roadmap bullet for #67 (branch/ref install)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -122,6 +122,7 @@ Deferred items surfaced during the v0.1 polish-pass architecture audit. None are
 - [ ] Enforce tarball size cap in `downloadShard` ([#32](https://github.com/breferrari/shardmind/issues/32))
 - [ ] `--force` flag on install for scripted collision overwrite without backup ([#55](https://github.com/breferrari/shardmind/issues/55))
 - [ ] E2E: bridge SIGINT delivery reliably on GH Actions Windows runner ([#57](https://github.com/breferrari/shardmind/issues/57))
+- [ ] Branch/ref install: `github:owner/repo#<ref>` syntax for shard-author dev loop ([#67](https://github.com/breferrari/shardmind/issues/67))
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a v0.2 engine-polish bullet pointing at [#67](https://github.com/breferrari/shardmind/issues/67) (branch/ref install, `github:owner/repo#<ref>`)
- Surfaces the deferred engine change alongside the other v0.1-review items so it doesn't drift into plan prose only (per the repo's "track deferred work" convention)

Filed after the flagship-shard conversion ([#14](https://github.com/breferrari/shardmind/issues/14)) hit the "tag-per-iteration" friction documented in `docs/AUTHORING.md §7`. `VISION.md:134` already names degit's `user/repo#tag` addressing as a design influence, so this is a commitment-to-be-implemented, not a new design bet.

No code changes — one-line doc update.

## Test plan
- [x] `ROADMAP.md` renders the new bullet under the correct section
- [x] Issue link resolves to [#67](https://github.com/breferrari/shardmind/issues/67)

🤖 Generated with [Claude Code](https://claude.com/claude-code)