### PR TITLE
fix(renderer): pass through non-Nunjucks content on parse error

### DIFF
--- a/source/core/renderer.ts
+++ b/source/core/renderer.ts
@@ -253,6 +253,9 @@ function renderTemplate(
   try {
     return env.renderString(source, context);
   } catch (err) {
+    if (!containsNunjucksSyntax(source)) {
+      return source;
+    }
     const message = err instanceof Error ? err.message : String(err);
     throw new ShardMindError(
       `Template error in ${filePath}: ${message}`,
@@ -260,6 +263,10 @@ function renderTemplate(
       'Check the template for Nunjucks syntax errors.',
     );
   }
+}
+
+function containsNunjucksSyntax(source: string): boolean {
+  return /%\}|{%|{{.*?}}/.test(source);
 }
 
 /**

--- a/tests/unit/renderer.test.ts
+++ b/tests/unit/renderer.test.ts
@@ -378,4 +378,29 @@ describe('renderString', () => {
     const ctx = makeContext({ values: { name: 'alice' } });
     expect(renderString('Hi {{ name | shout }}!', ctx, 'x.md', env)).toBe('Hi ALICE!');
   });
+
+  it('passes through content with literal {{ that is not a valid Nunjucks expression', () => {
+    // Regression test: .test.ts files and other non-template content may
+    // contain literal {{ (e.g., "garbage{{" in a test fixture). When the
+    // differ renders old/new templates for three-way merge, files without
+    // any actual Nunjucks syntax should be returned as-is rather than
+    // crashing with RENDER_TEMPLATE_ERROR.
+    const ctx = makeContext({ values: {} });
+    const source = 'const input = "garbage{{";\nassert.equal(runScript(input), expected);\n';
+    expect(renderString(source, ctx, 'stop-checklist.test.ts')).toBe(source);
+  });
+
+  it('passes through content with unclosed {{ in a string literal', () => {
+    const ctx = makeContext({ values: {} });
+    const source = 'test("handles malformed input", () => {\n  const result = parse("data{{");\n  expect(result).toBeNull();\n});\n';
+    expect(renderString(source, ctx, 'test.ts')).toBe(source);
+  });
+
+  it('still substitutes valid Nunjucks variables alongside literal {{', () => {
+    // A file that uses {{ user_name }} (valid) should still get substituted.
+    // Only broken Nunjucks that can't be parsed should fall back.
+    const ctx = makeContext({ values: { user_name: 'Alice' } });
+    const source = 'Hello {{ user_name }}!\n';
+    expect(renderString(source, ctx, 'note.md')).toBe('Hello Alice!\n');
+  });
 });


### PR DESCRIPTION
## Problem

`shardmind update` crashes with `RENDER_TEMPLATE_ERROR` when the vault contains non-template files with literal `{{` strings (e.g., test fixtures like `"garbage{{"` in `.claude/scripts/tests/stop-checklist.test.ts`).

The differ (`source/core/differ.ts`) renders both old and new template content through `renderString()` for three-way merge comparison. When Nunjucks encounters `{{` that isn't a valid variable expression, it throws `expected variable end`.

## Root Cause

`renderTemplate()` in `source/core/renderer.ts` treats **every** Nunjucks parse failure as fatal. Files that aren't Nunjucks templates (no `{{ expr }}`, `{% block %}`, or `%}` syntax) should pass through unchanged rather than crash.

## Fix

In `renderTemplate()`, before throwing `RENDER_TEMPLATE_ERROR`, check if the source contains any actual Nunjucks syntax. If not, return the raw source — the parse error is from accidental `{{` in non-template content, not a template authoring mistake.

```typescript
function renderTemplate(source, context, env, filePath): string {
  try {
    return env.renderString(source, context);
  } catch (err) {
    if (!containsNunjucksSyntax(source)) {
      return source;
    }
    throw new ShardMindError(...);
  }
}

function containsNunjucksSyntax(source: string): boolean {
  return /%\}|{%|{{.*?}}/.test(source);
}
```

## Test Plan

- **RED**: Two regression tests proving `renderString` crashes on `"garbage{{"` and `"data{{"`
- **GREEN**: Fix makes both tests pass
- **Regression**: All 1114 existing tests pass (78 test files)

## Commits

1. `test(renderer): add regression tests for literal {{ in non-template content` — failing tests
2. `fix(renderer): pass through non-Nunjucks content on parse error` — minimal fix

---
Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)