### PR TITLE
docs: add SHARD-LAYOUT.md — v6 flat-layout contract

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,65 @@
+<!--
+Before opening this PR, confirm you've read CLAUDE.md §Working Agreement:
+https://github.com/breferrari/shardmind/blob/main/CLAUDE.md#working-agreement-v6-execution-standard
+
+Every v6 sub-issue (#73–#78, #14, #15, #85) must pass the quality gate below.
+For non-v6 PRs, delete the v6 sections and keep Summary + Test plan only.
+-->
+
+## Summary
+
+<!-- 1-3 bullets on what changed and why. Reference the issue (`closes #N`). -->
+
+-
+-
+
+Closes #
+
+## Adversarial cases considered
+
+<!--
+List the edge cases you enumerated before coding, each with a corresponding test.
+See CLAUDE.md §Working Agreement §3 for the starter list per v0.1 track.
+Delete this section for non-v6 PRs.
+-->
+
+-
+-
+
+## Quality gate (v6 PRs only)
+
+<!-- Every item must be checked or explicitly justified before merge. -->
+
+- [ ] `npm run typecheck` passes locally and in CI
+- [ ] `npm test` passes locally and in CI (all scopes: unit, component, integration, E2E)
+- [ ] **Tests added before implementation** (no code without a failing test that motivated it) — CLAUDE.md §Working Agreement §2
+- [ ] Adversarial cases from the section above are all covered by tests
+- [ ] Copilot review requested and every comment addressed (or marked false-positive with justification in the PR thread)
+- [ ] Issue acceptance criteria checked off with evidence below (or in the issue)
+- [ ] ROADMAP.md checkbox updated in this PR
+- [ ] For PRs on #73-#77: manual Invariant 1 proxy run (`git clone <shard>` + `shardmind install --defaults` + `diff -r`) — pending #78's CI test
+- [ ] For PR on #78 and later: Invariant 1 CI test still green
+- [ ] Spec alignment: no divergence from [`docs/SHARD-LAYOUT.md`](../blob/main/docs/SHARD-LAYOUT.md); if the implementation revealed a spec gap, the spec update is in this PR or a predecessor
+
+## Test plan
+
+<!--
+Bulleted markdown of what was tested + how to verify manually.
+Keep concise — focus on surprising or manual-verification-only things.
+-->
+
+- [ ]
+- [ ]
+
+## Risk / blast radius
+
+<!--
+What could this break? What did you check that it didn't?
+Pre-existing behavior that must still work. Migration concerns (fixtures, state.json, test data).
+-->
+
+-
+
+---
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,53 @@ This project is **spec-driven**. The architecture and implementation are fully d
 | 5 | obsidian-mind v6 conversion (`.shardmind/` sidecar, dotfolder `.njk`, hooks) + `shardmind adopt` command |
 | 6 | Research-wiki shard, Invariant 1 E2E test, polish, npm publish |
 
+## Working Agreement (v6 execution standard)
+
+Every v6 sub-issue (#73–#78, #14, #15, #85) passes these gates before merge. These practices are what this project has used from day one — spec-driven, fixture-first, adversarial. This section makes them explicit so any session picking up work knows the bar.
+
+### 1. Spec before code
+
+- Read the relevant section of [`docs/SHARD-LAYOUT.md`](docs/SHARD-LAYOUT.md) AND the linked issue body before touching code.
+- If the spec is silent or ambiguous on a decision you need, **update the spec first via a separate commit** — do not invent behavior in the implementation.
+- If your implementation reveals a spec mistake, fix the spec and submit the fix alongside the code change.
+
+### 2. Tests before implementation
+
+- Write the failing test first for every new behavior or bug fix. No code without a test.
+- For merge-engine-class work (`drift.ts`, `differ.ts`, `renderer.ts`), write **fixtures first** — the pattern used for the 20 merge fixtures in `tests/fixtures/merge/`.
+- Prefer property-based tests via `fast-check` when the input space is wide: ref-syntax parsing, `.shardmindignore` glob matching, hash-equivalence under whitespace.
+- Right test type for the work: unit for pure functions in `source/core/*.ts`; component via `ink-testing-library` for `source/components/*.tsx`; integration for multi-module pipelines; E2E via `tests/e2e/cli.test.ts` spawning `dist/cli.js`.
+
+### 3. Adversarial cases enumerated
+
+Before coding, list adversarial scenarios in the issue thread or PR description. Every listed case gets a test. Starter enumeration per v0.1 track:
+
+- **#73 walk**: symlinks pointing outside vault, paths with Unicode + spaces, missing `.shardmind/`, empty `.shardmind/`, `.shardmindignore` with thousands of patterns, tarball with Windows path separators.
+- **#74 schema**: defaults of `null` / `""` / `0` / `false` / nested objects; required-without-default must reject at parse time.
+- **#75 hooks**: hook crashes mid-edit (state.json must still reflect actual content), hook exceeds timeout, hook writes to unmanaged paths, `valuesAreDefaults` deep-equal vs. near-equal (whitespace, case, type coercion).
+- **#76 update**: ref moves between install and update, tag force-moved upstream, non-existent ref, rate-limited GitHub API, `--version` + `--include-prerelease` combined, beta-only repos (no stable release).
+- **#77 adopt**: adopt into dir with partial vault, adopt with existing `.shardmind/`, adopt with user files byte-equivalent to shard paths, adopt mid-failure recovery, adopt when shard can't be fetched.
+- **#78 Invariant 1**: shard with all-defaults empty strings, shard with zero modules, `.shardmindignore` excluding everything, byte-equivalence on case-insensitive filesystems (macOS), clone of shard vs. install includes/excludes parity.
+
+### 4. Quality gate (PR-merge requirements)
+
+Every PR for a v6 issue must demonstrate in its description:
+
+- [ ] `npm run typecheck` passes.
+- [ ] `npm test` passes (all scopes).
+- [ ] New behavior has new tests (§2) — no code without tests.
+- [ ] Adversarial cases from §3 are enumerated and covered.
+- [ ] Copilot review requested and addressed (or each flag explicitly justified as false-positive in PR conversation).
+- [ ] Once [#78](https://github.com/breferrari/shardmind/issues/78) lands: Invariant 1 E2E test still green.
+- [ ] Issue's acceptance criteria checked off with evidence.
+- [ ] Roadmap checkbox updated in the same PR.
+
+### 5. Session hygiene
+
+- **Start**: read this file, then `ROADMAP.md` (find first unchecked), then the linked issue, then `docs/SHARD-LAYOUT.md` (relevant section). In that order. Don't skip ahead.
+- **During**: run `npm run typecheck` and `npm test` frequently, not just at the end. If a test that should stay green goes red, stop and investigate before continuing — don't paper over.
+- **End**: if work is complete, open a PR referencing the issue (`closes #N`) with the quality-gate evidence. If incomplete, push the branch and comment on the issue with where you stopped, why, and what blocks progress — so the next session can resume.
+
 ## Tech Stack
 
 | Tool | Purpose |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,24 +12,25 @@ This project is **spec-driven**. The architecture and implementation are fully d
 |----------|------|-------------|
 | `VISION.md` | Origin story, architectural bets, scope guardrails, non-goals. | Before proposing features or scope changes. |
 | `ROADMAP.md` | v0.1 milestones linked to GitHub issues. Build order. | Before starting a new milestone. |
-| `docs/ARCHITECTURE.md` | The what and why. 22 sections. Core concepts, ownership model, schema format, module system, values layer, signals, operations, competitive moat. | Before making any architectural decision. |
-| `docs/IMPLEMENTATION.md` | The how, exactly. System diagram, data flows, 10 module specs with TypeScript signatures, algorithms as numbered steps, error cases, 17 merge test fixtures, 6-day build plan. | Before implementing any module. |
-| `examples/minimal-shard/` | Minimal test shard for development. 4 values, 2 modules (core + removable), signals, CLAUDE.md partials. | Use this for testing during Days 1-4 before the obsidian-mind shard conversion on Day 5. |
+| **`docs/SHARD-LAYOUT.md`** | **v6 shard-layout contract + three binding invariants. Active design spec.** Supersedes `ARCHITECTURE.md §3` (File Anatomy) and any stale `templates/`-walk assumptions in `IMPLEMENTATION.md §9` (Build Plan) + `§4.*` (module specs) until those docs are rewritten. | **Before implementing anything related to shard layout, install walk, hook context, adopt command, or obsidian-mind v6. Authoritative over ARCHITECTURE.md / IMPLEMENTATION.md where they conflict.** |
+| `docs/ARCHITECTURE.md` | The what and why. 22 sections. Core concepts, ownership model, schema format, module system, values layer, signals, operations, competitive moat. **§3 (File Anatomy) is stale — see `docs/SHARD-LAYOUT.md` for the v6 contract. §10.7 `--version` gap is tracked in [#70](https://github.com/breferrari/shardmind/issues/70).** | Before making any architectural decision. |
+| `docs/IMPLEMENTATION.md` | The how, exactly. System diagram, data flows, 10 module specs with TypeScript signatures, algorithms as numbered steps, error cases, 17 merge test fixtures, 6-day build plan. **§9 (Build Plan) is stale — see [#70](https://github.com/breferrari/shardmind/issues/70) for the current task list. §4.* module specs referencing `templates/` walk or `partials` field are superseded by `docs/SHARD-LAYOUT.md §Engine change scope`.** | Before implementing any module. |
+| `examples/minimal-shard/` | Minimal test shard for development. 4 values, 2 modules, signals. **Structure follows the flat v6 contract (`docs/SHARD-LAYOUT.md`) once migrated during Day 1-4; current committed state may still use the old `templates/` layout.** | Use this for testing during Days 1-4 before the obsidian-mind shard conversion on Day 5. |
 
 **Read the relevant spec section before writing code.** The specs define inputs, outputs, algorithms, error cases, and test expectations for every module. Don't improvise — implement what the spec says.
 
 ### Build Order
 
-Follow `docs/IMPLEMENTATION.md` §9 (Build Plan). Day-by-day, morning/afternoon splits, exact files to create, exact tests to write, verification steps. The order is designed so each piece has its dependencies ready.
+**Authoritative task list for v0.1: [#70](https://github.com/breferrari/shardmind/issues/70)** (engine changes, shard conversion, docs, tests, acceptance criteria). Spec for what to build: [`docs/SHARD-LAYOUT.md`](docs/SHARD-LAYOUT.md). The day-by-day rhythm in `docs/IMPLEMENTATION.md §9` is preserved below for cadence reference, but the specific sub-tasks within each day are superseded by #70's tracks (the `templates/` walk, `partials` field, and Cookiecutter-style source/target split described in §9 do not reflect the v6 contract).
 
 | Day | Focus |
 |-----|-------|
-| 1 | Scaffold + core modules (manifest, schema, download, renderer, modules, runtime) |
-| 2 | Install command with full Ink wizard + module review |
+| 1 | Scaffold + core modules per #70 "Walk + discovery" and "Schema + values" tracks |
+| 2 | Install command with full Ink wizard + module review + `--defaults` flag |
 | 3 | Merge engine — TDD with 17 fixtures (write fixtures FIRST, then implement) |
-| 4 | Update command + status display + verbose mode |
-| 5 | obsidian-mind v6 conversion (shard.yaml, .njk templates, TS hooks) |
-| 6 | Research-wiki shard, E2E tests, polish, npm publish |
+| 4 | Update command + status display + verbose mode + ref re-resolution + `--version` / `--include-prerelease` |
+| 5 | obsidian-mind v6 conversion (`.shardmind/` sidecar, dotfolder `.njk`, hooks) + `shardmind adopt` command |
+| 6 | Research-wiki shard, Invariant 1 E2E test, polish, npm publish |
 
 ## Tech Stack
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,12 @@ Every PR for a v6 issue must demonstrate in its description:
 - **During**: run `npm run typecheck` and `npm test` frequently, not just at the end. If a test that should stay green goes red, stop and investigate before continuing — don't paper over.
 - **End**: if work is complete, open a PR referencing the issue (`closes #N`) with the quality-gate evidence. If incomplete, push the branch and comment on the issue with where you stopped, why, and what blocks progress — so the next session can resume.
 
+### 6. PR hygiene
+
+- **One PR per issue** by default. Bundling multiple issues into one PR is discouraged — it tangles review, makes revert granularity worse, and confuses the roadmap-checkbox flow. If two issues are truly inseparable, comment on both issues explaining why before opening the combined PR.
+- The quality-gate checklist above lives in [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) and auto-populates every new PR. Don't delete items — check them or justify their absence.
+- **Interim proxy for Invariant 1** while #73-#77 are in-flight: until [#78](https://github.com/breferrari/shardmind/issues/78) lands its CI test, each PR on #73-#77 should manually run `git clone <a fixture shard>` + `shardmind install --defaults` + `diff -r` and paste the result (or "no diff beyond Tier 1 + `.shardmind/` metadata") into the PR description.
+
 ## Tech Stack
 
 | Tool | Purpose |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,15 @@
 # ShardMind Roadmap
 
-> Living document. Updated as priorities shift and milestones land.
+> Living document. Every item links to a GitHub issue so a fresh session can pick up the next unchecked task without context from prior conversations.
 >
-> Context: [`VISION.md`](VISION.md) | Architecture: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | Implementation: [`docs/IMPLEMENTATION.md`](docs/IMPLEMENTATION.md) | Dev guide: [`CLAUDE.md`](CLAUDE.md)
+> Context: [`VISION.md`](VISION.md) | Architecture: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | Implementation: [`docs/IMPLEMENTATION.md`](docs/IMPLEMENTATION.md) | **v6 layout spec**: [`docs/SHARD-LAYOUT.md`](docs/SHARD-LAYOUT.md) | Dev guide: [`CLAUDE.md`](CLAUDE.md)
+
+## How to use this roadmap
+
+1. Open this file.
+2. Find the first unchecked (`[ ]`) item in the earliest uncompleted milestone.
+3. Open the linked issue; read its description for scope + acceptance.
+4. Execute. Check the box here + close the issue on merge.
 
 ---
 
@@ -10,7 +17,7 @@
 
 Ship the core: install, update, status. Prove that vault template upgrades work where every other tool failed.
 
-### Milestone 1: Foundation (Day 1)
+### Milestone 1: Foundation (Day 1) — shipped
 
 - [x] Scaffold with `create-pastel-app` ([#1](https://github.com/breferrari/shardmind/issues/1))
 - [x] `source/core/manifest.ts` — parse + validate shard.yaml with zod ([#2](https://github.com/breferrari/shardmind/issues/2))
@@ -23,81 +30,72 @@ Ship the core: install, update, status. Prove that vault template upgrades work 
 - [x] Unit tests: manifest, schema, renderer (5 fixture scenarios), modules
 - [x] `shardmind --version` works
 
-### Milestone 2: Install Command (Day 2)
+### Milestone 2: Install Command (Day 2) — shipped
 
 - [x] `source/core/state.ts` + `source/core/registry.ts` ([#9](https://github.com/breferrari/shardmind/issues/9))
 - [x] `commands/install.tsx` — full install flow with Ink wizard ([#8](https://github.com/breferrari/shardmind/issues/8))
 - [x] Integration test: install pipeline against `examples/minimal-shard` (real obsidian-mind shard verified at Milestone 5)
 - [x] `ink-testing-library` component tests for ValueInput, ModuleReview, ExistingInstallGate, InstallWizard ([#38](https://github.com/breferrari/shardmind/issues/38) — pulled forward from v0.2)
 
-### Milestone 3: Merge Engine (Day 3)
+### Milestone 3: Merge Engine (Day 3) — shipped
 
 - [x] Write all 17 merge fixture directories — fixtures before code ([#10](https://github.com/breferrari/shardmind/issues/10))
 - [x] `core/drift.ts` + `core/differ.ts` — three-way merge engine ([#11](https://github.com/breferrari/shardmind/issues/11))
 - [x] Iterate until all 17 scenarios pass
-- [x] Add edge case fixtures: empty file (18), UTF-8 non-ASCII (19), frontmatter merge on modified ownership (20). Hash-identical behavior already covered by scenarios 01 and 05 (both hit the `sha256(base) === sha256(ours)` shortcut)
+- [x] Add edge case fixtures: empty file (18), UTF-8 non-ASCII (19), frontmatter merge on modified ownership (20). Hash-identical behavior already covered by scenarios 01 and 05
 
-### Milestone 4: Update Command + Status (Day 4)
+### Milestone 4: Update Command + Status (Day 4) — shipped
 
 - [x] `commands/update.tsx` — upgrade flow with drift detection + DiffView ([#12](https://github.com/breferrari/shardmind/issues/12))
-- [x] `commands/index.tsx` — status display + --verbose diagnostics ([#13](https://github.com/breferrari/shardmind/issues/13))
+- [x] `commands/index.tsx` — status display + `--verbose` diagnostics ([#13](https://github.com/breferrari/shardmind/issues/13))
 - [x] Integration test: install → modify files → update → verify merge behavior
 - [x] E2E test: all 3 commands via CLI invocation ([#54](https://github.com/breferrari/shardmind/issues/54))
 
-### Milestone 5: Flagship Shard (Day 5)
+### Milestone 4.5: v6 Layout Integration — **active** (tracked in [#70](https://github.com/breferrari/shardmind/issues/70))
 
-- [ ] obsidian-mind v6 — convert to shard format ([#14](https://github.com/breferrari/shardmind/issues/14))
-- [x] Finalize post-install hook runtime ([#30](https://github.com/breferrari/shardmind/issues/30)) — subprocess-backed via bundled `tsx`; ships with #30 so obsidian-mind (#14) can carry a real `post-install.ts`
-- [ ] Verify: `shardmind install github:breferrari/obsidian-mind` (direct mode) produces identical vault to git clone — the registry repo isn't created until Milestone 6
+Engine rework required by the v6 shard-layout contract. Must land before Milestone 5. Spec: [`docs/SHARD-LAYOUT.md`](docs/SHARD-LAYOUT.md).
 
-### Milestone 6: Ship (Day 6)
+- [ ] Flat shard-root walk + Tier 1 exclusions + `.shardmindignore` parser ([#73](https://github.com/breferrari/shardmind/issues/73))
+- [ ] Schema defaults enforcement + drop `partials` field ([#74](https://github.com/breferrari/shardmind/issues/74))
+- [ ] `HookContext` extensions (`valuesAreDefaults`, `newFiles`, `removedFiles`) + post-hook re-hash ([#75](https://github.com/breferrari/shardmind/issues/75))
+- [ ] Ref installs (`github:owner/repo#<ref>`) + update semantics (`--version`, `--include-prerelease`, ref re-resolution) ([#76](https://github.com/breferrari/shardmind/issues/76))
+- [ ] `shardmind adopt` command (2-way diff UI + adopt-planner + adopt-executor) ([#77](https://github.com/breferrari/shardmind/issues/77))
+- [ ] `install --defaults` flag + **Invariant 1 byte-equivalence CI test** ([#78](https://github.com/breferrari/shardmind/issues/78))
+
+### Milestone 5: Flagship Shard (Day 5) — blocked on Milestone 4.5
+
+- [ ] obsidian-mind v6 conversion — `.shardmind/` sidecar, hooks, `.shardmindignore` ([#14](https://github.com/breferrari/shardmind/issues/14), under [#70](https://github.com/breferrari/shardmind/issues/70))
+- [x] Finalize post-install hook runtime ([#30](https://github.com/breferrari/shardmind/issues/30))
+- [ ] Verify: `shardmind install github:breferrari/obsidian-mind` (direct mode) produces a vault byte-equivalent to git clone under Invariant 1
+
+### Milestone 6: Ship (Day 6) — blocked on Milestone 5
 
 - [ ] Research-wiki shard + E2E tests + npm publish ([#15](https://github.com/breferrari/shardmind/issues/15))
 - [ ] Create `shardmind/registry` repo with index.json (2 shards) — finalize schema per [#29](https://github.com/breferrari/shardmind/issues/29)
-- [ ] Final test: fresh machine → `npm install -g shardmind` → `shardmind install breferrari/obsidian-mind` (registry mode, proves #29 shape works end-to-end)
+- [ ] Final test: fresh machine → `npm install -g shardmind` → `shardmind install breferrari/obsidian-mind` (registry mode, proves [#29](https://github.com/breferrari/shardmind/issues/29) shape works end-to-end)
 
 ---
 
 ## v0.2.0 — Composition & Polish (Q2–Q3 2026)
 
-Deferred from v0.1. Build only after v0.1 is stable and adoption signals are real.
+Deferred from v0.1 per [`docs/SHARD-LAYOUT.md §Out of scope`](docs/SHARD-LAYOUT.md#out-of-scope--deferred-to-v02) + [`VISION.md §Current Priorities`](VISION.md). Build only after v0.1 is stable and adoption signals are real. Each feature has an umbrella issue tracking its sub-tasks.
 
-### Guided File Creation
+### Core features
 
-- [ ] `guided_files` section in shard-schema.yaml
-- [ ] Third install phase: guided prompts for files like SOUL.md
-- [ ] Render partially populated files from wizard answers + template structure
+- [ ] Guided file creation (`guided_files` schema + third install phase) ([#79](https://github.com/breferrari/shardmind/issues/79))
+- [ ] Structural variants (`modules.structure` + `vault_purpose`) ([#80](https://github.com/breferrari/shardmind/issues/80))
+- [ ] Shard composition (multi-shard per vault) ([#81](https://github.com/breferrari/shardmind/issues/81))
+- [ ] Dependency fetching (recursive + lock file) ([#82](https://github.com/breferrari/shardmind/issues/82))
+- [ ] `shardmind eject` command ([#83](https://github.com/breferrari/shardmind/issues/83))
+- [ ] `shardmind init` command for shard authors ([#84](https://github.com/breferrari/shardmind/issues/84))
 
-### Structural Variants
+### Layout / contract extensions (deferred from v0.1)
 
-- [ ] `modules.structure` field with purpose-driven folder variants
-- [ ] `vault_purpose` drives folder structure, not just CLAUDE.md framing
-- [ ] Design doc: the Vigil Mind Reshape decision record
+Tracked in [`docs/SHARD-LAYOUT.md §Out of scope`](docs/SHARD-LAYOUT.md#out-of-scope--deferred-to-v02). Parent issues to be created when scoped.
 
-### Shard Composition
-
-- [ ] `state.json` schema_version 2 with `shards[]`
-- [ ] Multiple shards in one vault (base shard + overlay shard)
-- [ ] Module conflict resolution between shards
-- [ ] `shardmind list` command (now useful with multiple shards)
-
-### Dependency Fetching
-
-- [ ] `registry.ts` gains `fetchDependencies()` method
-- [ ] Recursive download loop for declared dependencies
-- [ ] Lock file for transitive dependency resolution
-
-### Eject
-
-- [ ] `shardmind eject` command
-- [ ] Clean removal of `.shardmind/` and `shard-values.yaml`
-- [ ] Confirm prompt with file count
-
-### Init
-
-- [ ] `shardmind init` command for shard authors
-- [ ] Scaffold `shard.yaml`, `shard-schema.yaml`, `templates/` from prompts
-- [ ] Generate starter module structure
+- [ ] `rendered_files` opt-in (Nunjucks at vault-visible paths) — driver: research-wiki or other shard that needs `{{ values.X }}` in user-facing markdown
+- [ ] `.shardmindignore` negation (`!pattern`) — driver: a shard whose author needs to override broader patterns
+- [ ] Rename migrations + `shardmind adopt --from-version` — **must ship before any obsidian-mind release that introduces path renames**
 
 ### Engine polish (from v0.1 review)
 
@@ -110,27 +108,26 @@ Deferred items surfaced during the v0.1 polish-pass architecture audit. None are
 - [ ] `NO_COLOR` / `FORCE_COLOR` respect across Ink components ([#37](https://github.com/breferrari/shardmind/issues/37))
 - [ ] Alternate registry configurability (GHE, private, custom URL) ([#39](https://github.com/breferrari/shardmind/issues/39))
 - [ ] Encode state-schema migration rules (uses v0.1 framework) ([#40](https://github.com/breferrari/shardmind/issues/40))
-- [ ] Re-evaluate `@inkjs/ui` dependency (upstream frozen; shim at `source/components/ui.ts` keeps swap cheap) ([#43](https://github.com/breferrari/shardmind/issues/43))
-- [ ] Drop `LineInterner` workaround once `node-diff3` releases the prototype-lookup fix ([#49](https://github.com/breferrari/shardmind/issues/49), upstream [bhousel/node-diff3#87](https://github.com/bhousel/node-diff3/pull/87))
+- [ ] Re-evaluate `@inkjs/ui` dependency ([#43](https://github.com/breferrari/shardmind/issues/43))
+- [ ] Drop `LineInterner` workaround once `node-diff3` releases the prototype-lookup fix ([#49](https://github.com/breferrari/shardmind/issues/49))
 - [ ] `$EDITOR` integration for DiffView conflict resolution ([#50](https://github.com/breferrari/shardmind/issues/50))
 - [x] 24h update-check cache shared between status + update ([#51](https://github.com/breferrari/shardmind/issues/51) — shipped with #13)
 - [ ] DiffView: distinguish preexisting add-collision from modified-file conflict ([#60](https://github.com/breferrari/shardmind/issues/60))
-- [ ] `--yes` policy for preexisting add-collisions (currently churns every update) ([#61](https://github.com/breferrari/shardmind/issues/61))
+- [ ] `--yes` policy for preexisting add-collisions ([#61](https://github.com/breferrari/shardmind/issues/61))
 - [ ] Byte-identical preexisting add-collision adopts silently ([#62](https://github.com/breferrari/shardmind/issues/62))
 - [ ] Binary files bypass three-way merge entirely ([#63](https://github.com/breferrari/shardmind/issues/63))
 - [ ] `docs/IMPLEMENTATION.md` §4.11a / §4.11b for install-planner + install-executor ([#64](https://github.com/breferrari/shardmind/issues/64))
 - [ ] Enforce tarball size cap in `downloadShard` ([#32](https://github.com/breferrari/shardmind/issues/32))
 - [ ] `--force` flag on install for scripted collision overwrite without backup ([#55](https://github.com/breferrari/shardmind/issues/55))
 - [ ] E2E: bridge SIGINT delivery reliably on GH Actions Windows runner ([#57](https://github.com/breferrari/shardmind/issues/57))
-- [ ] Branch/ref install: `github:owner/repo#<ref>` syntax for shard-author dev loop ([#67](https://github.com/breferrari/shardmind/issues/67))
 
 ---
 
 ## v1.0.0 — Ecosystem (2026–2027)
 
-Only after the engine is proven, the flagship shard is stable, and community shards exist.
+Only after the engine is proven, the flagship shard is stable, and community shards exist. Issues to be created when v1.0 scoping begins — this section is aspirational.
 
-### Registry
+### Registry (hosted)
 
 - [ ] Hosted registry (shardmind.dev) with shard discovery and search
 - [ ] Shard metadata indexing from GitHub repos
@@ -164,6 +161,8 @@ Only after the engine is proven, the flagship shard is stable, and community sha
 **The moat is the update engine.** Every feature decision should be evaluated against: "does this make upgrades better?" If not, it can wait.
 
 **Agent-agnostic engine, agent-specific shards.** ShardMind renders templates. Shard authors decide which AIs to support. Don't couple the engine to any agent.
+
+**Invariant 1 is law.** `shardmind install --defaults <shard>` produces a vault byte-equivalent to `git clone <shard>` (modulo Tier 1 exclusions + `.shardmind/` engine metadata + vault-root `shard-values.yaml`). If CI catches a diff, the shard or the engine is wrong.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,13 +66,14 @@ Engine rework required by the v6 shard-layout contract. Must land before Milesto
 
 - [ ] obsidian-mind v6 conversion — `.shardmind/` sidecar, hooks, `.shardmindignore` ([#14](https://github.com/breferrari/shardmind/issues/14), under [#70](https://github.com/breferrari/shardmind/issues/70))
 - [x] Finalize post-install hook runtime ([#30](https://github.com/breferrari/shardmind/issues/30))
-- [ ] Verify: `shardmind install github:breferrari/obsidian-mind` (direct mode) produces a vault byte-equivalent to git clone under Invariant 1
+- [ ] Verify: `shardmind install github:breferrari/obsidian-mind` (direct mode) produces a vault byte-equivalent to git clone under Invariant 1 ([#78](https://github.com/breferrari/shardmind/issues/78))
 
 ### Milestone 6: Ship (Day 6) — blocked on Milestone 5
 
 - [ ] Research-wiki shard + E2E tests + npm publish ([#15](https://github.com/breferrari/shardmind/issues/15))
 - [ ] Create `shardmind/registry` repo with index.json (2 shards) — finalize schema per [#29](https://github.com/breferrari/shardmind/issues/29)
-- [ ] Final test: fresh machine → `npm install -g shardmind` → `shardmind install breferrari/obsidian-mind` (registry mode, proves [#29](https://github.com/breferrari/shardmind/issues/29) shape works end-to-end)
+- [ ] v6 docs rewrite: ARCHITECTURE §3, AUTHORING §2, IMPLEMENTATION §4.* / §9; fold SHARD-LAYOUT.md into ARCHITECTURE ([#85](https://github.com/breferrari/shardmind/issues/85))
+- [ ] Final test: fresh machine → `npm install -g shardmind` → `shardmind install breferrari/obsidian-mind` (registry mode, proves [#29](https://github.com/breferrari/shardmind/issues/29) shape works end-to-end) ([#15](https://github.com/breferrari/shardmind/issues/15))
 
 ---
 
@@ -91,11 +92,11 @@ Deferred from v0.1 per [`docs/SHARD-LAYOUT.md §Out of scope`](docs/SHARD-LAYOUT
 
 ### Layout / contract extensions (deferred from v0.1)
 
-Tracked in [`docs/SHARD-LAYOUT.md §Out of scope`](docs/SHARD-LAYOUT.md#out-of-scope--deferred-to-v02). Parent issues to be created when scoped.
+Tracked in [`docs/SHARD-LAYOUT.md §Out of scope`](docs/SHARD-LAYOUT.md#out-of-scope--deferred-to-v02).
 
-- [ ] `rendered_files` opt-in (Nunjucks at vault-visible paths) — driver: research-wiki or other shard that needs `{{ values.X }}` in user-facing markdown
-- [ ] `.shardmindignore` negation (`!pattern`) — driver: a shard whose author needs to override broader patterns
-- [ ] Rename migrations + `shardmind adopt --from-version` — **must ship before any obsidian-mind release that introduces path renames**
+- [ ] `rendered_files` opt-in (Nunjucks at vault-visible paths) ([#86](https://github.com/breferrari/shardmind/issues/86))
+- [ ] `.shardmindignore` negation (`!pattern`) ([#87](https://github.com/breferrari/shardmind/issues/87))
+- [ ] Rename migrations + `shardmind adopt --from-version` — **must ship before any obsidian-mind release that introduces path renames** ([#88](https://github.com/breferrari/shardmind/issues/88))
 
 ### Engine polish (from v0.1 review)
 
@@ -125,28 +126,28 @@ Deferred items surfaced during the v0.1 polish-pass architecture audit. None are
 
 ## v1.0.0 — Ecosystem (2026–2027)
 
-Only after the engine is proven, the flagship shard is stable, and community shards exist. Issues to be created when v1.0 scoping begins — this section is aspirational.
+Only after the engine is proven, the flagship shard is stable, and community shards exist. Each area has a parent umbrella issue; sub-tasks detailed as scoping begins.
 
-### Registry (hosted)
+### Registry (hosted) ([#89](https://github.com/breferrari/shardmind/issues/89))
 
 - [ ] Hosted registry (shardmind.dev) with shard discovery and search
 - [ ] Shard metadata indexing from GitHub repos
 - [ ] Version history and changelog display
 - [ ] `shardmind search` command
 
-### Community
+### Community ([#90](https://github.com/breferrari/shardmind/issues/90))
 
 - [x] Shard authoring guide ([`docs/AUTHORING.md`](docs/AUTHORING.md), shipped in v0.1 polish pass)
 - [ ] Shard validation CI (GitHub Action for shard authors)
 - [ ] Community shard listing
 - [ ] Fork-to-shard conversion guide (for obsidian-mind fork authors)
 
-### Teams (if demand signals appear)
+### Teams (if demand signals appear) ([#91](https://github.com/breferrari/shardmind/issues/91))
 
 - [ ] Managed vault templates for organizations
 - [ ] Shared values with org-level defaults
 - [ ] Admin controls for module enforcement
-- [ ] Team sync for brain/ namespaces
+- [ ] Team sync for `brain/` namespaces
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -62,6 +62,7 @@ Engine rework required by the v6 shard-layout contract. Must land before Milesto
 - [ ] Ref installs (`github:owner/repo#<ref>`) + update semantics (`--version`, `--include-prerelease`, ref re-resolution) ([#76](https://github.com/breferrari/shardmind/issues/76))
 - [ ] `shardmind adopt` command (2-way diff UI + adopt-planner + adopt-executor) ([#77](https://github.com/breferrari/shardmind/issues/77))
 - [ ] `install --defaults` flag + **Invariant 1 byte-equivalence CI test** ([#78](https://github.com/breferrari/shardmind/issues/78))
+- [ ] **Contract acceptance suite** — full install / update (no-conflict + with-conflict) / adopt / additive-principle / hook-failure / adversarial scenario matrix ([#92](https://github.com/breferrari/shardmind/issues/92))
 
 ### Milestone 5: Flagship Shard (Day 5) — blocked on Milestone 4.5
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,8 @@
 1. Open this file.
 2. Find the first unchecked (`[ ]`) item in the earliest uncompleted milestone.
 3. Open the linked issue; read its description for scope + acceptance.
-4. Execute. Check the box here + close the issue on merge.
+4. **Before touching code**: read [`CLAUDE.md §Working Agreement`](CLAUDE.md#working-agreement-v6-execution-standard) — spec-before-code, tests-before-implementation, adversarial enumeration, quality gate, and session hygiene. Non-negotiable for v6 sub-issues.
+5. Execute. Check the box here + close the issue on merge.
 
 ---
 

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -1107,6 +1107,13 @@ Decisions made during architecture that should be preserved:
 
 ## 9. Build Plan
 
+> **Superseded by [#70](https://github.com/breferrari/shardmind/issues/70) (2026-04-24).** This build plan predates the v6 shard-layout design. The six-day cadence is still a useful frame, but the **specific sub-tasks** in each day below assume the old `templates/`-walk contract, the `partials` field, and the Cookiecutter-style source/target split — all removed in the v6 contract. For the current work plan, engine change scope, invariants, and acceptance criteria, read:
+>
+> - [`docs/SHARD-LAYOUT.md`](SHARD-LAYOUT.md) — the v6 contract + three binding invariants (the spec).
+> - [#70](https://github.com/breferrari/shardmind/issues/70) — the task list mapped onto the six days (the plan).
+>
+> The day headings below stay; the bullet lists within each day do not reflect reality and should be cross-checked against SHARD-LAYOUT.md + #70 before being actioned. This section will be rewritten when the engine changes land.
+
 ### Day 1: Foundation
 
 ```

--- a/docs/SHARD-LAYOUT.md
+++ b/docs/SHARD-LAYOUT.md
@@ -60,20 +60,27 @@ my-shard/                             ← git repo root; also opens cleanly as a
 ```
 my-vault/
 │
-├── .shardmind/
-│   ├── state.json                    ← ownership + hashes + modules + agents + version + ref (if applicable)
-│   ├── shard-values.yaml             ← user's answers from the wizard
-│   └── templates/                    ← cached source files; merge base on update
+├── .shardmind/                       ← engine metadata (installed-side)
+│   ├── state.json                    ← ownership hashes + module/agent selections + version + resolved ref
+│   ├── shard.yaml                    ← cached manifest (runtime reads without re-extracting the tarball)
+│   ├── shard-schema.yaml             ← cached values schema
+│   └── templates/                    ← cached source files; merge base for three-way merge on update
+│
+├── shard-values.yaml                 ← user's answers from the wizard; vault-root (not under .shardmind/);
+│                                       named separately from .shardmind/ in VISION.md line 85
 │
 ├── <same vault content as source, with:>
 │   ├── .njk files in dotfolders rendered with user values (suffix stripped)
 │   ├── optional modules/agents included per wizard (default: all)
 │   └── hook may have personalized managed files (bound by Invariants 2 + 3)
 │
+├── .shardmindignore                  ← installed verbatim (Tier 2); inert post-install
 ├── README.md, LICENSE, CHANGELOG.md
 │
 └── (no .github/, no CONTRIBUTING.md, no translations, no demo media)
 ```
+
+The installed-side path constants are authoritative in [`source/runtime/vault-paths.ts`](../source/runtime/vault-paths.ts): `STATE_FILE`, `CACHED_MANIFEST`, `CACHED_SCHEMA`, `CACHED_TEMPLATES` all live under `.shardmind/`; `VALUES_FILE` lives at vault root.
 
 ## Personalization model
 
@@ -93,7 +100,7 @@ Three hard rules the engine + authors uphold. Enforced by CI.
 
 If a user runs `shardmind install <shard>` and accepts every default value, the resulting vault is byte-identical to `git clone <shard>`, modulo:
 - Tier 1 engine exclusions (absent from install)
-- `.shardmind/{state.json, shard-values.yaml, templates/}` (present in install)
+- Engine metadata (present in install): `.shardmind/state.json`, `.shardmind/shard.yaml` (cached manifest), `.shardmind/shard-schema.yaml` (cached schema), `.shardmind/templates/` (merge-base cache), and vault-root `shard-values.yaml`
 
 Enforced by a CI E2E test. Any other delta is a shard-design bug. Byte-equivalence = content hash + relative path; modes and mtimes are not compared.
 
@@ -120,7 +127,7 @@ Post-update hooks receive `ctx.newFiles: string[]` — managed files added in th
   - `valuesAreDefaults: boolean` — true iff every user value equals its schema default
   - `newFiles: string[]` — managed files added by this install/update (empty on clean install; populated on update with paths newly added in the new version)
   - `removedFiles: string[]` — managed files removed by this update (module deselection). Hooks use this to maintain external state (QMD collection refs, MCP registrations).
-- **`.shardmind/hooks/` is source-side only.** The installed-side `.shardmind/` holds state.json + shard-values.yaml + templates/ cache — not hooks. Engine reads hook scripts from the extracted source tarball during install/update; hook scripts never get copied into the installed vault.
+- **`.shardmind/hooks/` is source-side only.** The installed-side `.shardmind/` holds `state.json` + cached `shard.yaml` + cached `shard-schema.yaml` + `templates/` cache — not hooks. (User's `shard-values.yaml` lives at vault root, not inside `.shardmind/`.) Engine reads hook scripts from the extracted source tarball during install/update; hook scripts never get copied into the installed vault.
 - **Hook timeout** stays at the existing `DEFAULT_HOOK_TIMEOUT_MS` (non-fatal on timeout).
 
 ## Update semantics — spec rules
@@ -142,7 +149,7 @@ Flow:
    - Exists in user's vault but not in shard → left as user-created (not managed).
    - Exists in shard but not in user's vault → installed fresh, managed.
 3. Wizard collects values (same as install).
-4. Write `.shardmind/state.json` + `shard-values.yaml` + cache shard content to `.shardmind/templates/`.
+4. Write `.shardmind/state.json` + `.shardmind/shard.yaml` (cached) + `.shardmind/shard-schema.yaml` (cached) + vault-root `shard-values.yaml`; cache shard source files to `.shardmind/templates/`.
 5. Run post-install hook with `valuesAreDefaults` reflecting user's values, `newFiles` = files created in step 2d, `removedFiles` = [].
 6. Re-hash managed files per the usual post-hook semantics.
 
@@ -248,7 +255,7 @@ Paths reference current code. Detail to land in `ARCHITECTURE.md §3` + `IMPLEME
 16. New command: `source/commands/adopt.tsx` + `source/commands/hooks/use-adopt-machine.ts`.
 17. New component: 2-way diff UI (`source/components/AdoptDiffView.tsx`) + per-file prompt flow.
 18. `source/core/adopt-planner.ts` — walk existing vault, classify each file (matches-shard, differs-from-shard, user-created, shard-only), plan adoption operations.
-19. `source/core/adopt-executor.ts` — apply plan, write state.json + shard-values.yaml + templates/ cache; run post-install hook; re-hash managed files.
+19. `source/core/adopt-executor.ts` — apply plan; write installed-side metadata (`.shardmind/state.json` + cached `shard.yaml` + cached `shard-schema.yaml` + `.shardmind/templates/` cache) and vault-root `shard-values.yaml`; run post-install hook; re-hash managed files.
 
 ### Install non-interactive mode
 
@@ -256,7 +263,7 @@ Paths reference current code. Detail to land in `ARCHITECTURE.md §3` + `IMPLEME
 
 ### Testing
 
-21. **Invariant 1 byte-equivalence E2E test.** Clone shard repo to dir-A; run `shardmind install --defaults` to dir-B; recursively compare file trees. Expected delta: Tier 1 absent in B, `.shardmind/{state.json,shard-values.yaml,templates/}` present in B, content of all other files identical (content-hash match; modes and mtimes not compared). Any other diff fails.
+21. **Invariant 1 byte-equivalence E2E test.** Clone shard repo to dir-A; run `shardmind install --defaults` to dir-B; recursively compare file trees. Expected delta: Tier 1 absent in B; engine metadata present in B (`.shardmind/state.json`, `.shardmind/shard.yaml`, `.shardmind/shard-schema.yaml`, `.shardmind/templates/`, and vault-root `shard-values.yaml`); content of all other files identical (content-hash match; modes and mtimes not compared). Any other diff fails.
 22. **Unit tests**: `valuesAreDefaults` computation, `newFiles`/`removedFiles` diff, `.shardmindignore` glob matching, symlink rejection.
 23. Migrate `examples/minimal-shard/` to flat layout.
 24. Migrate `tests/fixtures/shards/` tarballs.

--- a/docs/SHARD-LAYOUT.md
+++ b/docs/SHARD-LAYOUT.md
@@ -67,7 +67,9 @@ my-vault/
 │   └── templates/                    ← cached source files; merge base for three-way merge on update
 │
 ├── shard-values.yaml                 ← user's answers from the wizard; vault-root (not under .shardmind/);
-│                                       named separately from .shardmind/ in VISION.md line 85
+│                                       named separately from .shardmind/ per VISION's
+│                                       "Delete .shardmind/ and shard-values.yaml — the vault
+│                                       continues to work" contract (§What ShardMind Is Not)
 │
 ├── <same vault content as source, with:>
 │   ├── .njk files in dotfolders rendered with user values (suffix stripped)
@@ -84,7 +86,7 @@ The installed-side path constants are authoritative in [`source/runtime/vault-pa
 
 ## Personalization model
 
-Three mechanisms. v0.1 deliberately does NOT ship Nunjucks rendering at vault-visible paths — hooks cover what obsidian-mind v6 needs. Adding rendered-content at visible paths is a v0.2 feature when a shard (likely research-wiki) pushes on it.
+Three mechanisms. v0.1 deliberately does NOT ship Nunjucks rendering at **user-visible vault paths** (root markdown, folder-level notes). The one rendering path v0.1 DOES ship is dotfolder `.njk` (item 2 below) — hidden from Obsidian's file view, so no clone-UX cost. Hooks cover any personalization that needs to touch user-visible content. Vault-visible `{{ values.X }}` is a v0.2 feature when a shard (likely research-wiki) pushes on it.
 
 1. **Module / agent selection.** Wizard values gate which files ship. Default wizard state is **all modules enabled, all agent files shipped** — per VISION's "ships complete" posture and Invariant 1. User deselects what they don't want.
 
@@ -294,7 +296,7 @@ Criterion: **obsidian-mind v6 does not need these to install, configure, or upgr
 | Dependency fetching | Shards vendor deps (obsidian-mind already does this) | `shard.yaml` gets `dependencies: []`; engine fetches on install. No break |
 | Structural variants | obsidian-mind is a single shard | Future feature; orthogonal to layout |
 | `shardmind init` | obsidian-mind author already has the shard; manual scaffolding works | New command; doesn't interact with existing install/update |
-| `shardmind eject` | Manual `rm -rf .shardmind/` works per additive principle (VISION.md line 85) | New command; orchestrates the manual delete + optional backup |
+| `shardmind eject` | Manual `rm -rf .shardmind/ shard-values.yaml` works per VISION's additive principle ("delete `.shardmind/` and `shard-values.yaml` — the vault continues to work ... ShardMind is additive, not load-bearing") | New command; orchestrates the manual delete + optional backup |
 | SOUL guided creation | Obsidian-mind product feature, not a shardmind engine concern | — |
 
 ## Transition

--- a/docs/SHARD-LAYOUT.md
+++ b/docs/SHARD-LAYOUT.md
@@ -1,0 +1,301 @@
+# Shard Layout (v6 contract)
+
+> **Status**: Design resolved for v0.1. All rules binding. Folds into [`ARCHITECTURE.md §3`](ARCHITECTURE.md) + [`AUTHORING.md §2`](AUTHORING.md) once implementation lands; until then this is the source of truth.
+> Discussion thread: [#70](https://github.com/breferrari/shardmind/issues/70).
+
+## Guiding principle
+
+From [`VISION.md`](../VISION.md):
+
+> **Not dependent on ShardMind to function.** A vault installed by ShardMind works exactly the same without ShardMind. Delete `.shardmind/` and `shard-values.yaml` — the vault continues to work in Obsidian and Claude Code. ShardMind is additive, not load-bearing.
+
+The mirror obligation: **the shard repo must also work as a vault without shardmind**. obsidian-mind's clone-and-open experience is the product that earned the flagship its 2k+ stars. ShardMind extends that experience with install-time personalization, safe upgrades, and modular composition — without subtracting anything.
+
+## Design posture: minimum viable sidecar
+
+A shard is today's vault + a `.shardmind/` sidecar. No wrapper directories, no partials/assembly system, no committed-rendered artifacts. The engine's full capability surface (Nunjucks rendering, merge, migrations, signals, values, modules, hooks, runtime) stays intact; only the *shard contract* is simplified.
+
+**Scope rule for this design**: v0.1 ships what obsidian-mind v6 needs to install, configure, and upgrade cleanly. Features not exercised by obsidian-mind v6 live in the Out-of-scope section with explicit justifications showing they can be added later without retroactive redesign.
+
+## What a shard is
+
+> **A shard is an Obsidian vault with a `.shardmind/` directory.** The vault is the product; `.shardmind/` is the opt-in sidecar that makes it installable, configurable, and upgradeable.
+
+Three testable properties:
+
+1. The shard repo at HEAD opens cleanly as a vault in Obsidian with no preparation.
+2. `shardmind install <shard>` with all defaults produces a vault byte-equivalent to `git clone <shard>` (modulo Tier 1 exclusions + `.shardmind/` engine metadata).
+3. Deleting `.shardmind/` on either side leaves a working vault.
+
+## Layout — source side (the shard repo)
+
+```
+my-shard/                             ← git repo root; also opens cleanly as an Obsidian vault
+│
+├── .shardmind/                       ← engine metadata (source-side)
+│   ├── shard.yaml                    ← manifest (name, version, values refs, modules, agents, hooks)
+│   ├── shard-schema.yaml             ← values schema → zod at runtime (every value MUST have a default)
+│   └── hooks/                        ← source-side only; engine reads from tarball, does NOT copy to installed vault
+│       ├── post-install.ts           ← optional, non-fatal
+│       └── post-update.ts            ← optional, non-fatal
+│
+├── .shardmindignore                  ← at repo root; glob semantics (negation deferred to v0.2)
+│
+├── <vault content at native paths>   ← brain/, work/, Home.md, bases/, etc. (v5.1's shape)
+│
+├── CLAUDE.md, AGENTS.md, GEMINI.md   ← verbatim; included per agent selection
+│
+├── .claude/, .codex/, .gemini/       ← agent operational layers (dotfolders; .njk allowed inside)
+├── .mcp.json, .obsidian/             ← config + Obsidian vault-shape config
+│
+├── README.md, LICENSE, CHANGELOG.md  ← installed by default; vault-relevant docs
+├── ARCHITECTURE.md, .gitignore       ← installed if present
+│
+└── <repo-only>                       ← .github/, CONTRIBUTING.md, README.<lang>.md, demo media
+                                        (excluded via .shardmindignore; see §File disposition)
+```
+
+## Layout — installed side (after `shardmind install`)
+
+```
+my-vault/
+│
+├── .shardmind/
+│   ├── state.json                    ← ownership + hashes + modules + agents + version + ref (if applicable)
+│   ├── shard-values.yaml             ← user's answers from the wizard
+│   └── templates/                    ← cached source files; merge base on update
+│
+├── <same vault content as source, with:>
+│   ├── .njk files in dotfolders rendered with user values (suffix stripped)
+│   ├── optional modules/agents included per wizard (default: all)
+│   └── hook may have personalized managed files (bound by Invariants 2 + 3)
+│
+├── README.md, LICENSE, CHANGELOG.md
+│
+└── (no .github/, no CONTRIBUTING.md, no translations, no demo media)
+```
+
+## Personalization model
+
+Three mechanisms. v0.1 deliberately does NOT ship Nunjucks rendering at vault-visible paths — hooks cover what obsidian-mind v6 needs. Adding rendered-content at visible paths is a v0.2 feature when a shard (likely research-wiki) pushes on it.
+
+1. **Module / agent selection.** Wizard values gate which files ship. Default wizard state is **all modules enabled, all agent files shipped** — per VISION's "ships complete" posture and Invariant 1. User deselects what they don't want.
+
+2. **Dotfolder `.njk` rendering.** Config files the user doesn't see (`.claude/settings.json.njk`, `.mcp.json.njk`) render with user values; suffix stripped on install. Obsidian hides dotfolders, so no clone-UX cost.
+
+3. **Post-install / post-update hooks.** Shard-author TypeScript reads `shard-values.yaml` and does whatever it wants — QMD bootstrap, programmatic edits to `brain/North Star.md`, MCP wiring. Bound by Invariants 2 + 3 below.
+
+## Installation invariants
+
+Three hard rules the engine + authors uphold. Enforced by CI.
+
+### Invariant 1 — `install --defaults` is byte-equivalent to clone
+
+If a user runs `shardmind install <shard>` and accepts every default value, the resulting vault is byte-identical to `git clone <shard>`, modulo:
+- Tier 1 engine exclusions (absent from install)
+- `.shardmind/{state.json, shard-values.yaml, templates/}` (present in install)
+
+Enforced by a CI E2E test. Any other delta is a shard-design bug. Byte-equivalence = content hash + relative path; modes and mtimes are not compared.
+
+### Invariant 2 — Hooks respect default-values
+
+Hooks that modify *managed* files (tracked in state.json) must no-op when `ctx.valuesAreDefaults === true`. Hooks that create *unmanaged* files (QMD indexes, MCP caches, etc.) may run unconditionally — they don't affect the 1-1 invariant. Engine computes `valuesAreDefaults` by deep-equal comparing each user value against its schema default.
+
+### Invariant 3 — Post-update hooks are additive-only by default
+
+Post-update hooks receive `ctx.newFiles: string[]` — managed files added in this update. By default, hook writes are restricted to those paths. Writing to any other managed file risks clobbering user edits or the three-way-merge resolution that just ran.
+
+## Values, schema, and modules — spec rules
+
+- **Every value has a default.** `shard-schema.yaml` validator rejects values without a `default` field. Makes Invariant 1 testable. Since v0.1 is the first contract, no migration cost. Authors model "required" behavior via non-empty defaults or hook validation.
+- **Default wizard state = all modules + all agents selected.** User deselects. Preserves Invariant 1 under default install.
+- **Agent selection is modeled as module gating.** Shard declares `agents` in `shard.yaml`; each agent is a module with file patterns. Uniform mechanism; no per-agent engine code.
+- **Module deselection = file-path gating, not section pruning.** Files under deselected module paths don't install. CLAUDE.md / AGENTS.md / GEMINI.md stay whole. Per VISION: "empty folders cost nothing; unused commands sit silently."
+
+## Hooks, state, and re-hash semantics
+
+- **Hook runs after state.json write.** Unchanged from current engine behavior.
+- **Engine re-hashes all managed files after hook exits — success OR failure.** State.json must reflect actual file content even if the hook partially failed (hook non-fatal contract preserved). Parallel hash compute; cost is bounded.
+- **`HookContext` extensions** (new fields in `source/runtime/types.ts`):
+  - `valuesAreDefaults: boolean` — true iff every user value equals its schema default
+  - `newFiles: string[]` — managed files added by this install/update (empty on clean install; populated on update with paths newly added in the new version)
+  - `removedFiles: string[]` — managed files removed by this update (module deselection). Hooks use this to maintain external state (QMD collection refs, MCP registrations).
+- **`.shardmind/hooks/` is source-side only.** The installed-side `.shardmind/` holds state.json + shard-values.yaml + templates/ cache — not hooks. Engine reads hook scripts from the extracted source tarball during install/update; hook scripts never get copied into the installed vault.
+- **Hook timeout** stays at the existing `DEFAULT_HOOK_TIMEOUT_MS` (non-fatal on timeout).
+
+## Update semantics — spec rules
+
+- **Default: latest stable release.** `shardmind update` resolves via GitHub's `/releases` filtered for non-prerelease. Closes the [`ARCHITECTURE §10.7`](ARCHITECTURE.md) gap (current code hits `/releases/latest` which 404s for beta-only repos).
+- **Prerelease opt-in.** `--include-prerelease` flag widens resolution to all releases. Explicit opt-in matches npm tag conventions; safer default.
+- **`--version <version>` flag.** Pins to a specific tag (stable or prerelease).
+- **Ref-install re-resolution.** Vaults installed via `github:owner/repo#<ref>` re-fetch HEAD of the ref on every `shardmind update` — ref installs track the branch/ref. `state.json` records the resolved commit SHA so status can show movement. Enables the shard-author dev loop (install from `#main`, iterate, update to pull new commits).
+
+## Adopt semantics — `shardmind adopt <shard>`
+
+For users who cloned before shardmind support (obsidian-mind v5.1 and earlier) and want to adopt the update engine retroactively.
+
+Flow:
+1. Fetch shard at target version into temp.
+2. Walk the user's existing vault (cwd); for each file:
+   - Matches shard content exactly → record hash, mark managed.
+   - Differs from shard content → 2-way diff UI (no base); user marks "my modification" (record user's content hash as managed) or "use shard's version" (overwrite, record shard hash as managed).
+   - Exists in user's vault but not in shard → left as user-created (not managed).
+   - Exists in shard but not in user's vault → installed fresh, managed.
+3. Wizard collects values (same as install).
+4. Write `.shardmind/state.json` + `shard-values.yaml` + cache shard content to `.shardmind/templates/`.
+5. Run post-install hook with `valuesAreDefaults` reflecting user's values, `newFiles` = files created in step 2d, `removedFiles` = [].
+6. Re-hash managed files per the usual post-hook semantics.
+
+Future `shardmind update` calls work normally — merge base is the adopt-time cache.
+
+Reuses: drift detection (`core/drift.ts`), install-executor, values wizard, hook runtime. New surfaces: 2-way diff UI component, adopt-planner, adopt-executor.
+
+## Naming decisions
+
+| Thing | Name | Rationale |
+|-------|------|-----------|
+| Engine metadata dir | `.shardmind/` on both sides | Mirror; same semantics source ↔ installed |
+| Exclusion file | `.shardmindignore` at repo root | `.gitignore` convention; more discoverable than nested |
+| Ignore-file semantics | Glob-only in v0.1 (negation deferred to v0.2) | obsidian-mind's patterns are simple excludes; negation not exercised |
+| Dotfolder render marker | `.njk` suffix | Obsidian hides dotfolders; no clone-UX cost |
+| No `templates/` in vocabulary | — | Obsidian reserves `templates/` for user note templates |
+
+## File disposition
+
+Three tiers. **Default is install.** Engine subtracts the minimum necessary; authors use `.shardmindignore` for the rest.
+
+### Tier 1 — engine-enforced exclusions (always excluded)
+
+Not author-configurable. Would break things or are meaningless off-GitHub:
+
+- `.shardmind/` (source-side) — installed side gets a fresh one with different contents
+- `.git/` — VCS database
+- `.github/` — GitHub CI, issue templates, `FUNDING.yml` (defensive: prevents accidental Actions activation if user git-pushes their vault)
+- `.obsidian/workspace.json`, `.obsidian/workspace-mobile.json`, `.obsidian/graph.json` — Obsidian ephemeral user-specific state
+- **Symbolic links anywhere in the shard source** — engine rejects with a clear error during the install walk. Security baseline: an untrusted shard could symlink outside the install target.
+
+Other Obsidian user-state files (`starred.json`, `bookmarks.json`, `backlink.json`, `page-preview.json`) are author-controlled via `.shardmindignore`. obsidian-mind v5.1 commits none of these, so no practical issue.
+
+### Tier 2 — default-included
+
+Everything else at the shard root. The annotations below cover the two audiences the layout must serve:
+
+| File | In the vault (installed user) | In the repo (contributor) |
+|------|------------------------------|---------------------------|
+| `README.md` | Instructions manual | GitHub landing page |
+| `LICENSE` | Attribution | Legal terms |
+| `CHANGELOG.md` | What changed — surfaced post-update | Release notes |
+| `ARCHITECTURE.md` (if shipped) | How the vault is structured | Design rationale |
+| `Home.md` | Obsidian landing note | Same |
+| `.gitignore` | Useful if user gits their vault | Git hygiene |
+| `.obsidian/` (minus Tier 1) | Vault-shape config; plugins pre-enabled | Same |
+| `.claude/`, `.codex/`, `.gemini/`, `.mcp.json`, `.claude-plugin/` | Operational layer | Same |
+| `scripts/` | Vault-bundled scripts (QMD bootstrap) | Same |
+| `vault-manifest.json` | Shard-author config; vault content | Same |
+| `bases/`, `brain/`, `work/`, … | Vault content folders | Same |
+| `templates/` | **Obsidian's** native user-templates folder | Same |
+
+### Tier 3 — author-controlled via `.shardmindignore`
+
+Glob-only in v0.1. Typical obsidian-mind-shaped shard:
+
+```gitignore
+# Repo-meta — meaningful on GitHub, noise in a vault
+CONTRIBUTING.md
+README.*.md              # translations (README.ja.md, README.ko.md, …)
+
+# Marketing media — not vault content
+*.gif
+*.png
+obsidian-mind-logo.*
+```
+
+**Rule of thumb**: if a file is a property of *the GitHub repo*, exclude it. If it's *about the shard's content*, leave it installed.
+
+## Engine change scope
+
+Paths reference current code. Detail to land in `ARCHITECTURE.md §3` + `IMPLEMENTATION.md §4.*`.
+
+### Walk + discovery
+
+1. `source/core/modules.ts` — replace `templates/` walk with shard-root walk; apply Tier 1 exclusions + root-level `.shardmindignore`. Remove partials gating (`mod.partials`). Reject symlinks with a clear error.
+2. `source/core/state.ts:117-119` — replace "Missing `templates/`" error with `.shardmind/shard.yaml`-absence check.
+3. `source/core/download.ts:78-79` — look for manifest/schema under `.shardmind/` in the extracted tarball.
+4. `source/core/fs-utils.ts:25-27` — remove `stripTemplatePrefix` helper (dead under flat layout).
+5. `source/runtime/vault-paths.ts` — add `SHARD_SOURCE_DIR = '.shardmind'`; keep installed-side `.shardmind/templates/` cache constant.
+6. New parser: `.shardmindignore` glob matcher (gitignore semantics minus negation).
+7. New data: canonical Tier 1 exclusion set.
+
+### Schema + values
+
+8. `source/core/schema.ts:66` — remove dead `partials` field; **add validation that every value has a `default`** (reject at parse time if missing).
+9. `source/runtime/types.ts:71` — remove `partials?: string[]` from module type.
+
+### Hooks + state
+
+10. `source/runtime/types.ts` — extend `HookContext` with `valuesAreDefaults: boolean`, `newFiles: string[]`, `removedFiles: string[]`.
+11. `source/core/install-executor.ts` + `source/core/update-executor.ts` — compute `valuesAreDefaults` (deep-equal values vs schema defaults), `newFiles` + `removedFiles` (diff current file set vs previous state). Re-hash all managed files after hook exits (success or failure) and write updated state.json.
+
+### Registry + update
+
+12. `source/core/registry.ts` — `github:owner/repo#<ref>` syntax (subsumes [#67](https://github.com/breferrari/shardmind/issues/67)); record resolved commit SHA for ref installs.
+13. `source/core/update-check.ts` — default resolution via `/releases` filtered non-prerelease; `--include-prerelease` widens. For ref-installs, re-resolve ref HEAD on every update.
+14. `source/commands/update.tsx` — add `--version <version>` flag; add `--include-prerelease` flag.
+15. `source/runtime/types.ts` — `ShardState.ref?` + `ShardState.resolvedSha?` for ref installs.
+
+### Adopt
+
+16. New command: `source/commands/adopt.tsx` + `source/commands/hooks/use-adopt-machine.ts`.
+17. New component: 2-way diff UI (`source/components/AdoptDiffView.tsx`) + per-file prompt flow.
+18. `source/core/adopt-planner.ts` — walk existing vault, classify each file (matches-shard, differs-from-shard, user-created, shard-only), plan adoption operations.
+19. `source/core/adopt-executor.ts` — apply plan, write state.json + shard-values.yaml + templates/ cache; run post-install hook; re-hash managed files.
+
+### Install non-interactive mode
+
+20. `source/commands/install.tsx` — add `--defaults` flag that accepts all schema defaults, enables all modules + agents, skips wizard prompts. Used by Invariant 1 CI test; also useful for CI/scripting.
+
+### Testing
+
+21. **Invariant 1 byte-equivalence E2E test.** Clone shard repo to dir-A; run `shardmind install --defaults` to dir-B; recursively compare file trees. Expected delta: Tier 1 absent in B, `.shardmind/{state.json,shard-values.yaml,templates/}` present in B, content of all other files identical (content-hash match; modes and mtimes not compared). Any other diff fails.
+22. **Unit tests**: `valuesAreDefaults` computation, `newFiles`/`removedFiles` diff, `.shardmindignore` glob matching, symlink rejection.
+23. Migrate `examples/minimal-shard/` to flat layout.
+24. Migrate `tests/fixtures/shards/` tarballs.
+25. Verify `tests/fixtures/merge/*` don't reference `templates/` prefixes.
+
+## Why `shardmind install` beats `git clone`
+
+The adoption pitch for obsidian-mind v6 users:
+
+1. **Configured on install.** Wizard applies values, modules, agents; hooks finish the job. No hand-editing.
+2. **Modular.** Skip modules you don't want — vault sized to your life.
+3. **Safe upgrades.** `shardmind update` three-way-merges your edits with upstream. Backstage has had this open for three years. This is the moat per `VISION.md §The Moat`.
+4. **Drift visibility.** `shardmind` status shows stale / diverged / user-created.
+5. **Retroactive adopt.** Cloned v5.1 already? `shardmind adopt github:breferrari/obsidian-mind` reconciles your vault in place.
+
+Compressed: **clone is free but frozen; install (or adopt) gives you a configured, upgradeable vault.**
+
+## Out of scope — deferred to v0.2
+
+Criterion: **obsidian-mind v6 does not need these to install, configure, or upgrade cleanly.** Each is a clean additive extension — deferring doesn't force retroactive design changes.
+
+| Deferred | Why not needed for v6 | How it's added later without redesign |
+|----------|----------------------|---------------------------------------|
+| `rendered_files` opt-in (Nunjucks at vault-visible paths) | obsidian-mind uses post-install hook to personalize `brain/North Star.md`; no `{{ }}` at vault-visible paths | New optional field in `shard.yaml`; `renderer.ts` extended to include files in the list during install. Existing `rendered_files: undefined` behavior stays |
+| `.shardmindignore` negation (`!pattern`) | obsidian-mind's patterns are simple excludes; no negation needed | Parser upgrade; existing glob-only files keep working |
+| Rename migrations + `adopt --from-version` | v6.0 = v5.1's structure + `.shardmind/` sidecar (zero renames vs v5.1). **If a future obsidian-mind release introduces renames, rename migrations must ship before that release** | New `migrations` field in `shard.yaml`; update-planner + adopt-planner consume it. Missing field = no-op (current behavior) |
+| Shard composition (multi-shard per vault) | One shard per vault in v0.1 | State.json extends from `{shard, version}` to `{shards: [...]}`; single-shard remains the special case. No break |
+| Dependency fetching | Shards vendor deps (obsidian-mind already does this) | `shard.yaml` gets `dependencies: []`; engine fetches on install. No break |
+| Structural variants | obsidian-mind is a single shard | Future feature; orthogonal to layout |
+| `shardmind init` | obsidian-mind author already has the shard; manual scaffolding works | New command; doesn't interact with existing install/update |
+| `shardmind eject` | Manual `rm -rf .shardmind/` works per additive principle (VISION.md line 85) | New command; orchestrates the manual delete + optional backup |
+| SOUL guided creation | Obsidian-mind product feature, not a shardmind engine concern | — |
+
+## Transition
+
+No shard migration required — zero shards published under the v0.1 `templates/` contract. obsidian-mind v6 is the first shard under this contract.
+
+- `examples/minimal-shard/` restructures to the flat layout during Day 1-4 build.
+- obsidian-mind v6 conversion (Day 5): v5.1's structure + `.shardmind/` sidecar + any dotfolder `.njk` for config rendering.
+- Research-wiki shard (Day 6): same flat layout; uses hooks for any personalization (no `rendered_files` dependency).
+- `docs/ARCHITECTURE.md §3`, `docs/AUTHORING.md §2` + §7, `docs/IMPLEMENTATION.md §4.*` rewrite once this design lands in code.
+- [#67](https://github.com/breferrari/shardmind/issues/67) (branch/ref install) and [#69](https://github.com/breferrari/shardmind/issues/69) (`.shardmind/` source layout) subsumed by [#70](https://github.com/breferrari/shardmind/issues/70).


### PR DESCRIPTION
## Summary

- Lands the resolved v6 shard-layout design: a shard is an Obsidian vault + a \`.shardmind/\` sidecar.
- Codifies three binding invariants enforced by CI: \`install --defaults\` ≡ clone, hooks respect defaults, post-update hooks additive-only.
- Scopes implementation to exactly what obsidian-mind v6 needs for v0.1; v0.2 deferrals are enumerated with justification showing each is a clean additive extension.

Preserves clone-and-open as the flagship's hero flow while enabling shardmind install/update/adopt. Resolves [#70](https://github.com/breferrari/shardmind/issues/70); subsumes #67 and #69.

## Test plan

- [ ] Doc renders correctly on GitHub with all internal anchors resolving
- [ ] Cross-references to VISION.md / ARCHITECTURE.md / IMPLEMENTATION.md / AUTHORING.md land
- [ ] Issue #70 body matches the doc's scope decisions (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)