### PR TITLE
feat(core): engine version-compatibility check — requires.shardmind (#121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,18 @@ Part of [#102](https://github.com/breferrari/shardmind/issues/102) (the engine +
 
 - **Docs**: `docs/SHARD-LAYOUT.md` (Invariant 2 now engine-enforced, new Invariant 4 for bootstrap fingerprint, rewritten §Hook lifecycle, layout tree), `docs/AUTHORING.md §6` (three-slot reference + per-slot ctx + worked migration), `docs/ARCHITECTURE.md §9.3`, `docs/IMPLEMENTATION.md §4.16` + new §4.16a/§4.16b, `docs/ERRORS.md` (new `HOOK_SLOT_CONFLICT` + non-fatal hook-warning section), `CLAUDE.md` (two new core modules + module table).
 
+### Added (engine version-compatibility check — #121)
+
+Closes [#121](https://github.com/breferrari/shardmind/issues/121). The guard that ships alongside the #102 hook lifecycle: a shard can declare `requires.shardmind` (a semver range the running engine must satisfy), and install/update/adopt refuse with a clear upgrade hint when an older engine can't satisfy it — instead of silently ignoring new-engine features.
+
+- **`requires.shardmind`** — optional semver range on `shard.yaml`, validated as a range at parse time (a typo surfaces as `MANIFEST_VALIDATION_FAILED`). Absent → no check, so every pre-#121 shard keeps installing on any engine.
+
+- **Enforced before any vault write.** `assertEngineCompatible` (pure, in `source/core/manifest.ts`) runs in all three command machines immediately after `parseManifest`. On a mismatch it throws the new `SHARDMIND_VERSION_MISMATCH` error code (message names the range + running version; hint is `npm i -g shardmind@latest`). A refused command leaves the vault untouched. Comparison uses `includePrerelease` so a prerelease engine ahead of the floor isn't wrongly blocked.
+
+- **Unresolvable engine version skips the check.** A new `resolveEngineVersion` helper (`source/commands/hooks/cli-version.ts`) maps the `PKG_VERSION_FALLBACK` sentinel to `undefined`; an engine that can't locate its own `package.json` (a bundle-layout quirk) must not hard-block a real install.
+
+- **Tests**: `tests/unit/manifest.test.ts` (range parse + reject; `assertEngineCompatible` matrix — satisfied / lower-bound / too-old / absent / unknown-version skip / prerelease) and a Layer 1 flow test (`install-flow.test.ts` scenario 12 — `>=99.0.0` refuses + no `state.json`). **Docs**: `docs/AUTHORING.md` (field reference + §6 note), `docs/ERRORS.md` (`SHARDMIND_VERSION_MISMATCH`), `schemas/shard.schema.json` (`requires.shardmind`).
+
 ### Added (multiselect value type — #101)
 
 Closes [#101](https://github.com/breferrari/shardmind/issues/101). Promotes `multiselect` from a partially-wired type (engine validation existed; the wizard rendered a comma-separated text fallback flagged in-code as v0.2 polish) to a first-class value type. Lets a shard author ask one checkbox question ("Which agents do you use?") instead of N booleans. Scope is the value type + widget; gating *which modules install* on a multiselect value remains [#80](https://github.com/breferrari/shardmind/issues/80) (v0.2).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Closes [#121](https://github.com/breferrari/shardmind/issues/121). The guard tha
 
 - **Unresolvable engine version skips the check.** A new `resolveEngineVersion` helper (`source/commands/hooks/cli-version.ts`) maps the `PKG_VERSION_FALLBACK` sentinel to `undefined`; an engine that can't locate its own `package.json` (a bundle-layout quirk) must not hard-block a real install.
 
-- **Tests**: `tests/unit/manifest.test.ts` (range parse + reject; `assertEngineCompatible` matrix — satisfied / lower-bound / too-old / absent / unknown-version skip / prerelease) and a Layer 1 flow test (`install-flow.test.ts` scenario 12 — `>=99.0.0` refuses + no `state.json`). **Docs**: `docs/AUTHORING.md` (field reference + §6 note), `docs/ERRORS.md` (`SHARDMIND_VERSION_MISMATCH`), `schemas/shard.schema.json` (`requires.shardmind`).
+- **Tests**: `tests/unit/manifest.test.ts` (range parse + reject incl. empty/whitespace → `MANIFEST_VALIDATION_FAILED` and deliberate `*`/`x` match-all; `assertEngineCompatible` matrix — satisfied / lower-bound / too-old / absent / unknown-version skip / prerelease-ahead / match-all) and Layer 1 flow tests refusing `>=99.0.0` before any write across all three commands: install (scenario 12, no `state.json`), update (scenario 18, `state.json` byte-unchanged), adopt (scenario 24, no `.shardmind/`). **Docs**: `docs/AUTHORING.md` (field reference + §6 note), `docs/ERRORS.md` (`SHARDMIND_VERSION_MISMATCH`), `schemas/shard.schema.json` (`requires.shardmind`).
 
 ### Added (multiselect value type — #101)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -114,7 +114,7 @@ Demoted from "Foundation BLOCKING" on 2026-04-27 (see [#113 comment](https://git
 [#102](https://github.com/breferrari/shardmind/issues/102) was previously listed as a peer to #100 (wizard scroll) and #101 (multiselect) in the flagship-UX list. It is not a peer — it deprecates the `post-install` hook (which obsidian-mind v6.0 ships with), changes Invariants 2 + 3 from comment-checked to engine-checked, requires a `docs/SHARD-LAYOUT.md` spec update, and forces every shard author to migrate. Reclassified as a single-issue release block on 2026-04-27.
 
 - [ ] **Hook lifecycle split — bootstrap / personalize / post-update** ([#102](https://github.com/breferrari/shardmind/issues/102)). Engine + fixture + docs landed in PR (the three-slot orchestrator, detect-and-warn boundaries, engine-enforced Invariant 2, bootstrap fingerprint, legacy deprecation); issue stays open pending the release-window items below. Acceptance:
-  - [ ] [#121](https://github.com/breferrari/shardmind/issues/121) (engine version-compatibility check) lands first or in the same release.
+  - [x] [#121](https://github.com/breferrari/shardmind/issues/121) (engine version-compatibility check) lands first or in the same release.
   - [x] `docs/SHARD-LAYOUT.md` updated with the new lifecycle.
   - [x] `docs/AUTHORING.md` documents the migration path with a worked example.
   - [ ] obsidian-mind hook migration ships in the same release window (cross-repo coupling — see Cross-repo dependencies below).
@@ -169,7 +169,7 @@ Deferred from v0.1 per [`docs/SHARD-LAYOUT.md §Out of scope`](docs/SHARD-LAYOUT
 
 Ordered by cost ascending. Sizes are rough — small (≤1 PR), medium (2–4 PRs), large (5+ PRs touching multiple subsystems), anchor (multi-month, rideable releases on top).
 
-- [ ] **small** — Engine version-compatibility check on install ([#121](https://github.com/breferrari/shardmind/issues/121)). Should land first or with #102 — see Hook lifecycle.
+- [x] **small** — Engine version-compatibility check on install ([#121](https://github.com/breferrari/shardmind/issues/121)). Landed in the v0.1.x #102 release window (`requires.shardmind` + `SHARDMIND_VERSION_MISMATCH`, enforced on install/update/adopt).
 - [ ] **small** — `shardmind eject` command ([#83](https://github.com/breferrari/shardmind/issues/83))
 - [ ] **medium** — `shardmind init` command for shard authors ([#84](https://github.com/breferrari/shardmind/issues/84))
 - [ ] **medium** — Guided file creation (`guided_files` schema + third install phase) ([#79](https://github.com/breferrari/shardmind/issues/79))

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -200,6 +200,7 @@ homepage: https://github.com/breferrari/obsidian-mind
 requires:
   obsidian: ">=1.12.0"
   node: ">=18.0.0"
+  shardmind: ">=0.2.0"   # engine-enforced: install/update/adopt refuse on an older engine
 
 dependencies:
   - name: obsidian-skills

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -79,6 +79,7 @@ homepage: https://github.com/breferrari/obsidian-mind
 
 requires:
   node: ">=22.0.0"
+  shardmind: ">=0.2.0"
 
 hooks:
   bootstrap:
@@ -102,6 +103,7 @@ hooks:
 | `homepage` | no | URL. |
 | `requires.obsidian` | no | Semver range. Advisory only in v0.1. |
 | `requires.node` | no | Semver range. Applied when hooks run. |
+| `requires.shardmind` | no | Semver range the running engine must satisfy. **Enforced** — install/update/adopt refuse with `SHARDMIND_VERSION_MISMATCH` before any vault write when the engine is older. Absent → no check. Declare it once your shard depends on an engine feature (e.g. the post-#102 hook lifecycle). See §6. |
 | `dependencies` | no | Array of `{ name, namespace, version }`. Vendored in v0.1 (pre-install manually); auto-fetched in v0.2+. |
 | `hooks.bootstrap` | no | Path string, or `{ script, fingerprint? }`. Unmanaged-path setup. Runs on install/adopt + on update when `fingerprint` changes. See §6. |
 | `hooks.personalize` | no | Path relative to shard root. Managed-file edits. Runs on install/adopt only; skipped when values are defaults. See §6. |
@@ -403,6 +405,15 @@ export default async function (ctx: PersonalizeContext): Promise<void> {
 ```
 
 and the manifest moves from `hooks.post-install: hooks/post-install.ts` to the three-slot form above. Declaring `post-install` alongside `bootstrap`/`personalize` is rejected at parse time (`HOOK_SLOT_CONFLICT`) — finish the migration in one step. The legacy slot is honored until at least 0.3.0; migrate before then.
+
+Once your shard relies on the new lifecycle, declare the engine that introduced it so older engines refuse cleanly instead of mis-running the hook:
+
+```yaml
+requires:
+  shardmind: ">=0.2.0"
+```
+
+Install/update/adopt then refuse with `SHARDMIND_VERSION_MISMATCH` and an upgrade hint when run on an engine that can't satisfy the range — before any vault write. Absent → no check, so pre-lifecycle shards keep installing on any engine.
 
 ### Capabilities
 

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -135,6 +135,14 @@ Thrown by `source/core/manifest.ts`.
 
 **Remedy:** Remove `hooks.post-install` once you've split it into `bootstrap` (unmanaged setup) + `personalize` (managed edits). See [`docs/AUTHORING.md §6`](AUTHORING.md) for the worked migration.
 
+### `SHARDMIND_VERSION_MISMATCH`
+
+**Meaning:** The shard declares `requires.shardmind` (a semver range the engine must satisfy) and the ShardMind engine you're running is too old. Install, update, and adopt all check this immediately after parsing `shard.yaml`, before any vault write — so a refused command leaves the vault untouched.
+
+**Typical cause:** Installing a shard built against a newer engine feature (e.g. the post-#102 hook lifecycle) with an older globally-installed `shardmind`.
+
+**Remedy:** Upgrade the engine — `npm i -g shardmind@latest` — then retry. (Shard authors: the range lives at `requires.shardmind`; absent means no check. See [`docs/AUTHORING.md §3`](AUTHORING.md).)
+
 ---
 
 ## Schema (`shard-schema.yaml` parsing)

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -339,6 +339,9 @@ const ShardManifestSchema = z.object({
   requires: z.object({
     obsidian: z.string().optional(),
     node: z.string().optional(),
+    // Engine-enforced semver range (#121). Validated as a non-empty range at
+    // parse time; checked by assertEngineCompatible before any vault write.
+    shardmind: z.string().refine(v => v.trim() && semver.validRange(v), 'range').optional(),
   }).optional(),
   dependencies: z.array(z.object({
     name: z.string(),

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -349,8 +349,18 @@ const ShardManifestSchema = z.object({
     version: z.string(),
   })).default([]),
   hooks: z.object({
-    'post-install': z.string().optional(),
+    // Three named slots since the #102 lifecycle split. `bootstrap` accepts
+    // the bare-string form or `{ script, fingerprint? }` (normalized to the
+    // object shape post-parse).
+    bootstrap: z.union([
+      z.string().transform((script) => ({ script })),
+      z.object({ script: z.string(), fingerprint: z.string().optional() }),
+    ]).optional(),
+    personalize: z.string().optional(),
     'post-update': z.string().optional(),
+    // Deprecated combined hook — mutually exclusive with bootstrap/personalize
+    // (rejected post-parse as HOOK_SLOT_CONFLICT). Honored ≥1 minor release.
+    'post-install': z.string().optional(),
     // Per-shard hook execution timeout in milliseconds. Default 30_000
     // when absent; clamped to 1_000..600_000 at validation time.
     timeout_ms: z.number().int().min(1_000).max(600_000).optional(),
@@ -358,9 +368,14 @@ const ShardManifestSchema = z.object({
 });
 ```
 
+`requires.shardmind` is validated as a non-empty semver range at parse time
+and enforced before any vault write by `assertEngineCompatible` (#121).
+
 **Error cases**:
-- YAML parse error → `"shard.yaml is not valid YAML: {error}"`
-- Zod validation error → `"shard.yaml validation failed: {field}: {message}"`
+- YAML parse error → `MANIFEST_INVALID_YAML`
+- Zod validation error → `MANIFEST_VALIDATION_FAILED` (`"{field}: {message}"`)
+- Deprecated `post-install` declared alongside `bootstrap`/`personalize` → `HOOK_SLOT_CONFLICT` (#102)
+- Running engine can't satisfy `requires.shardmind` → `SHARDMIND_VERSION_MISMATCH` (#121, thrown by `assertEngineCompatible`, not `parseManifest`)
 
 **Dependencies**: `yaml`, `zod`, `semver`.
 

--- a/schemas/shard.schema.json
+++ b/schemas/shard.schema.json
@@ -43,16 +43,20 @@
       "format": "uri"
     },
     "requires": {
-      "description": "Environment requirements. ShardMind does not enforce these in v0.1 but tooling may warn.",
+      "description": "Environment requirements. `obsidian` / `node` are advisory in v0.1; `shardmind` is engine-enforced before any vault write (install/update/adopt).",
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "obsidian": {
-          "description": "Minimum Obsidian version required (semver range).",
+          "description": "Minimum Obsidian version required (semver range). Advisory only.",
           "type": "string"
         },
         "node": {
-          "description": "Minimum Node.js version required for hook execution (semver range).",
+          "description": "Minimum Node.js version required for hook execution (semver range). Advisory only.",
+          "type": "string"
+        },
+        "shardmind": {
+          "description": "Semver range the running ShardMind engine must satisfy. Enforced: install/update/adopt refuse with SHARDMIND_VERSION_MISMATCH when unmet. Absent means no check.",
           "type": "string"
         }
       }

--- a/source/commands/hooks/cli-version.ts
+++ b/source/commands/hooks/cli-version.ts
@@ -65,3 +65,19 @@ export function resolvePkgVersion(startUrl: string): string {
   }
   return PKG_VERSION_FALLBACK;
 }
+
+/**
+ * The running engine version for compatibility checks (#121), or `undefined`
+ * when it can't be resolved (the `PKG_VERSION_FALLBACK` sentinel).
+ *
+ * Unlike the self-update banner — which keeps the `'0.0.0'` sentinel so it
+ * errs toward over-notifying — a hard install/update/adopt refusal needs the
+ * opposite bias: an unknown engine version must not block a real install over
+ * a bundle-layout quirk. `assertEngineCompatible` treats `undefined` as
+ * "skip the check". Resolved from this module's own location; the walk finds
+ * shardmind's `package.json` regardless of which bundled chunk starts it.
+ */
+export function resolveEngineVersion(): string | undefined {
+  const version = resolvePkgVersion(import.meta.url);
+  return version === PKG_VERSION_FALLBACK ? undefined : version;
+}

--- a/source/commands/hooks/use-adopt-machine.ts
+++ b/source/commands/hooks/use-adopt-machine.ts
@@ -27,7 +27,8 @@ import type {
 import { ShardMindError } from '../../runtime/types.js';
 import { resolve as resolveRef } from '../../core/registry.js';
 import { downloadShard } from '../../core/download.js';
-import { parseManifest } from '../../core/manifest.js';
+import { parseManifest, assertEngineCompatible } from '../../core/manifest.js';
+import { resolveEngineVersion } from './cli-version.js';
 import { parseSchema, buildValuesValidator } from '../../core/schema.js';
 import { loadValuesYaml } from '../../core/values-io.js';
 import {
@@ -194,6 +195,9 @@ export function useAdoptMachine(input: UseAdoptMachineInput): UseAdoptMachineOut
 
         setPhase({ kind: 'loading', message: 'Parsing manifest and schema…' });
         const manifest = await parseManifest(temp.manifest);
+        // Refuse before any vault write if this engine can't satisfy the
+        // shard's declared requires.shardmind range (#121).
+        assertEngineCompatible(manifest, resolveEngineVersion());
         const schema = await parseSchema(temp.schema);
 
         const prefill = valuesFile ? await loadValuesFile(valuesFile, schema) : {};

--- a/source/commands/hooks/use-install-machine.ts
+++ b/source/commands/hooks/use-install-machine.ts
@@ -24,7 +24,8 @@ import { ShardMindError } from '../../runtime/types.js';
 
 import { resolve as resolveRef } from '../../core/registry.js';
 import { downloadShard } from '../../core/download.js';
-import { parseManifest } from '../../core/manifest.js';
+import { parseManifest, assertEngineCompatible } from '../../core/manifest.js';
+import { resolveEngineVersion } from './cli-version.js';
 import { parseSchema, buildValuesValidator } from '../../core/schema.js';
 import { readState } from '../../core/state.js';
 import {
@@ -206,6 +207,9 @@ export function useInstallMachine(input: UseInstallMachineInput): UseInstallMach
 
         setPhase({ kind: 'loading', message: 'Parsing manifest and schema…' });
         const manifest = await parseManifest(temp.manifest);
+        // Refuse before any vault write if this engine can't satisfy the
+        // shard's declared requires.shardmind range (#121).
+        assertEngineCompatible(manifest, resolveEngineVersion());
         const schema = await parseSchema(temp.schema);
 
         const prefill = valuesFile ? await loadValuesFile(valuesFile, schema) : {};

--- a/source/commands/hooks/use-update-machine.ts
+++ b/source/commands/hooks/use-update-machine.ts
@@ -33,7 +33,8 @@ import { ShardMindError } from '../../runtime/types.js';
 import { resolve as resolveRef } from '../../core/registry.js';
 import { primeLatestVersion } from '../../core/update-check.js';
 import { downloadShard } from '../../core/download.js';
-import { parseManifest } from '../../core/manifest.js';
+import { parseManifest, assertEngineCompatible } from '../../core/manifest.js';
+import { resolveEngineVersion } from './cli-version.js';
 import { parseSchema, buildValuesValidator } from '../../core/schema.js';
 import { readState } from '../../core/state.js';
 import { detectDrift } from '../../core/drift.js';
@@ -261,6 +262,9 @@ export function useUpdateMachine(input: UseUpdateMachineInput): UseUpdateMachine
 
         setPhase({ kind: 'loading', message: 'Parsing new manifest and schema…' });
         const newManifest = await parseManifest(temp.manifest);
+        // Refuse before any vault write if this engine can't satisfy the new
+        // shard's declared requires.shardmind range (#121).
+        assertEngineCompatible(newManifest, resolveEngineVersion());
         const newSchema = await parseSchema(temp.schema);
 
         // Up-to-date short-circuit. For ref installs, "up-to-date" is

--- a/source/core/manifest.ts
+++ b/source/core/manifest.ts
@@ -18,6 +18,13 @@ export const ShardManifestSchema = z.object({
   requires: z.object({
     obsidian: z.string().optional(),
     node: z.string().optional(),
+    // Semver range the running engine must satisfy (#121). Validated as a
+    // range at parse time (same posture as `version`'s semver.valid refine) so
+    // a typo surfaces as MANIFEST_VALIDATION_FAILED, not a runtime mismatch.
+    shardmind: z
+      .string()
+      .refine(v => semver.validRange(v) !== null, 'Must be a valid semver range')
+      .optional(),
   }).optional(),
   dependencies: z.array(z.object({
     name: z.string(),
@@ -115,4 +122,35 @@ export async function parseManifest(filePath: string): Promise<ShardManifest> {
   }
 
   return result.data as ShardManifest;
+}
+
+/**
+ * Refuse install/update/adopt when the running engine can't satisfy the shard's
+ * declared `requires.shardmind` range (#121). Pure — the caller supplies the
+ * engine version (see `resolveEngineVersion` in commands/hooks/cli-version.ts),
+ * so this stays testable without process state and keeps the `'0.0.0'` fallback
+ * sentinel a commands-layer concern.
+ *
+ * No-ops when:
+ *  - the manifest declares no `requires.shardmind` (every pre-#121 shard), or
+ *  - `engineVersion` is `undefined` / not valid semver — an unresolvable engine
+ *    version is a bundle-layout quirk, not a reason to hard-block a real install.
+ *
+ * `includePrerelease` so a 0.x / prerelease engine (e.g. `0.2.0-beta.1`)
+ * compares sanely against a stable `>=0.2.0`-style range.
+ */
+export function assertEngineCompatible(
+  manifest: ShardManifest,
+  engineVersion: string | undefined,
+): void {
+  const range = manifest.requires?.shardmind;
+  if (!range) return;
+  if (!engineVersion || semver.valid(engineVersion) === null) return;
+  if (semver.satisfies(engineVersion, range, { includePrerelease: true })) return;
+
+  throw new ShardMindError(
+    `This shard requires shardmind ${range}, but you are running ${engineVersion}.`,
+    'SHARDMIND_VERSION_MISMATCH',
+    'Upgrade the engine with `npm i -g shardmind@latest`, then retry.',
+  );
 }

--- a/source/core/manifest.ts
+++ b/source/core/manifest.ts
@@ -21,9 +21,14 @@ export const ShardManifestSchema = z.object({
     // Semver range the running engine must satisfy (#121). Validated as a
     // range at parse time (same posture as `version`'s semver.valid refine) so
     // a typo surfaces as MANIFEST_VALIDATION_FAILED, not a runtime mismatch.
+    // The non-empty guard is load-bearing: `semver.validRange('')` and any
+    // whitespace-only string both normalize to `*` (match-all), so without it
+    // a declared-but-empty `shardmind: ""` would parse clean and then silently
+    // disable the check — worse than a typo, because it reads as a constraint.
+    // Deliberate match-all (`*`, `x`) stays valid.
     shardmind: z
       .string()
-      .refine(v => semver.validRange(v) !== null, 'Must be a valid semver range')
+      .refine(v => v.trim().length > 0 && semver.validRange(v) !== null, 'Must be a valid, non-empty semver range')
       .optional(),
   }).optional(),
   dependencies: z.array(z.object({
@@ -136,8 +141,11 @@ export async function parseManifest(filePath: string): Promise<ShardManifest> {
  *  - `engineVersion` is `undefined` / not valid semver — an unresolvable engine
  *    version is a bundle-layout quirk, not a reason to hard-block a real install.
  *
- * `includePrerelease` so a 0.x / prerelease engine (e.g. `0.2.0-beta.1`)
- * compares sanely against a stable `>=0.2.0`-style range.
+ * `includePrerelease` so a prerelease engine *ahead* of the floor (e.g.
+ * `0.3.0-beta.1` against `>=0.2.0`) isn't wrongly blocked — default
+ * `satisfies` rejects any prerelease against a stable range. A prerelease of
+ * the required version itself (`0.2.0-beta.1`) still fails: it sorts before
+ * the `0.2.0` release, so the engine is genuinely too old.
  */
 export function assertEngineCompatible(
   manifest: ShardManifest,

--- a/source/runtime/errors.ts
+++ b/source/runtime/errors.ts
@@ -23,6 +23,9 @@ export type ErrorCode =
   | 'MANIFEST_VALIDATION_FAILED'
   | 'HOOK_SLOT_CONFLICT'
 
+  // Engine compatibility (requires.shardmind vs. running engine, #121)
+  | 'SHARDMIND_VERSION_MISMATCH'
+
   // Shard schema (shard-schema.yaml)
   | 'SCHEMA_NOT_FOUND'
   | 'SCHEMA_READ_FAILED'

--- a/source/runtime/types.ts
+++ b/source/runtime/types.ts
@@ -16,6 +16,12 @@ export interface ShardManifest {
   requires?: {
     obsidian?: string;
     node?: string;
+    /**
+     * Semver range the running ShardMind engine must satisfy. Enforced by
+     * `assertEngineCompatible` before any vault write on install/update/adopt
+     * (#121). Absent → no check (every pre-#121 shard keeps installing).
+     */
+    shardmind?: string;
   };
   dependencies: ShardDependency[];
   hooks: {

--- a/tests/component/flows/adopt-flow.test.tsx
+++ b/tests/component/flows/adopt-flow.test.tsx
@@ -19,6 +19,7 @@ import {
   mountAdopt,
   makeVaultDir,
   cleanupVault,
+  buildCustomTarball,
   driveMinimalWizard,
   driveDiffIteration,
   SHARD_SLUG,
@@ -29,10 +30,16 @@ import {
 import { tick, waitFor, ENTER, ARROW_DOWN } from '../helpers.js';
 import { createInstalledVault, type Vault } from '../../e2e/helpers/vault.js';
 
+const SLUG_VERSION_MISMATCH = 'acme/adopt-future-engine';
+
 describe('adopt command — Layer 1 flow tests (#111 Phase 1, scenarios 19-23)', () => {
   const getCtx = setupFlowSuite({
     shards: {
       [SHARD_SLUG]: {
+        versions: {} as Record<string, string>,
+        latest: '0.1.0',
+      },
+      [SLUG_VERSION_MISMATCH]: {
         versions: {} as Record<string, string>,
         latest: '0.1.0',
       },
@@ -227,6 +234,49 @@ describe('adopt command — Layer 1 flow tests (#111 Phase 1, scenarios 19-23)',
       await cleanupVault(vault);
     }
   }, 60_000);
+
+  // ───── Scenario 24: requires.shardmind unsatisfiable → refuse before any write (#121) ─────
+
+  it('24. requires.shardmind not satisfied → SHARDMIND_VERSION_MISMATCH, no .shardmind written (#121)', async () => {
+    const { stub } = getCtx();
+    const vault = await makeVaultDir('s24-adopt-version-mismatch');
+    try {
+      // A pre-existing user file the adopt would otherwise classify. The
+      // refusal must fire before the planner touches it.
+      await writeRel(vault, 'Home.md', '# user-only Home\n');
+      const tarPath = await buildCustomTarball({
+        version: '0.1.0',
+        prefix: 'adopt-future-engine-0.1.0',
+        manifestOverrides: {
+          hooks: {},
+          name: 'adopt-future-engine',
+          namespace: 'flowtest',
+          requires: { shardmind: '>=99.0.0' },
+        },
+        outDir: vault,
+      });
+      stub.setRef(SLUG_VERSION_MISMATCH, 'v0.1.0', STUB_SHA, tarPath);
+
+      const r = mountAdopt({
+        shardRef: `github:${SLUG_VERSION_MISMATCH}#v0.1.0`,
+        vaultRoot: vault,
+      });
+      await waitFor(
+        r.lastFrame,
+        (f) => /requires shardmind >=99\.0\.0/.test(f),
+        30_000,
+      );
+      expect(r.lastFrame() ?? '').toMatch(/SHARDMIND_VERSION_MISMATCH/);
+      // No engine state written — the vault was never adopted.
+      const stateExists = await fs
+        .stat(path.join(vault, '.shardmind', 'state.json'))
+        .then((s) => s.isFile())
+        .catch(() => false);
+      expect(stateExists).toBe(false);
+    } finally {
+      await cleanupVault(vault);
+    }
+  }, 45_000);
 });
 
 async function writeRel(vault: string, rel: string, content: string): Promise<void> {

--- a/tests/component/flows/install-flow.test.tsx
+++ b/tests/component/flows/install-flow.test.tsx
@@ -40,6 +40,7 @@ const SLUG_MIDDLE_DEFAULT = 'acme/select-middle';
 const SLUG_NUMBER_TYPE = 'acme/number-range';
 const SLUG_COMPUTED = 'acme/computed-default';
 const SLUG_MULTISELECT = 'acme/multiselect';
+const SLUG_VERSION_MISMATCH = 'acme/future-engine';
 
 describe('install command — Layer 1 flow tests (#111 Phase 1, scenarios 1–10)', () => {
   const getCtx = setupFlowSuite({
@@ -61,6 +62,10 @@ describe('install command — Layer 1 flow tests (#111 Phase 1, scenarios 1–10
         latest: '0.1.0',
       },
       [SLUG_MULTISELECT]: {
+        versions: {} as Record<string, string>,
+        latest: '0.1.0',
+      },
+      [SLUG_VERSION_MISMATCH]: {
         versions: {} as Record<string, string>,
         latest: '0.1.0',
       },
@@ -526,6 +531,52 @@ describe('install command — Layer 1 flow tests (#111 Phase 1, scenarios 1–10
       const valuesYaml = await fs.readFile(path.join(vault, 'shard-values.yaml'), 'utf-8');
       const parsed = parseYaml(valuesYaml) as Record<string, unknown>;
       expect(parsed['agents']).toEqual(['claude', 'codex']);
+    } finally {
+      await cleanupVault(vault);
+    }
+  }, 45_000);
+
+  // ───── Scenario 12: requires.shardmind unsatisfiable → refuse before any write (#121) ─────
+
+  it('12. requires.shardmind not satisfied → SHARDMIND_VERSION_MISMATCH, no vault write (#121)', async () => {
+    const { stub } = getCtx();
+    const vault = await makeVaultDir('s12-version-mismatch');
+    try {
+      // A shard demanding a far-future engine. The running test engine
+      // (shardmind's own package.json version) can never satisfy >=99.0.0,
+      // so the check must fire and refuse before the wizard or any write.
+      const tarPath = await buildCustomTarball({
+        version: '0.1.0',
+        prefix: 'future-engine-0.1.0',
+        manifestOverrides: {
+          hooks: {},
+          name: 'future-engine',
+          namespace: 'flowtest',
+          requires: { shardmind: '>=99.0.0' },
+        },
+        outDir: vault,
+      });
+      stub.setRef(SLUG_VERSION_MISMATCH, 'v0.1.0', STUB_SHA, tarPath);
+
+      const r = mountInstall({
+        shardRef: `github:${SLUG_VERSION_MISMATCH}#v0.1.0`,
+        vaultRoot: vault,
+      });
+      await waitFor(
+        r.lastFrame,
+        (f) => /requires shardmind >=99\.0\.0/.test(f),
+        30_000,
+      );
+      const frame = r.lastFrame() ?? '';
+      expect(frame).toMatch(/SHARDMIND_VERSION_MISMATCH/);
+      expect(frame).toMatch(/npm i -g shardmind@latest/);
+      // The refusal happens after parseManifest but before any executor
+      // runs — the vault must hold no engine state.
+      const stateExists = await fs
+        .stat(path.join(vault, '.shardmind', 'state.json'))
+        .then((s) => s.isFile())
+        .catch(() => false);
+      expect(stateExists).toBe(false);
     } finally {
       await cleanupVault(vault);
     }

--- a/tests/component/flows/update-flow.test.tsx
+++ b/tests/component/flows/update-flow.test.tsx
@@ -351,6 +351,52 @@ describe('update command — Layer 1 flow tests (#111 Phase 1, scenarios 13-17)'
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
   }, 120_000);
+
+  // ───── Scenario 18: upgrade target declares an unsatisfiable engine → refuse (#121) ─────
+
+  it('18. update target requires a future engine → SHARDMIND_VERSION_MISMATCH, state untouched (#121)', async () => {
+    const { stub, fixtures } = getCtx();
+    stub.setVersion(SHARD_SLUG, '0.1.0', fixtures.byVersion['0.1.0']!);
+    stub.setLatest(SHARD_SLUG, '0.1.0');
+    let vault: Vault | null = null;
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 's18-'));
+    try {
+      vault = await createInstalledVault({
+        stub,
+        shardRef: SHARD_REF,
+        values: DEFAULT_VALUES,
+        prefix: 's18-version-mismatch',
+      });
+      // Publish a 0.2.0 that demands a far-future engine. name/namespace
+      // stay minimal-shard's (default buildCustomTarball copy) so the
+      // update source matches the installed shard; only `requires` is added.
+      const tarPath = await buildCustomTarball({
+        version: '0.2.0',
+        manifestOverrides: { requires: { shardmind: '>=99.0.0' } },
+        outDir: tmpDir,
+      });
+      stub.setVersion(SHARD_SLUG, '0.2.0', tarPath);
+      stub.setLatest(SHARD_SLUG, '0.2.0');
+
+      const statePath = path.join(vault.root, '.shardmind', 'state.json');
+      const stateBefore = await fs.readFile(statePath, 'utf-8');
+
+      const r = mountUpdate({ vaultRoot: vault.root });
+      await waitFor(
+        r.lastFrame,
+        (f) => /requires shardmind >=99\.0\.0/.test(f),
+        30_000,
+      );
+      expect(r.lastFrame() ?? '').toMatch(/SHARDMIND_VERSION_MISMATCH/);
+      // The refusal fires after parsing the new manifest but before any
+      // executor runs — installed state is byte-unchanged (still 0.1.0).
+      const stateAfter = await fs.readFile(statePath, 'utf-8');
+      expect(stateAfter).toBe(stateBefore);
+    } finally {
+      if (vault) await vault.cleanup();
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  }, 90_000);
 });
 
 // Helpers local to this file ───────────────────────────────────────

--- a/tests/unit/manifest.test.ts
+++ b/tests/unit/manifest.test.ts
@@ -3,7 +3,8 @@ import os from 'node:os';
 import fs from 'node:fs/promises';
 import crypto from 'node:crypto';
 import { describe, it, expect } from 'vitest';
-import { parseManifest, ShardManifestSchema } from '../../source/core/manifest.js';
+import { parseManifest, ShardManifestSchema, assertEngineCompatible } from '../../source/core/manifest.js';
+import type { ShardManifest } from '../../source/runtime/types.js';
 
 // Unique tmp filename per call. `Date.now()` collides under parallel
 // vitest workers (two tests within the same millisecond share a path,
@@ -215,6 +216,117 @@ describe('hooks.timeout_ms validation', () => {
     });
     expect(parsed.hooks['post-install']).toBe('h.ts');
     expect(parsed.hooks.timeout_ms).toBeUndefined();
+  });
+});
+
+describe('requires.shardmind parsing (#121)', () => {
+  const base = {
+    apiVersion: 'v1' as const,
+    name: 'test',
+    namespace: 'ns',
+    version: '1.0.0',
+  };
+
+  it('accepts a valid semver range', () => {
+    const parsed = ShardManifestSchema.parse({ ...base, requires: { shardmind: '>=0.2.0' } });
+    expect(parsed.requires?.shardmind).toBe('>=0.2.0');
+  });
+
+  it('accepts caret/tilde and complex ranges', () => {
+    expect(ShardManifestSchema.parse({ ...base, requires: { shardmind: '^0.2.0' } }).requires?.shardmind).toBe('^0.2.0');
+    expect(ShardManifestSchema.parse({ ...base, requires: { shardmind: '>=0.2 <0.4' } }).requires?.shardmind).toBe('>=0.2 <0.4');
+  });
+
+  it('coexists with obsidian and node', () => {
+    const parsed = ShardManifestSchema.parse({
+      ...base,
+      requires: { obsidian: '>=1.5.0', node: '>=22.0.0', shardmind: '>=0.2.0' },
+    });
+    expect(parsed.requires).toEqual({ obsidian: '>=1.5.0', node: '>=22.0.0', shardmind: '>=0.2.0' });
+  });
+
+  it('rejects a garbage range at parse time', async () => {
+    const yaml = [
+      'apiVersion: v1',
+      'name: test',
+      'namespace: ns',
+      'version: 1.0.0',
+      'requires:',
+      '  shardmind: "not a range"',
+    ].join('\n');
+    const tmp = tmpYaml('manifest-test');
+    await fs.writeFile(tmp, yaml);
+    try {
+      const err = await parseManifest(tmp).catch((e) => e);
+      expect(err.code).toBe('MANIFEST_VALIDATION_FAILED');
+      expect(err.message).toContain('shardmind');
+    } finally {
+      await fs.unlink(tmp);
+    }
+  });
+});
+
+describe('assertEngineCompatible (#121)', () => {
+  const make = (shardmind?: string): ShardManifest =>
+    ShardManifestSchema.parse({
+      apiVersion: 'v1',
+      name: 'test',
+      namespace: 'ns',
+      version: '1.0.0',
+      ...(shardmind ? { requires: { shardmind } } : {}),
+    }) as ShardManifest;
+
+  it('passes when the engine satisfies the range', () => {
+    expect(() => assertEngineCompatible(make('>=0.2.0'), '0.3.1')).not.toThrow();
+  });
+
+  it('passes at the exact lower bound', () => {
+    expect(() => assertEngineCompatible(make('>=0.2.0'), '0.2.0')).not.toThrow();
+  });
+
+  it('passes when the range requires a lower engine than installed', () => {
+    expect(() => assertEngineCompatible(make('>=0.1.0'), '0.9.9')).not.toThrow();
+  });
+
+  it('throws SHARDMIND_VERSION_MISMATCH when the engine is too old', () => {
+    const err = (() => {
+      try {
+        assertEngineCompatible(make('>=0.2.0'), '0.1.3');
+      } catch (e) {
+        return e as { code?: string; message?: string; hint?: string };
+      }
+    })();
+    expect(err?.code).toBe('SHARDMIND_VERSION_MISMATCH');
+    expect(err?.message).toContain('>=0.2.0');
+    expect(err?.message).toContain('0.1.3');
+  });
+
+  it('is a no-op when the manifest declares no requires.shardmind', () => {
+    expect(() => assertEngineCompatible(make(), '0.0.1')).not.toThrow();
+  });
+
+  it('skips the check when the engine version is unknown (undefined)', () => {
+    // resolveEngineVersion() returns undefined when the engine cannot locate
+    // its own package.json — a bundle-layout quirk must not hard-block a real
+    // install. See cli-version.ts PKG_VERSION_FALLBACK.
+    expect(() => assertEngineCompatible(make('>=99.0.0'), undefined)).not.toThrow();
+  });
+
+  it('skips the check when the engine version is not valid semver', () => {
+    expect(() => assertEngineCompatible(make('>=99.0.0'), 'garbage')).not.toThrow();
+  });
+
+  it('lets a prerelease engine ahead of the floor satisfy a stable range (includePrerelease)', () => {
+    // A prerelease engine *ahead* of the required floor (0.3.0-beta.1 > 0.2.0)
+    // must not be blocked. Default semver.satisfies rejects any prerelease
+    // against a non-prerelease range; includePrerelease is what allows it.
+    expect(() => assertEngineCompatible(make('>=0.2.0'), '0.3.0-beta.1')).not.toThrow();
+  });
+
+  it('still blocks a prerelease of the required version (it is genuinely older)', () => {
+    // 0.2.0-beta.1 sorts BEFORE the 0.2.0 release, so >=0.2.0 is correctly
+    // unsatisfied — even under includePrerelease. Refusing is the right call.
+    expect(() => assertEngineCompatible(make('>=0.2.0'), '0.2.0-beta.1')).toThrow();
   });
 });
 

--- a/tests/unit/manifest.test.ts
+++ b/tests/unit/manifest.test.ts
@@ -264,6 +264,34 @@ describe('requires.shardmind parsing (#121)', () => {
       await fs.unlink(tmp);
     }
   });
+
+  // semver.validRange('') and whitespace-only strings normalize to '*'
+  // (match-all). Left unguarded, a declared-but-empty range would parse
+  // clean and silently disable the check. Reject at parse time instead.
+  it.each(['""', '" "', '"   "'])('rejects an empty/whitespace range %s at parse time', async (val) => {
+    const yaml = [
+      'apiVersion: v1',
+      'name: test',
+      'namespace: ns',
+      'version: 1.0.0',
+      'requires:',
+      `  shardmind: ${val}`,
+    ].join('\n');
+    const tmp = tmpYaml('manifest-test');
+    await fs.writeFile(tmp, yaml);
+    try {
+      const err = await parseManifest(tmp).catch((e) => e);
+      expect(err.code).toBe('MANIFEST_VALIDATION_FAILED');
+      expect(err.message).toContain('shardmind');
+    } finally {
+      await fs.unlink(tmp);
+    }
+  });
+
+  it('accepts a deliberate match-all wildcard (* and x)', () => {
+    expect(ShardManifestSchema.parse({ ...base, requires: { shardmind: '*' } }).requires?.shardmind).toBe('*');
+    expect(ShardManifestSchema.parse({ ...base, requires: { shardmind: 'x' } }).requires?.shardmind).toBe('x');
+  });
 });
 
 describe('assertEngineCompatible (#121)', () => {
@@ -303,6 +331,10 @@ describe('assertEngineCompatible (#121)', () => {
 
   it('is a no-op when the manifest declares no requires.shardmind', () => {
     expect(() => assertEngineCompatible(make(), '0.0.1')).not.toThrow();
+  });
+
+  it('treats a deliberate match-all (*) range as satisfied by any engine', () => {
+    expect(() => assertEngineCompatible(make('*'), '0.0.1')).not.toThrow();
   });
 
   it('skips the check when the engine version is unknown (undefined)', () => {


### PR DESCRIPTION
## Summary

- Adds **`requires.shardmind`** to `shard.yaml` — a semver range the running engine must satisfy. Install/update/adopt refuse with the new `SHARDMIND_VERSION_MISMATCH` error code (+ `npm i -g shardmind@latest` hint) **before any vault write** when the engine is too old. Absent field → no check, so every pre-#121 shard keeps installing on any engine.
- This is the guard the roadmap gates #102 on: it stops a pre-lifecycle engine from silently ignoring the new hook slots. Field placement chosen as `requires.shardmind` (alongside advisory `obsidian`/`node`) over a top-level `shardmind_version` for one-block consistency.
- Pure `assertEngineCompatible(manifest, engineVersion)` in `source/core/manifest.ts`; engine version resolved via a new `resolveEngineVersion()` that maps the `PKG_VERSION_FALLBACK` sentinel to `undefined` (an unresolvable engine version skips rather than hard-blocks a real install). `status` is intentionally **not** gated — a mismatched-but-installed vault stays diagnosable.

Closes #121

> **Note on the issue wording:** the issue body names the field `shardmind_version`; this PR lands it as `requires.shardmind` to keep all engine/env constraints in one block. Confirmed as the intended shape during planning.

## Adversarial cases considered

Enumerated up front, each covered by a test (verified against the installed `semver` package, not assumed):

- **Empty / whitespace range** (`""`, `" "`, `"   "`) — `semver.validRange` normalizes these to `*` (match-all); without a guard a declared-but-empty range parses clean then silently disables the check. → rejected at parse time (`MANIFEST_VALIDATION_FAILED`). *(found in the harden adversarial pass)*
- **Deliberate match-all** (`*`, `x`) — must stay valid and satisfy any engine.
- **Garbage range** (`"not a range"`) — rejected at parse time.
- **Prerelease semantics** — a prerelease engine *ahead* of the floor (`0.3.0-beta.1` vs `>=0.2.0`) must pass (`includePrerelease`); a prerelease *of* the floor (`0.2.0-beta.1`) is genuinely older and is correctly blocked.
- **Unresolvable engine version** (`undefined` / invalid semver / `0.0.0` sentinel) — skips the check rather than false-refusing.
- **Lower-bound exact match** and **range requiring a lower engine than installed** — pass.
- **Refusal surfaces through every command before any write** — install (no `state.json`), update (`state.json` byte-unchanged), adopt (no `.shardmind/`).

## Quality gate

- [x] `npm run typecheck` passes locally and in CI
- [x] `npm test` passes (1081 passed | 30 skipped; **1074 → 1081**, +7 from the harden round)
- [x] **Tests added before implementation** — unit matrix written first; flow refusal tests pin the wiring
- [x] **Step-by-step commits** — 7 commits (core → wiring → docs → harden fix → harden tests → changelog), typecheck + relevant scope green at each
- [x] Adversarial cases above all covered by tests
- [x] Copilot review requested — reviewed all 16 files, **generated no comments** (clean pass)
- [x] Issue acceptance criteria checked off (see below)
- [x] ROADMAP.md checkbox updated (#102 acceptance sub-box + v0.2 core-features #121)
- [x] Spec alignment: no `docs/SHARD-LAYOUT.md` divergence; manifest-field docs (AUTHORING §3/§6, ERRORS, JSON schema) updated in this PR

### Issue acceptance criteria

- [x] `shard.yaml` schema includes optional `shardmind_version` (semver range) — landed as `requires.shardmind`.
- [x] Install + update + adopt all check it before any vault writes.
- [x] Refuses with error code (`SHARDMIND_VERSION_MISMATCH`) + hint when unsatisfied.
- [x] Test: install a fixture shard requiring a future engine version → fails with the right code (install scenario 12; also update 18 + adopt 24).
- [x] AUTHORING.md documents the field and its purpose.

## Test plan

- `npx vitest run tests/unit/manifest.test.ts` — range parse/reject + `assertEngineCompatible` matrix (43 tests).
- `npx vitest run tests/component/flows/{install,update,adopt}-flow.test.tsx` — refusal surfaces before any write across all three commands.
- Manual Invariant-1 proxy: existing fixture shards declare no `requires.shardmind`, so the absent-field no-op path guarantees zero behavior change — full suite (incl. the Invariant-1 byte-equivalence E2E) green confirms it.

## Risk / blast radius

- **Backward compatibility:** the check is opt-in. Absent `requires.shardmind` → early `return`, no behavior change for any existing shard. Verified by the full E2E + contract suites staying green.
- **`status` unaffected:** it parses the manifest but never calls the check, so an already-installed-but-now-incompatible vault remains diagnosable.
- **Sentinel handling:** if the engine can't locate its own `package.json` (bundle-layout quirk), `resolveEngineVersion` returns `undefined` → check skipped, never a false refusal.

## Harden Audit

Reference PR: #127 (#102 hook lifecycle).

### Rounds
- Round 1 — /simplify (reuse / simplification / efficiency / altitude): 0 findings — diff already clean (acceptable 3-call-site duplication; correct reuse of `resolvePkgVersion`; pure-check + 3-call-site split is right altitude given `status.ts` must stay read-only).
- Round 2 — adversarial + correctness/docs: 2 real findings → empty/whitespace range silently disables the check (fixed); update + adopt refusal had no flow coverage (added). Docs/correctness audit: all green (error code typed + asserted, type↔schema match, no `any`, docs in sync).
- Round 3 — fresh-eyes re-read: 1 doc-accuracy nit (prerelease example in `assertEngineCompatible` JSDoc was misleading; corrected).

### Real bug found
- Empty/whitespace `requires.shardmind` silently disabled the check — `source/core/manifest.ts` (zod refine) — author declares a constraint that reads as active but is inert. Fixed: non-empty guard rejects at parse time.

### Tests added
- Unit: +5 (empty/whitespace reject ×3, `*`/`x` accept, match-all assert). Flow: +2 (update 18, adopt 24). Tests-before → after: 1074 → 1081.

### Deferrals
- None.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
